### PR TITLE
fix: resolve Date constructor type error in formatSyncDate

### DIFF
--- a/src/app/features/projects/components/project-settings-panel.component.ts
+++ b/src/app/features/projects/components/project-settings-panel.component.ts
@@ -1136,7 +1136,8 @@ export class ProjectSettingsPanelComponent {
 
   formatSyncDate(date: Date | { toDate: () => Date } | null | undefined): string {
     if (!date) return 'Never';
-    const d = date instanceof Date ? date : date.toDate?.() || new Date(date);
+    const d =
+      date instanceof Date ? date : ((date as { toDate?: () => Date }).toDate?.() ?? new Date());
     return d.toLocaleString();
   }
 


### PR DESCRIPTION
## Summary
Fixes TypeScript build error TS2769 that was causing the Docker build to fail in the GitHub Actions workflow.

## Problem
The `formatSyncDate` function on line 1139 was using `new Date(date)` as a fallback, which incorrectly received an object with a `toDate()` method (Firebase Timestamp) instead of a valid Date constructor argument.

## Solution
Changed the fallback logic to use:
- Explicit type assertion for type safety
- Optional chaining `?.('')` to safely call `toDate` if it exists
- Nullish coalescing `??` to only fallback when `toDate()` returns undefined
- Clean fallback to `new Date()` instead of trying to construct from an incompatible object

## Changes
- `project-settings-panel.component.ts`: Fixed date conversion in `formatSyncDate` method