### PR TITLE
Enhance .ofx-gradient-button with isolation and pointer-events

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -54,9 +54,16 @@
     0 0 32px rgba(165, 100, 255, 0.14);
 }
 
+.ofx-gradient-button {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
 .ofx-gradient-button::after {
   content: '';
   @apply absolute inset-[2px] rounded-md bg-slate-950/80 opacity-0 transition-all duration-300;
+  pointer-events: none;
 }
 
 .ofx-gradient-button:hover::before {


### PR DESCRIPTION
Added 'isolation: isolate' and 'overflow: hidden' to .ofx-gradient-button for better stacking context and visual effects. Also set 'pointer-events: none' on the ::after pseudo-element to prevent it from blocking interactions.