### PR TITLE
feat(tasks): enhance task views with tag removal, markdown titles, and description preview

### DIFF
--- a/src/app/core/models/domain.model.ts
+++ b/src/app/core/models/domain.model.ts
@@ -38,6 +38,8 @@ export interface Subtask {
   title: string;
   completed: boolean;
   description?: string; // Markdown
+  assigneeIds?: string[]; // Multiple assignees for subtasks
+  assigneeNames?: string[]; // Display names corresponding to assigneeIds
 }
 
 export interface Tag {
@@ -74,8 +76,13 @@ export interface Task {
   sectionId?: string; // For board view positioning
   title: string;
   description: string; // Markdown
+  /** @deprecated Use assigneeIds instead. Kept for backward compatibility. */
   assignedToId?: string;
+  /** @deprecated Use assigneeNames instead. Kept for backward compatibility. */
   assigneeName?: string;
+  assigneeIds?: string[]; // Multiple assignees
+  assigneeNames?: string[]; // Display names corresponding to assigneeIds
+  notifyAssignees?: boolean; // Whether to send email notifications on assignment/status changes
   status: 'todo' | 'in-progress' | 'done';
   priority: 'low' | 'medium' | 'high';
   order: number; // Position in list/section for drag-and-drop

--- a/src/app/core/services/task.service.ts
+++ b/src/app/core/services/task.service.ts
@@ -329,8 +329,12 @@ export class TaskService {
         }
       }
 
-      // Auto-add assignee to project members
-      if (task.assignedToId) {
+      // Auto-add assignees to project members
+      if (task.assigneeIds?.length) {
+        for (const uid of task.assigneeIds) {
+          void this.autoAddMember(task.projectId, uid);
+        }
+      } else if (task.assignedToId) {
         void this.autoAddMember(task.projectId, task.assignedToId);
       }
 
@@ -368,8 +372,12 @@ export class TaskService {
         }),
       );
 
-      // Auto-add assignee to project members
-      if (reconciled.assignedToId && taskDoc) {
+      // Auto-add assignees to project members
+      if (reconciled.assigneeIds?.length && taskDoc) {
+        for (const uid of reconciled.assigneeIds) {
+          void this.autoAddMember(taskDoc.projectId, uid);
+        }
+      } else if (reconciled.assignedToId && taskDoc) {
         void this.autoAddMember(taskDoc.projectId, reconciled.assignedToId);
       }
 

--- a/src/app/features/tasks/task-board-view.component.ts
+++ b/src/app/features/tasks/task-board-view.component.ts
@@ -9,11 +9,12 @@ import {
 import { Task, Section, Project } from '../../core/models/domain.model';
 import { TaskService } from '../../core/services/task.service';
 import { ProjectService } from '../../core/services/project.service';
+import { MarkdownPipe, MarkdownPlainPipe } from '../../shared/pipes/markdown.pipe';
 
 @Component({
   selector: 'app-task-board-view',
   standalone: true,
-  imports: [CommonModule, DragDropModule],
+  imports: [CommonModule, DragDropModule, MarkdownPipe, MarkdownPlainPipe],
   template: `
     <div class="h-full flex flex-col overflow-hidden">
       <!-- Filter Bar -->
@@ -56,6 +57,56 @@ import { ProjectService } from '../../core/services/project.service';
           </svg>
           {{ showCompleted() ? 'Showing Completed' : 'Hide Completed' }}
         </button>
+
+        <!-- View Mode Toggle -->
+        <div class="flex items-center bg-slate-800/60 rounded-lg border border-white/5 p-0.5">
+          <button
+            class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium transition-all"
+            [class.bg-cyan-500/20]="viewMode() === 'simplified'"
+            [class.text-cyan-400]="viewMode() === 'simplified'"
+            [class.text-slate-500]="viewMode() !== 'simplified'"
+            (click)="viewMode.set('simplified')"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-3.5 w-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h16M4 12h16M4 18h7"
+              />
+            </svg>
+            Simple
+          </button>
+          <button
+            class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium transition-all"
+            [class.bg-purple-500/20]="viewMode() === 'detailed'"
+            [class.text-purple-400]="viewMode() === 'detailed'"
+            [class.text-slate-500]="viewMode() !== 'detailed'"
+            (click)="viewMode.set('detailed')"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-3.5 w-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 6h16M4 10h16M4 14h16M4 18h16"
+              />
+            </svg>
+            Detailed
+          </button>
+        </div>
       </div>
 
       <div class="flex-1 overflow-x-auto overflow-y-hidden">
@@ -70,7 +121,7 @@ import { ProjectService } from '../../core/services/project.service';
               [ngClass]="{
                 'cyber-column-todo': getSectionStatus(section) === 'todo',
                 'cyber-column-progress': getSectionStatus(section) === 'in-progress',
-                'cyber-column-done': getSectionStatus(section) === 'done'
+                'cyber-column-done': getSectionStatus(section) === 'done',
               }"
             >
               <!-- Column Header -->
@@ -83,33 +134,58 @@ import { ProjectService } from '../../core/services/project.service';
                 @if (getSectionStatus(section) !== 'done') {
                   <div
                     class="absolute inset-0 opacity-10 pointer-events-none"
-                    [style.background]="'linear-gradient(135deg, ' + getColorWithOpacity(section.color, 0.2) + ', transparent)'"
+                    [style.background]="
+                      'linear-gradient(135deg, ' +
+                      getColorWithOpacity(section.color, 0.2) +
+                      ', transparent)'
+                    "
                   ></div>
                 }
-                
+
                 <div class="flex items-center gap-3 relative z-10">
                   <span
                     class="w-3 h-3 rounded-full transition-all duration-300"
                     [style.background]="section.color || '#64748b'"
-                    [style.box-shadow]="getSectionStatus(section) !== 'done' ? '0 0 12px ' + getColorWithOpacity(section.color, 0.5) + ', 0 0 20px ' + getColorWithOpacity(section.color, 0.25) : 'none'"
+                    [style.box-shadow]="
+                      getSectionStatus(section) !== 'done'
+                        ? '0 0 12px ' +
+                          getColorWithOpacity(section.color, 0.5) +
+                          ', 0 0 20px ' +
+                          getColorWithOpacity(section.color, 0.25)
+                        : 'none'
+                    "
                     [class.animate-pulse]="getSectionStatus(section) === 'in-progress'"
                   ></span>
-                  <h3 
+                  <h3
                     class="font-bold text-sm tracking-wide transition-colors duration-300"
                     [class.text-slate-200]="getSectionStatus(section) !== 'done'"
                     [class.text-slate-500]="getSectionStatus(section) === 'done'"
-                    [style.text-shadow]="getSectionStatus(section) !== 'done' ? '0 0 8px ' + getColorWithOpacity(section.color, 0.6) : 'none'"
+                    [style.text-shadow]="
+                      getSectionStatus(section) !== 'done'
+                        ? '0 0 8px ' + getColorWithOpacity(section.color, 0.6)
+                        : 'none'
+                    "
                   >
                     {{ section.name }}
                   </h3>
-                  <span 
+                  <span
                     class="text-xs px-2 py-0.5 rounded-full transition-colors duration-300"
                     [class.bg-white/5]="getSectionStatus(section) === 'done'"
                     [class.text-slate-500]="getSectionStatus(section) === 'done'"
                     [class.text-slate-400]="getSectionStatus(section) !== 'done'"
-                    [style.background]="getSectionStatus(section) !== 'done' ? getColorWithOpacity(section.color, 0.2) : ''"
-                    [style.color]="getSectionStatus(section) !== 'done' ? (section.color || '#64748b') : ''"
-                    [style.border]="getSectionStatus(section) !== 'done' ? '1px solid ' + getColorWithOpacity(section.color, 0.25) : ''"
+                    [style.background]="
+                      getSectionStatus(section) !== 'done'
+                        ? getColorWithOpacity(section.color, 0.2)
+                        : ''
+                    "
+                    [style.color]="
+                      getSectionStatus(section) !== 'done' ? section.color || '#64748b' : ''
+                    "
+                    [style.border]="
+                      getSectionStatus(section) !== 'done'
+                        ? '1px solid ' + getColorWithOpacity(section.color, 0.25)
+                        : ''
+                    "
                   >
                     {{ getFilteredTasksForSection(section.id).length }}
                   </span>
@@ -157,26 +233,38 @@ import { ProjectService } from '../../core/services/project.service';
                     [class.hover:shadow-lg]="task.status !== 'done'"
                     [ngClass]="{
                       'task-todo': getSectionStatus(section) === 'todo' && task.status !== 'done',
-                      'task-progress': getSectionStatus(section) === 'in-progress' && task.status !== 'done',
-                      'task-done': task.status === 'done'
+                      'task-progress':
+                        getSectionStatus(section) === 'in-progress' && task.status !== 'done',
+                      'task-done': task.status === 'done',
                     }"
-                    [style.border-color]="task.status !== 'done' ? getColorWithOpacity(section.color, 0.3) : ''"
+                    [style.border-color]="
+                      task.status !== 'done' ? getColorWithOpacity(section.color, 0.3) : ''
+                    "
                     (click)="taskClick.emit(task)"
                   >
                     <!-- Neon glow effect for active tasks -->
                     @if (task.status !== 'done') {
                       <div
                         class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"
-                        [style.background]="'linear-gradient(135deg, ' + getColorWithOpacity(section.color, 0.1) + ', transparent)'"
-                        [style.box-shadow]="'0 0 20px ' + getColorWithOpacity(section.color, 0.2) + ', inset 0 0 20px ' + getColorWithOpacity(section.color, 0.1)"
+                        [style.background]="
+                          'linear-gradient(135deg, ' +
+                          getColorWithOpacity(section.color, 0.1) +
+                          ', transparent)'
+                        "
+                        [style.box-shadow]="
+                          '0 0 20px ' +
+                          getColorWithOpacity(section.color, 0.2) +
+                          ', inset 0 0 20px ' +
+                          getColorWithOpacity(section.color, 0.1)
+                        "
                       ></div>
                     }
-                    
+
                     <!-- Scanline effect for done tasks -->
                     @if (task.status === 'done') {
                       <div class="absolute inset-0 scanline-overlay pointer-events-none"></div>
                     }
-                    
+
                     <!-- Drag Handle (invisible but essentially the whole card) -->
                     <div
                       *cdkDragPlaceholder
@@ -194,7 +282,7 @@ import { ProjectService } from '../../core/services/project.service';
                           task.priority === 'medium' && task.status !== 'done',
                         'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.6)]':
                           task.priority === 'low' && task.status !== 'done',
-                        'bg-slate-600': task.status === 'done'
+                        'bg-slate-600': task.status === 'done',
                       }"
                     ></div>
 
@@ -203,7 +291,11 @@ import { ProjectService } from '../../core/services/project.service';
                       [class.text-slate-100]="task.status !== 'done'"
                       [class.text-slate-500]="task.status === 'done'"
                       [class.line-through]="task.status === 'done'"
-                      [style.text-shadow]="task.status !== 'done' ? '0 0 4px ' + getColorWithOpacity(section.color, 0.2) : 'none'"
+                      [style.text-shadow]="
+                        task.status !== 'done'
+                          ? '0 0 4px ' + getColorWithOpacity(section.color, 0.2)
+                          : 'none'
+                      "
                     >
                       {{ task.title }}
                       @if (task.googleTaskId) {
@@ -223,6 +315,20 @@ import { ProjectService } from '../../core/services/project.service';
                         </svg>
                       }
                     </h4>
+
+                    <!-- Description Preview -->
+                    @if (task.description) {
+                      @if (viewMode() === 'detailed') {
+                        <div
+                          class="text-[11px] text-slate-400 mt-1.5 mb-1 prose prose-invert prose-xs max-w-none relative z-10 board-preview-content"
+                          [innerHTML]="task.description | markdown"
+                        ></div>
+                      } @else {
+                        <div class="text-[11px] text-slate-500 mt-1 line-clamp-2 relative z-10">
+                          {{ task.description | markdownPlain: 60 }}
+                        </div>
+                      }
+                    }
 
                     <div class="flex items-center justify-between mt-3 relative z-10">
                       <div class="flex items-center gap-2">
@@ -326,7 +432,7 @@ import { ProjectService } from '../../core/services/project.service';
         --board-column-width: 22rem; /* ~352px at 16px root, good desktop size */
         --board-column-min-width: 18rem; /* ~288px minimum for readability */
         --add-section-width: 3.5rem; /* Narrow add section button */
-        
+
         /* Cyberpunk color variables */
         --cyber-purple: #e040fb;
         --cyber-blue: #00d2ff;
@@ -354,23 +460,23 @@ import { ProjectService } from '../../core/services/project.service';
       /* Cyberpunk column styles */
       .cyber-column-todo {
         border: 1px solid rgba(224, 64, 251, 0.2);
-        box-shadow: 
+        box-shadow:
           0 0 20px rgba(224, 64, 251, 0.1),
           inset 0 0 20px rgba(224, 64, 251, 0.05);
       }
-      
+
       .cyber-column-progress {
         border: 1px solid rgba(0, 210, 255, 0.2);
-        box-shadow: 
+        box-shadow:
           0 0 20px rgba(0, 210, 255, 0.1),
           inset 0 0 20px rgba(0, 210, 255, 0.05);
         animation: pulse-progress 3s ease-in-out infinite;
       }
-      
+
       .cyber-column-done {
         position: relative;
       }
-      
+
       .cyber-column-done::before {
         content: '';
         position: absolute;
@@ -392,35 +498,35 @@ import { ProjectService } from '../../core/services/project.service';
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
         transition: all 0.3s ease;
       }
-      
+
       .task-todo:hover {
         border-color: rgba(224, 64, 251, 0.6);
-        box-shadow: 
+        box-shadow:
           0 8px 24px rgba(0, 0, 0, 0.4),
           0 0 20px rgba(224, 64, 251, 0.3);
         transform: translateY(-2px);
       }
-      
+
       .task-progress {
         border: 1px solid rgba(0, 210, 255, 0.3);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
         transition: all 0.3s ease;
       }
-      
+
       .task-progress:hover {
         border-color: rgba(0, 210, 255, 0.6);
-        box-shadow: 
+        box-shadow:
           0 8px 24px rgba(0, 0, 0, 0.4),
           0 0 20px rgba(0, 210, 255, 0.3);
         transform: translateY(-2px);
       }
-      
+
       .task-done {
         position: relative;
         filter: grayscale(70%);
         transition: all 0.3s ease;
       }
-      
+
       .task-done:hover {
         filter: grayscale(50%);
         opacity: 0.7 !important;
@@ -437,7 +543,7 @@ import { ProjectService } from '../../core/services/project.service';
         );
         animation: scanline 8s linear infinite;
       }
-      
+
       @keyframes scanline {
         0% {
           transform: translateY(0);
@@ -446,15 +552,16 @@ import { ProjectService } from '../../core/services/project.service';
           transform: translateY(100%);
         }
       }
-      
+
       @keyframes pulse-progress {
-        0%, 100% {
-          box-shadow: 
+        0%,
+        100% {
+          box-shadow:
             0 0 20px rgba(0, 210, 255, 0.1),
             inset 0 0 20px rgba(0, 210, 255, 0.05);
         }
         50% {
-          box-shadow: 
+          box-shadow:
             0 0 30px rgba(0, 210, 255, 0.2),
             inset 0 0 30px rgba(0, 210, 255, 0.1);
         }
@@ -478,6 +585,49 @@ import { ProjectService } from '../../core/services/project.service';
       .scrollbar-thin::-webkit-scrollbar-thumb:hover {
         background-color: rgba(148, 163, 184, 0.4);
       }
+
+      /* Board card description preview */
+      .board-preview-content {
+        max-height: 10rem;
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(148, 163, 184, 0.2) transparent;
+      }
+      .board-preview-content :is(h1, h2, h3) {
+        font-size: 0.7rem;
+        margin: 0.2rem 0;
+        font-weight: 600;
+        color: #cbd5e1;
+      }
+      .board-preview-content p {
+        margin: 0.1rem 0;
+      }
+      .board-preview-content ul,
+      .board-preview-content ol {
+        margin: 0.1rem 0;
+        padding-left: 0.8rem;
+      }
+      .board-preview-content pre {
+        font-size: 0.65rem;
+        padding: 0.25rem 0.4rem;
+        border-radius: 0.2rem;
+        background: rgba(255, 255, 255, 0.03);
+        margin: 0.15rem 0;
+      }
+      .board-preview-content code {
+        font-size: 0.65rem;
+      }
+      .board-preview-content .md-callout {
+        font-size: 0.65rem;
+        padding: 0.25rem 0.4rem;
+        margin: 0.15rem 0;
+      }
+      .line-clamp-2 {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
     `,
   ],
 })
@@ -496,6 +646,9 @@ export class TaskBoardViewComponent {
 
   // Filter state - hide completed tasks older than 30 minutes by default
   showCompleted = signal(false);
+
+  // View mode toggle
+  viewMode = signal<'simplified' | 'detailed'>('simplified');
 
   // Track session start time to show recently completed tasks
   private sessionStartTime = new Date();
@@ -632,7 +785,7 @@ export class TaskBoardViewComponent {
     if (section.status) {
       return section.status;
     }
-    
+
     // Otherwise, infer from section name or color
     const nameLower = section.name.toLowerCase();
     if (nameLower.includes('done') || nameLower.includes('complete')) {
@@ -650,7 +803,7 @@ export class TaskBoardViewComponent {
   hexToRgba(hex: string, alpha: number): string {
     // Remove # if present
     const cleanHex = hex.replace(/^#/, '');
-    
+
     // Validate and expand short hex codes (e.g., #fff -> #ffffff)
     let fullHex = cleanHex;
     if (cleanHex.length === 3) {
@@ -662,17 +815,17 @@ export class TaskBoardViewComponent {
       // Invalid hex format, return default gray
       return `rgba(100, 116, 139, ${alpha})`; // #64748b
     }
-    
+
     // Parse hex to RGB
     const r = parseInt(fullHex.substring(0, 2), 16);
     const g = parseInt(fullHex.substring(2, 4), 16);
     const b = parseInt(fullHex.substring(4, 6), 16);
-    
+
     // Validate parsed values
     if (isNaN(r) || isNaN(g) || isNaN(b)) {
       return `rgba(100, 116, 139, ${alpha})`; // #64748b fallback
     }
-    
+
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
 

--- a/src/app/features/tasks/task-create-modal.component.ts
+++ b/src/app/features/tasks/task-create-modal.component.ts
@@ -391,7 +391,7 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
               type="checkbox"
               id="notifyAssignees"
               [checked]="notifyAssignees()"
-              (change)="notifyAssignees.set($any($event.target).checked)"
+              (change)="onNotifyChange($event)"
               class="w-4 h-4 rounded border-white/20 bg-slate-950 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
             />
             <label for="notifyAssignees" class="text-xs text-slate-400 cursor-pointer select-none"
@@ -715,6 +715,11 @@ export class TaskCreateModalComponent {
 
   getSelectedTagsList(): string {
     return Array.from(this.selectedTags()).join(', ');
+  }
+
+  onNotifyChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.notifyAssignees.set(input.checked);
   }
 
   hasCustomFieldErrors(): boolean {

--- a/src/app/features/tasks/task-create-modal.component.ts
+++ b/src/app/features/tasks/task-create-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, inject, signal } from '@angular/core';
+import { Component, input, output, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { TaskService } from '../../core/services/task.service';
@@ -338,20 +338,65 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
             </div>
           }
 
-          <!-- Assignee -->
+          <!-- Assignees -->
           <div>
             <label
               class="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1"
-              >Assignee</label
+              >Assignees</label
             >
+            <!-- Selected Assignee Chips -->
+            @if (selectedAssignees().length > 0) {
+              <div class="flex flex-wrap gap-1.5 mb-2">
+                @for (assignee of selectedAssignees(); track assignee.id) {
+                  <span
+                    class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-cyan-500/10 border border-cyan-500/20 text-cyan-300"
+                  >
+                    @if (assignee.avatar) {
+                      <img
+                        [src]="assignee.avatar"
+                        class="w-3.5 h-3.5 rounded-full"
+                        referrerpolicy="no-referrer"
+                      />
+                    } @else {
+                      <span
+                        class="w-3.5 h-3.5 rounded-full flex items-center justify-center text-[8px] text-white font-bold"
+                        [style.background-color]="assignee.color || '#8b5cf6'"
+                        >{{ assignee.label.charAt(0).toUpperCase() }}</span
+                      >
+                    }
+                    {{ assignee.label }}
+                    <button
+                      type="button"
+                      (click)="removeAssignee(assignee.id)"
+                      class="ml-0.5 text-slate-400 hover:text-rose-400 transition-colors"
+                    >
+                      ×
+                    </button>
+                  </span>
+                }
+              </div>
+            }
             <app-autocomplete-input
-              [options]="assigneeOptions()"
-              [value]="form.value.assigneeName || ''"
-              [allowCustom]="true"
-              placeholder="Search contacts..."
+              [options]="availableAssigneeOptions()"
+              [value]="''"
+              [allowCustom]="false"
+              placeholder="Search contacts to add..."
               (optionSelected)="onAssigneeSelected($event)"
-              (valueChange)="onAssigneeValueChange($event)"
             ></app-autocomplete-input>
+          </div>
+
+          <!-- Notify Assignees Checkbox -->
+          <div class="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="notifyAssignees"
+              [checked]="notifyAssignees()"
+              (change)="notifyAssignees.set($any($event.target).checked)"
+              class="w-4 h-4 rounded border-white/20 bg-slate-950 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
+            />
+            <label for="notifyAssignees" class="text-xs text-slate-400 cursor-pointer select-none"
+              >📧 Notify assignees via email (assignment & status updates)</label
+            >
           </div>
 
           <!-- Tags -->
@@ -369,7 +414,9 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
                     type="button"
                     (click)="toggleTag(tag.name)"
                     [class.ring-2]="selectedTags().has(tag.name)"
-                    [class.ring-white]="selectedTags().has(tag.name)"
+                    [style.--tw-ring-color]="
+                      selectedTags().has(tag.name) ? tag.color : 'transparent'
+                    "
                     [style.background-color]="tag.color + '20'"
                     [style.color]="tag.color"
                     [style.border-color]="tag.color + '40'"
@@ -474,7 +521,8 @@ export class TaskCreateModalComponent {
   // State
   saving = signal(false);
   errorMessage = signal<string | null>(null);
-  selectedAssigneeId = signal<string | null>(null);
+  selectedAssignees = signal<AutocompleteOption[]>([]);
+  notifyAssignees = signal(true); // Default to notifying
 
   // AI State
   aiSubtasks = signal<Subtask[]>([]);
@@ -542,7 +590,6 @@ export class TaskCreateModalComponent {
     priority: ['low'],
     dueDate: [''],
     sectionId: [''],
-    assigneeName: [''],
   });
 
   constructor() {
@@ -675,34 +722,31 @@ export class TaskCreateModalComponent {
   }
 
   /**
-   * Handle assignee selection from autocomplete
+   * Compute available assignee options (exclude already selected)
+   */
+  availableAssigneeOptions = computed(() => {
+    const selected = new Set(this.selectedAssignees().map((a) => a.id));
+    return this.assigneeOptions().filter((opt) => !selected.has(opt.id));
+  });
+
+  /**
+   * Handle assignee selection from autocomplete - adds to multi-select list
    */
   onAssigneeSelected(selection: AutocompleteOption | string): void {
     if (typeof selection === 'object') {
-      // Selected a contact from the list
-      this.selectedAssigneeId.set(selection.id);
-      this.form.patchValue({ assigneeName: selection.label });
-    } else {
-      // Custom value entered
-      this.selectedAssigneeId.set(null);
-      this.form.patchValue({ assigneeName: selection });
+      // Add to selected list if not already there
+      const current = this.selectedAssignees();
+      if (!current.find((a) => a.id === selection.id)) {
+        this.selectedAssignees.set([...current, selection]);
+      }
     }
   }
 
   /**
-   * Handle assignee value change (for typing/clearing)
+   * Remove an assignee from the selected list
    */
-  onAssigneeValueChange(value: string): void {
-    this.form.patchValue({ assigneeName: value });
-    // If value doesn't match any option, clear the selected ID
-    const matchingOption = this.assigneeOptions().find(
-      (opt) => opt.label === value || opt.id === value,
-    );
-    if (matchingOption) {
-      this.selectedAssigneeId.set(matchingOption.id);
-    } else {
-      this.selectedAssigneeId.set(null);
-    }
+  removeAssignee(id: string): void {
+    this.selectedAssignees.update((list) => list.filter((a) => a.id !== id));
   }
 
   async onSubmit() {
@@ -723,6 +767,10 @@ export class TaskCreateModalComponent {
       const dueDate = val.dueDate ? new Date(val.dueDate) : undefined;
       const tags = Array.from(this.selectedTags());
 
+      const assignees = this.selectedAssignees();
+      const assigneeIds = assignees.map((a) => a.id);
+      const assigneeNames = assignees.map((a) => a.label);
+
       const taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> = {
         projectId: this.projectId(),
         title: val.title!,
@@ -731,8 +779,13 @@ export class TaskCreateModalComponent {
         priority: val.priority as Task['priority'],
         order: 0, // Will be assigned properly
         sectionId: val.sectionId || undefined,
-        assignedToId: this.selectedAssigneeId() || undefined,
-        assigneeName: val.assigneeName || undefined,
+        // Multi-assignee fields
+        assigneeIds: assigneeIds.length > 0 ? assigneeIds : undefined,
+        assigneeNames: assigneeNames.length > 0 ? assigneeNames : undefined,
+        notifyAssignees: this.notifyAssignees(),
+        // Backward compat: set assignedToId to first assignee
+        assignedToId: assigneeIds[0] || undefined,
+        assigneeName: assigneeNames[0] || undefined,
         dueDate: dueDate as any,
         tags,
         customFieldValues: this.customFieldValues(),

--- a/src/app/features/tasks/task-detail-modal.component.ts
+++ b/src/app/features/tasks/task-detail-modal.component.ts
@@ -211,7 +211,7 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
                 type="checkbox"
                 id="notifyAssigneesDetail"
                 [checked]="notifyAssigneesSig()"
-                (change)="onNotifyAssigneesChange($any($event.target).checked)"
+                (change)="onNotifyAssigneesChange($event)"
                 class="w-4 h-4 rounded border-white/20 bg-slate-950 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
               />
               <label
@@ -637,7 +637,6 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
                     type="button"
                     (click)="toggleTag(tag.name)"
                     [class.ring-2]="selectedTags().has(tag.name)"
-                    [style.ring-color]="selectedTags().has(tag.name) ? tag.color : ''"
                     [style.--tw-ring-color]="
                       selectedTags().has(tag.name) ? tag.color : 'transparent'
                     "
@@ -895,11 +894,23 @@ export class TaskDetailModalComponent {
         // Populate multi-assignee list from task data
         const ids = task.assigneeIds || (task.assignedToId ? [task.assignedToId] : []);
         const names = task.assigneeNames || (task.assigneeName ? [task.assigneeName] : []);
-        const options: AutocompleteOption[] = ids.map((id, idx) => ({
-          id,
-          label: names[idx] || id,
-          color: this.generateAvatarColor(id),
-        }));
+        let options: AutocompleteOption[];
+        if (ids.length > 0) {
+          options = ids.map((id: string, idx: number) => ({
+            id,
+            label: names[idx] || id,
+            color: this.generateAvatarColor(id),
+          }));
+        } else if (names.length > 0) {
+          // Legacy: assigneeName set without assignedToId — preserve name-only assignment
+          options = names.map((name: string) => ({
+            id: name,
+            label: name,
+            color: this.generateAvatarColor(name),
+          }));
+        } else {
+          options = [];
+        }
         this.selectedAssignees.set(options);
         this.notifyAssigneesSig.set(task.notifyAssignees ?? true);
 
@@ -1027,8 +1038,9 @@ export class TaskDetailModalComponent {
   /**
    * Handle notify assignees checkbox change
    */
-  onNotifyAssigneesChange(checked: boolean): void {
-    this.notifyAssigneesSig.set(checked);
+  onNotifyAssigneesChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.notifyAssigneesSig.set(input.checked);
     this.form.markAsDirty();
     this.autoSave();
   }
@@ -1088,8 +1100,8 @@ export class TaskDetailModalComponent {
       title: val.title!,
       description: val.description || '',
       // Multi-assignee fields
-      assigneeIds: assigneeIds.length > 0 ? assigneeIds : [],
-      assigneeNames: assigneeNames.length > 0 ? assigneeNames : [],
+      assigneeIds: assigneeIds.length > 0 ? assigneeIds : undefined,
+      assigneeNames: assigneeNames.length > 0 ? assigneeNames : undefined,
       notifyAssignees: this.notifyAssigneesSig(),
       // Backward compat
       assignedToId: assigneeIds[0] || undefined,

--- a/src/app/features/tasks/task-detail-modal.component.ts
+++ b/src/app/features/tasks/task-detail-modal.component.ts
@@ -825,7 +825,7 @@ export class TaskDetailModalComponent {
   /**
    * Generate a consistent color for a contact based on their email
    */
-  private generateAvatarColor(email: string): string {
+  generateAvatarColor(email: string): string {
     const colors = [
       '#8b5cf6',
       '#3b82f6',
@@ -857,7 +857,6 @@ export class TaskDetailModalComponent {
   form = this.fb.group({
     title: ['', Validators.required],
     description: [''],
-    assigneeName: [''],
     status: ['todo'],
     startDate: [''],
     dueDate: [''],

--- a/src/app/features/tasks/task-detail-modal.component.ts
+++ b/src/app/features/tasks/task-detail-modal.component.ts
@@ -1,4 +1,13 @@
-import { Component, input, output, computed, signal, inject, effect } from '@angular/core';
+import {
+  Component,
+  input,
+  output,
+  computed,
+  signal,
+  inject,
+  effect,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators, FormsModule } from '@angular/forms';
 import { TaskService } from '../../core/services/task.service';
@@ -150,19 +159,66 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
 
           <!-- Metadata Grid -->
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-4 mb-8">
-            <!-- Assignee -->
-            <div class="flex flex-col gap-1">
+            <!-- Assignees -->
+            <div class="flex flex-col gap-1 sm:col-span-2">
               <label class="text-xs font-semibold text-slate-500 uppercase tracking-widest"
-                >Assignee</label
+                >Assignees</label
               >
+              <!-- Selected Assignee Chips -->
+              @if (selectedAssignees().length > 0) {
+                <div class="flex flex-wrap gap-1.5 mb-1">
+                  @for (assignee of selectedAssignees(); track assignee.id) {
+                    <span
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-cyan-500/10 border border-cyan-500/20 text-cyan-300"
+                    >
+                      @if (assignee.avatar) {
+                        <img
+                          [src]="assignee.avatar"
+                          class="w-3.5 h-3.5 rounded-full"
+                          referrerpolicy="no-referrer"
+                        />
+                      } @else {
+                        <span
+                          class="w-3.5 h-3.5 rounded-full flex items-center justify-center text-[8px] text-white font-bold"
+                          [style.background-color]="assignee.color || '#8b5cf6'"
+                          >{{ assignee.label.charAt(0).toUpperCase() }}</span
+                        >
+                      }
+                      {{ assignee.label }}
+                      <button
+                        type="button"
+                        (click)="removeAssignee(assignee.id)"
+                        class="ml-0.5 text-slate-400 hover:text-rose-400 transition-colors"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  }
+                </div>
+              }
               <app-autocomplete-input
-                [options]="assigneeOptions()"
-                [value]="form.value.assigneeName || ''"
-                [allowCustom]="true"
-                placeholder="Search contacts..."
+                [options]="availableAssigneeOptions()"
+                [value]="''"
+                [allowCustom]="false"
+                placeholder="Search contacts to add..."
                 (optionSelected)="onAssigneeSelected($event)"
-                (valueChange)="onAssigneeValueChange($event)"
               ></app-autocomplete-input>
+            </div>
+
+            <!-- Notify Assignees -->
+            <div class="flex items-center gap-2 sm:col-span-2">
+              <input
+                type="checkbox"
+                id="notifyAssigneesDetail"
+                [checked]="notifyAssigneesSig()"
+                (change)="onNotifyAssigneesChange($any($event.target).checked)"
+                class="w-4 h-4 rounded border-white/20 bg-slate-950 text-cyan-500 focus:ring-cyan-500 focus:ring-offset-0 cursor-pointer"
+              />
+              <label
+                for="notifyAssigneesDetail"
+                class="text-xs text-slate-400 cursor-pointer select-none"
+                >📧 Notify assignees via email (assignment & status updates)</label
+              >
             </div>
 
             <!-- Status -->
@@ -443,6 +499,21 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
                       (click)="toggleSubtaskExpanded(subtask.id)"
                       >{{ subtask.title }}</span
                     >
+                    <!-- Subtask assignee avatars -->
+                    @if (subtask.assigneeNames?.length) {
+                      <div class="flex -space-x-1">
+                        @for (name of subtask.assigneeNames; track name; let i = $index) {
+                          <span
+                            class="w-5 h-5 rounded-full flex items-center justify-center text-[8px] text-white font-bold border border-slate-800"
+                            [style.background-color]="
+                              generateAvatarColor(subtask.assigneeIds?.[i] || name)
+                            "
+                            [title]="name"
+                            >{{ name.charAt(0).toUpperCase() }}</span
+                          >
+                        }
+                      </div>
+                    }
                     <button
                       class="p-1 text-slate-600 hover:text-cyan-400 transition-all"
                       (click)="toggleSubtaskExpanded(subtask.id)"
@@ -485,7 +556,7 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
                     </button>
                   </div>
                   @if (expandedSubtaskIds().has(subtask.id)) {
-                    <div class="ml-8 mt-2 mb-1">
+                    <div class="ml-8 mt-2 mb-1 space-y-2">
                       <app-markdown-editor
                         [value]="subtask.description || ''"
                         [rows]="2"
@@ -494,6 +565,38 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
                         (valueChange)="updateSubtaskDescription(subtask.id, $event)"
                         (blurred)="autoSave()"
                       />
+                      <!-- Subtask Assignee -->
+                      <div class="flex items-center gap-2">
+                        <span
+                          class="text-[10px] text-slate-500 uppercase tracking-widest flex-shrink-0"
+                          >Assign:</span
+                        >
+                        <app-autocomplete-input
+                          [options]="assigneeOptions()"
+                          [value]="''"
+                          [allowCustom]="false"
+                          placeholder="Add assignee..."
+                          (optionSelected)="onSubtaskAssigneeSelected(subtask.id, $event)"
+                        ></app-autocomplete-input>
+                      </div>
+                      @if (subtask.assigneeNames?.length) {
+                        <div class="flex flex-wrap gap-1">
+                          @for (name of subtask.assigneeNames; track name; let i = $index) {
+                            <span
+                              class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] bg-purple-500/10 border border-purple-500/20 text-purple-300"
+                            >
+                              {{ name }}
+                              <button
+                                type="button"
+                                (click)="removeSubtaskAssignee(subtask.id, i)"
+                                class="text-slate-400 hover:text-rose-400"
+                              >
+                                ×
+                              </button>
+                            </span>
+                          }
+                        </div>
+                      }
                     </div>
                   }
                 </div>
@@ -534,7 +637,10 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
                     type="button"
                     (click)="toggleTag(tag.name)"
                     [class.ring-2]="selectedTags().has(tag.name)"
-                    [class.ring-white]="selectedTags().has(tag.name)"
+                    [style.ring-color]="selectedTags().has(tag.name) ? tag.color : ''"
+                    [style.--tw-ring-color]="
+                      selectedTags().has(tag.name) ? tag.color : 'transparent'
+                    "
                     [style.background-color]="tag.color + '20'"
                     [style.color]="tag.color"
                     [style.border-color]="tag.color + '40'"
@@ -566,9 +672,29 @@ import { MarkdownEditorComponent } from '../../shared/components/markdown-editor
               </button>
             </div>
 
-            <!-- Selected Tags Display -->
+            <!-- Selected Tags Display with Remove -->
             @if (selectedTags().size > 0) {
-              <div class="mt-2 text-xs text-slate-500">Selected: {{ getSelectedTagsList() }}</div>
+              <div class="flex flex-wrap gap-1.5 mt-2">
+                @for (tagName of selectedTagsArray(); track tagName) {
+                  <span
+                    class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium border transition-all"
+                    [style.background-color]="getTagColor(tagName) + '20'"
+                    [style.color]="getTagColor(tagName)"
+                    [style.border-color]="getTagColor(tagName) + '40'"
+                  >
+                    {{ tagName }}
+                    <button
+                      type="button"
+                      (click)="$event.stopPropagation(); toggleTag(tagName)"
+                      class="ml-0.5 hover:brightness-150 transition-all rounded-full w-4 h-4 flex items-center justify-center text-[10px] opacity-70 hover:opacity-100"
+                      [style.color]="getTagColor(tagName)"
+                      title="Remove tag"
+                    >
+                      ×
+                    </button>
+                  </span>
+                }
+              </div>
             }
           </div>
         </div>
@@ -716,8 +842,17 @@ export class TaskDetailModalComponent {
     return colors[hash % colors.length];
   }
 
-  // Track selected assignee ID
-  selectedAssigneeId = signal<string | null>(null);
+  // Multi-assignee tracking
+  selectedAssignees = signal<AutocompleteOption[]>([]);
+  notifyAssigneesSig = signal(true); // Default: notify on assignment/status
+
+  /**
+   * Compute available assignee options (exclude already selected)
+   */
+  availableAssigneeOptions = computed(() => {
+    const selected = new Set(this.selectedAssignees().map((a) => a.id));
+    return this.assigneeOptions().filter((opt) => !selected.has(opt.id));
+  });
 
   form = this.fb.group({
     title: ['', Validators.required],
@@ -734,6 +869,7 @@ export class TaskDetailModalComponent {
   subtasks = signal<Subtask[]>([]);
   customFieldValues = signal<Record<string, any>>({});
   selectedTags = signal<Set<string>>(new Set());
+  selectedTagsArray = computed(() => Array.from(this.selectedTags()));
   newSubtaskTitle = '';
   expandedSubtaskIds = signal<Set<string>>(new Set());
 
@@ -748,7 +884,6 @@ export class TaskDetailModalComponent {
           {
             title: task.title,
             description: task.description,
-            assigneeName: task.assigneeName || '',
             status: task.status,
             startDate: (task as any).startDate ? this.toInputDate((task as any).startDate) : '',
             dueDate: task.dueDate ? this.toInputDate(task.dueDate) : '',
@@ -758,8 +893,16 @@ export class TaskDetailModalComponent {
           { emitEvent: false },
         );
 
-        // Set selected assignee ID from task
-        this.selectedAssigneeId.set(task.assignedToId || null);
+        // Populate multi-assignee list from task data
+        const ids = task.assigneeIds || (task.assignedToId ? [task.assignedToId] : []);
+        const names = task.assigneeNames || (task.assigneeName ? [task.assigneeName] : []);
+        const options: AutocompleteOption[] = ids.map((id, idx) => ({
+          id,
+          label: names[idx] || id,
+          color: this.generateAvatarColor(id),
+        }));
+        this.selectedAssignees.set(options);
+        this.notifyAssigneesSig.set(task.notifyAssignees ?? true);
 
         // Load subtasks and custom fields
         this.subtasks.set(task.subtasks || []);
@@ -853,38 +996,79 @@ export class TaskDetailModalComponent {
     return Array.from(this.selectedTags()).join(', ');
   }
 
+  getTagColor(tagName: string): string {
+    const projectTags = this.project()?.tags || [];
+    const tag = projectTags.find((t) => t.name === tagName);
+    return tag?.color || '#94a3b8';
+  }
+
   /**
    * Handle assignee selection from autocomplete
    */
   onAssigneeSelected(selection: AutocompleteOption | string): void {
     if (typeof selection === 'object') {
-      // Selected a contact from the list
-      this.selectedAssigneeId.set(selection.id);
-      this.form.patchValue({ assigneeName: selection.label });
-    } else {
-      // Custom value entered
-      this.selectedAssigneeId.set(null);
-      this.form.patchValue({ assigneeName: selection });
+      const current = this.selectedAssignees();
+      if (!current.find((a) => a.id === selection.id)) {
+        this.selectedAssignees.set([...current, selection]);
+        this.form.markAsDirty();
+        this.autoSave();
+      }
     }
+  }
+
+  /**
+   * Remove an assignee from the selected list
+   */
+  removeAssignee(id: string): void {
+    this.selectedAssignees.update((list) => list.filter((a) => a.id !== id));
     this.form.markAsDirty();
     this.autoSave();
   }
 
   /**
-   * Handle assignee value change (for typing/clearing)
+   * Handle notify assignees checkbox change
    */
-  onAssigneeValueChange(value: string): void {
-    this.form.patchValue({ assigneeName: value });
-    // If value doesn't match any option, clear the selected ID
-    const matchingOption = this.assigneeOptions().find(
-      (opt) => opt.label === value || opt.id === value,
-    );
-    if (matchingOption) {
-      this.selectedAssigneeId.set(matchingOption.id);
-    } else {
-      this.selectedAssigneeId.set(null);
-    }
+  onNotifyAssigneesChange(checked: boolean): void {
+    this.notifyAssigneesSig.set(checked);
     this.form.markAsDirty();
+    this.autoSave();
+  }
+
+  /**
+   * Select an assignee for a subtask
+   */
+  onSubtaskAssigneeSelected(subtaskId: string, selection: AutocompleteOption | string): void {
+    if (typeof selection !== 'object') return;
+    const updated = this.subtasks().map((s) => {
+      if (s.id !== subtaskId) return s;
+      const ids = [...(s.assigneeIds || [])];
+      const names = [...(s.assigneeNames || [])];
+      if (!ids.includes(selection.id)) {
+        ids.push(selection.id);
+        names.push(selection.label);
+      }
+      return { ...s, assigneeIds: ids, assigneeNames: names };
+    });
+    this.subtasks.set(updated);
+    this.form.markAsDirty();
+    this.autoSave();
+  }
+
+  /**
+   * Remove an assignee from a subtask
+   */
+  removeSubtaskAssignee(subtaskId: string, index: number): void {
+    const updated = this.subtasks().map((s) => {
+      if (s.id !== subtaskId) return s;
+      const ids = [...(s.assigneeIds || [])];
+      const names = [...(s.assigneeNames || [])];
+      ids.splice(index, 1);
+      names.splice(index, 1);
+      return { ...s, assigneeIds: ids, assigneeNames: names };
+    });
+    this.subtasks.set(updated);
+    this.form.markAsDirty();
+    this.autoSave();
   }
 
   async autoSave() {
@@ -897,11 +1081,20 @@ export class TaskDetailModalComponent {
     const dueDate = val.dueDate ? new Date(val.dueDate) : undefined;
     const tags = Array.from(this.selectedTags());
 
+    const assignees = this.selectedAssignees();
+    const assigneeIds = assignees.map((a) => a.id);
+    const assigneeNames = assignees.map((a) => a.label);
+
     const updates: Partial<Task> = {
       title: val.title!,
       description: val.description || '',
-      assignedToId: this.selectedAssigneeId() || undefined,
-      assigneeName: val.assigneeName || undefined,
+      // Multi-assignee fields
+      assigneeIds: assigneeIds.length > 0 ? assigneeIds : [],
+      assigneeNames: assigneeNames.length > 0 ? assigneeNames : [],
+      notifyAssignees: this.notifyAssigneesSig(),
+      // Backward compat
+      assignedToId: assigneeIds[0] || undefined,
+      assigneeName: assigneeNames[0] || undefined,
       status: val.status as Task['status'],
       dueDate,
       priority: val.priority as Task['priority'],

--- a/src/app/features/tasks/task-list-view.component.ts
+++ b/src/app/features/tasks/task-list-view.component.ts
@@ -4,15 +4,20 @@ import { FormsModule } from '@angular/forms';
 import { Task } from '../../core/models/domain.model';
 import { TaskService } from '../../core/services/task.service';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
+import { MarkdownPipe, MarkdownPlainPipe } from '../../shared/pipes/markdown.pipe';
 
 @Component({
   selector: 'app-task-list-view',
   standalone: true,
-  imports: [CommonModule, FormsModule, DragDropModule],
+  imports: [CommonModule, FormsModule, DragDropModule, MarkdownPipe, MarkdownPlainPipe],
   template: `
-    <div class="flex flex-col h-full bg-[#0a0f1e]/60 rounded-xl overflow-hidden border border-cyan-500/10 shadow-[0_0_20px_rgba(0,210,255,0.05)]">
+    <div
+      class="flex flex-col h-full bg-[#0a0f1e]/60 rounded-xl overflow-hidden border border-cyan-500/10 shadow-[0_0_20px_rgba(0,210,255,0.05)]"
+    >
       <!-- Filter Bar -->
-      <div class="flex items-center justify-between px-4 py-2 bg-[#0a0f1e]/90 border-b border-cyan-500/10">
+      <div
+        class="flex items-center justify-between px-4 py-2 bg-[#0a0f1e]/90 border-b border-cyan-500/10"
+      >
         <div class="flex items-center gap-3">
           <span class="text-xs text-slate-400">
             {{ filteredTasks().length }} of {{ tasks().length }} tasks
@@ -23,10 +28,60 @@ import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-
             </span>
           }
         </div>
-        
-        <!-- Completed Filter Toggle -->
+
         <div class="flex items-center gap-2">
-          <button 
+          <!-- View Mode Toggle -->
+          <div class="flex items-center bg-slate-800/60 rounded-lg border border-white/5 p-0.5">
+            <button
+              class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium transition-all"
+              [class.bg-cyan-500/20]="viewMode() === 'simplified'"
+              [class.text-cyan-400]="viewMode() === 'simplified'"
+              [class.text-slate-500]="viewMode() !== 'simplified'"
+              (click)="viewMode.set('simplified')"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 6h16M4 12h16M4 18h7"
+                />
+              </svg>
+              Simple
+            </button>
+            <button
+              class="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[11px] font-medium transition-all"
+              [class.bg-purple-500/20]="viewMode() === 'detailed'"
+              [class.text-purple-400]="viewMode() === 'detailed'"
+              [class.text-slate-500]="viewMode() !== 'detailed'"
+              (click)="viewMode.set('detailed')"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 6h16M4 10h16M4 14h16M4 18h16"
+                />
+              </svg>
+              Detailed
+            </button>
+          </div>
+
+          <!-- Completed Filter Toggle -->
+          <button
             class="flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium transition-all"
             [class.bg-emerald-500/20]="showCompleted()"
             [class.text-emerald-400]="showCompleted()"
@@ -37,8 +92,19 @@ import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-
             [class.border]="true"
             (click)="toggleShowCompleted()"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 13l4 4L19 7"
+              />
             </svg>
             {{ showCompleted() ? 'Showing Completed' : 'Hide Completed' }}
           </button>
@@ -46,135 +112,310 @@ import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-
       </div>
 
       <!-- Cyberpunk Header -->
-      <div class="grid grid-cols-[auto_1fr_120px_120px_120px_auto] gap-4 px-4 py-3 bg-[#0a0f1e]/80 border-b border-fuchsia-500/20 text-xs font-bold uppercase tracking-[0.15em]">
-        <div class="w-6"></div> <!-- Drag handle placeholder -->
-        <div class="cursor-pointer text-cyan-400 hover:text-cyan-300 transition-colors flex items-center gap-1" (click)="toggleSort('title')">
+      <div
+        class="grid grid-cols-[auto_1fr_120px_120px_120px_auto] gap-4 px-4 py-3 bg-[#0a0f1e]/80 border-b border-fuchsia-500/20 text-xs font-bold uppercase tracking-[0.15em]"
+      >
+        <div class="w-6"></div>
+        <!-- Drag handle placeholder -->
+        <div
+          class="cursor-pointer text-cyan-400 hover:text-cyan-300 transition-colors flex items-center gap-1"
+          (click)="toggleSort('title')"
+        >
           <span class="text-neon-blue">Task Name</span>
-          <span *ngIf="sortField() === 'title'" class="ml-1 text-purple-400">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
+          <span *ngIf="sortField() === 'title'" class="ml-1 text-purple-400">{{
+            sortDirection() === 'asc' ? '↑' : '↓'
+          }}</span>
         </div>
-        <div class="cursor-pointer text-slate-500 hover:text-cyan-400 transition-colors" (click)="toggleSort('dueDate')">
+        <div
+          class="cursor-pointer text-slate-500 hover:text-cyan-400 transition-colors"
+          (click)="toggleSort('dueDate')"
+        >
           Due Date
-          <span *ngIf="sortField() === 'dueDate'" class="ml-1 text-purple-400">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
+          <span *ngIf="sortField() === 'dueDate'" class="ml-1 text-purple-400">{{
+            sortDirection() === 'asc' ? '↑' : '↓'
+          }}</span>
         </div>
-        <div class="cursor-pointer text-slate-500 hover:text-cyan-400 transition-colors" (click)="toggleSort('priority')">
+        <div
+          class="cursor-pointer text-slate-500 hover:text-cyan-400 transition-colors"
+          (click)="toggleSort('priority')"
+        >
           Priority
-          <span *ngIf="sortField() === 'priority'" class="ml-1 text-purple-400">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
+          <span *ngIf="sortField() === 'priority'" class="ml-1 text-purple-400">{{
+            sortDirection() === 'asc' ? '↑' : '↓'
+          }}</span>
         </div>
-        <div class="cursor-pointer text-slate-500 hover:text-cyan-400 transition-colors" (click)="toggleSort('status')">
+        <div
+          class="cursor-pointer text-slate-500 hover:text-cyan-400 transition-colors"
+          (click)="toggleSort('status')"
+        >
           Status
-          <span *ngIf="sortField() === 'status'" class="ml-1 text-purple-400">{{ sortDirection() === 'asc' ? '↑' : '↓' }}</span>
+          <span *ngIf="sortField() === 'status'" class="ml-1 text-purple-400">{{
+            sortDirection() === 'asc' ? '↑' : '↓'
+          }}</span>
         </div>
-        <div class="w-8"></div> <!-- Actions placeholder -->
+        <div class="w-8"></div>
+        <!-- Actions placeholder -->
       </div>
 
       <!-- Task List -->
-      <div 
-        cdkDropList 
+      <div
+        cdkDropList
         [cdkDropListData]="sortedTasks()"
         (cdkDropListDropped)="onDrop($event)"
         class="overflow-y-auto flex-1 divide-y divide-cyan-500/5"
       >
         @if (sortedTasks().length === 0) {
           <div class="flex flex-col items-center justify-center p-12 text-slate-500">
-            <div class="w-16 h-16 rounded-full bg-cyan-500/10 flex items-center justify-center mb-4">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-cyan-500/50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            <div
+              class="w-16 h-16 rounded-full bg-cyan-500/10 flex items-center justify-center mb-4"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-8 w-8 text-cyan-500/50"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                />
               </svg>
             </div>
-            <p class="mb-2 text-cyan-400/70">{{ showCompleted() ? 'No tasks found' : 'No active tasks' }}</p>
-            <p class="text-xs text-slate-600">{{ showCompleted() ? 'Create a task to get started' : 'All tasks are completed!' }}</p>
+            <p class="mb-2 text-cyan-400/70">
+              {{ showCompleted() ? 'No tasks found' : 'No active tasks' }}
+            </p>
+            <p class="text-xs text-slate-600">
+              {{ showCompleted() ? 'Create a task to get started' : 'All tasks are completed!' }}
+            </p>
           </div>
         }
 
         @for (task of sortedTasks(); track task.id) {
-          <div 
+          <div
             cdkDrag
             [cdkDragData]="task"
             [class.opacity-50]="task.status === 'done'"
-            class="group grid grid-cols-[auto_1fr_120px_120px_120px_auto] gap-4 px-4 py-3 items-center hover:bg-cyan-500/5 transition-all cursor-pointer bg-[#0a0f1e]/80 border-l-2 border-transparent hover:border-cyan-500/50"
+            class="group hover:bg-cyan-500/5 transition-all cursor-pointer bg-[#0a0f1e]/80 border-l-2 border-transparent hover:border-cyan-500/50"
             (click)="taskClick.emit(task)"
           >
             <!-- Custom Drag Preview -->
-            <div *cdkDragPreview class="bg-[#0a0f1e] p-4 rounded-lg shadow-[0_0_20px_rgba(0,210,255,0.2)] border border-cyan-500/30 flex items-center gap-3">
+            <div
+              *cdkDragPreview
+              class="bg-[#0a0f1e] p-4 rounded-lg shadow-[0_0_20px_rgba(0,210,255,0.2)] border border-cyan-500/30 flex items-center gap-3"
+            >
               <span class="text-white font-medium">{{ task.title }}</span>
             </div>
 
-            <!-- Drag Handle -->
-            <div cdkDragHandle class="w-6 h-6 flex items-center justify-center text-slate-600 hover:text-cyan-400 cursor-grab active:cursor-grabbing transition-colors">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
-              </svg>
-            </div>
-
-            <!-- Title & ID -->
-            <div class="flex items-center gap-3 overflow-hidden">
-              <div 
-                class="w-5 h-5 rounded-full border-2 flex items-center justify-center cursor-pointer transition-colors"
-                [class.border-cyan-500]="task.status === 'done'"
-                [class.bg-cyan-500]="task.status === 'done'"
-                [class.border-slate-500]="task.status !== 'done'"
-                [class.hover:border-cyan-400]="task.status !== 'done'"
-                (click)="$event.stopPropagation(); toggleCompletion(task)"
+            <!-- Main Row -->
+            <div
+              class="grid grid-cols-[auto_1fr_120px_120px_120px_auto] gap-4 px-4 py-3 items-center"
+            >
+              <!-- Drag Handle -->
+              <div
+                cdkDragHandle
+                class="w-6 h-6 flex items-center justify-center text-slate-600 hover:text-cyan-400 cursor-grab active:cursor-grabbing transition-colors"
               >
-                @if (task.status === 'done') {
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 text-white" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M4 8h16M4 16h16"
+                  />
+                </svg>
+              </div>
+
+              <!-- Title & ID -->
+              <div class="flex items-center gap-3 overflow-hidden">
+                <div
+                  class="w-5 h-5 rounded-full border-2 flex items-center justify-center cursor-pointer transition-colors flex-shrink-0"
+                  [class.border-cyan-500]="task.status === 'done'"
+                  [class.bg-cyan-500]="task.status === 'done'"
+                  [class.border-slate-500]="task.status !== 'done'"
+                  [class.hover:border-cyan-400]="task.status !== 'done'"
+                  (click)="$event.stopPropagation(); toggleCompletion(task)"
+                >
+                  @if (task.status === 'done') {
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="h-3 w-3 text-white"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  }
+                </div>
+                <span
+                  class="truncate font-medium text-sm md-inline-title"
+                  [class.line-through]="task.status === 'done'"
+                  [class.text-slate-500]="task.status === 'done'"
+                  [class.text-slate-200]="task.status !== 'done'"
+                  [innerHTML]="task.title | markdown"
+                ></span>
+                @if (task.googleTaskId) {
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-4 w-4 text-blue-400 flex-shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                    />
                   </svg>
                 }
               </div>
-              <span class="truncate font-medium text-sm text-slate-200" [class.line-through]="task.status === 'done'" [class.text-slate-500]="task.status === 'done'">
-                {{ task.title }}
-              </span>
-              @if (task.googleTaskId) {
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                </svg>
-              }
-            </div>
 
-            <!-- Due Date -->
-            <div class="text-sm truncate" [class.text-rose-400]="isOverdue(task)" [class.text-slate-400]="!isOverdue(task)">
-              {{ formatDate(task.dueDate) }}
-            </div>
-
-            <!-- Priority -->
-            <div>
-              <span 
-                class="px-2 py-0.5 rounded text-[10px] uppercase font-bold tracking-wider"
-                [ngClass]="{
-                  'bg-rose-500/10 text-rose-400 border border-rose-500/20': task.priority === 'high',
-                  'bg-amber-500/10 text-amber-400 border border-amber-500/20': task.priority === 'medium',
-                  'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20': task.priority === 'low'
-                }"
+              <!-- Due Date -->
+              <div
+                class="text-sm truncate"
+                [class.text-rose-400]="isOverdue(task)"
+                [class.text-slate-400]="!isOverdue(task)"
               >
-                {{ task.priority }}
-              </span>
-            </div>
+                {{ formatDate(task.dueDate) }}
+              </div>
 
-            <!-- Status -->
-            <div>
-              <span class="text-xs text-slate-400 capitalize bg-white/5 px-2 py-1 rounded">
-                {{ task.status.replace('-', ' ') }}
-              </span>
-            </div>
+              <!-- Priority -->
+              <div>
+                <span
+                  class="px-2 py-0.5 rounded text-[10px] uppercase font-bold tracking-wider"
+                  [ngClass]="{
+                    'bg-rose-500/10 text-rose-400 border border-rose-500/20':
+                      task.priority === 'high',
+                    'bg-amber-500/10 text-amber-400 border border-amber-500/20':
+                      task.priority === 'medium',
+                    'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20':
+                      task.priority === 'low',
+                  }"
+                >
+                  {{ task.priority }}
+                </span>
+              </div>
 
-            <!-- Actions -->
-            <div class="flex items-center justify-end opacity-0 group-hover:opacity-100 transition-opacity">
-              <button 
-                class="p-1.5 text-rose-400 hover:text-rose-300 hover:bg-rose-500/10 rounded transition-colors"
-                (click)="$event.stopPropagation(); delete.emit(task.id)"
-                title="Delete Task"
+              <!-- Status -->
+              <div>
+                <span class="text-xs text-slate-400 capitalize bg-white/5 px-2 py-1 rounded">
+                  {{ task.status.replace('-', ' ') }}
+                </span>
+              </div>
+
+              <!-- Actions -->
+              <div
+                class="flex items-center justify-end opacity-0 group-hover:opacity-100 transition-opacity"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-              </button>
+                <button
+                  class="p-1.5 text-rose-400 hover:text-rose-300 hover:bg-rose-500/10 rounded transition-colors"
+                  (click)="$event.stopPropagation(); delete.emit(task.id)"
+                  title="Delete Task"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
+
+            <!-- Description Preview Row -->
+            @if (task.description) {
+              <div class="px-4 pb-3 pl-[3.25rem]">
+                @if (viewMode() === 'detailed') {
+                  <div
+                    class="text-xs text-slate-400 prose prose-invert prose-xs max-w-none md-preview-content"
+                    [innerHTML]="task.description | markdown"
+                  ></div>
+                } @else {
+                  <div class="text-xs text-slate-500 truncate max-w-2xl">
+                    {{ task.description | markdownPlain: 80 }}
+                  </div>
+                }
+              </div>
+            }
           </div>
         }
       </div>
     </div>
   `,
+  styles: [
+    `
+      .md-inline-title :is(p) {
+        display: inline;
+        margin: 0;
+      }
+      .md-inline-title :is(h1, h2, h3, h4, h5, h6) {
+        display: inline;
+        font-size: inherit;
+        margin: 0;
+      }
+      .md-preview-content {
+        max-height: 12rem;
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(148, 163, 184, 0.2) transparent;
+      }
+      .md-preview-content :is(h1, h2, h3) {
+        font-size: 0.8rem;
+        margin: 0.25rem 0;
+        font-weight: 600;
+        color: #cbd5e1;
+      }
+      .md-preview-content p {
+        margin: 0.15rem 0;
+      }
+      .md-preview-content ul,
+      .md-preview-content ol {
+        margin: 0.15rem 0;
+        padding-left: 1rem;
+      }
+      .md-preview-content pre {
+        font-size: 0.7rem;
+        padding: 0.35rem 0.5rem;
+        border-radius: 0.25rem;
+        background: rgba(255, 255, 255, 0.03);
+        margin: 0.25rem 0;
+      }
+      .md-preview-content code {
+        font-size: 0.7rem;
+      }
+      .md-preview-content table {
+        font-size: 0.7rem;
+        margin: 0.25rem 0;
+      }
+      .md-preview-content .md-callout {
+        font-size: 0.7rem;
+        padding: 0.35rem 0.5rem;
+        margin: 0.25rem 0;
+      }
+    `,
+  ],
 })
 export class TaskListViewComponent {
   private taskService = inject(TaskService);
@@ -183,6 +424,9 @@ export class TaskListViewComponent {
   googleTaskListId = input<string | undefined>(undefined);
   taskClick = output<Task>();
   delete = output<string>();
+
+  // View mode toggle
+  viewMode = signal<'simplified' | 'detailed'>('simplified');
 
   // Filter state - hide completed tasks older than 30 minutes by default
   showCompleted = signal(false);


### PR DESCRIPTION
## Summary

Enhances the task display and editing experience across list, board, and detail views.

## Changes

### Tag UI Improvements
- **Fixed white ring outline** on selected tags in both detail and create modals (replaced `ring-white` with inline `--tw-ring-color` matching tag color)
- **Added removable tag chips** with × buttons in task detail modal (replaces plain text "Selected: tag1, tag2" display)
- Added `selectedTagsArray` computed signal and `getTagColor()` helper

### Markdown Titles & Description Preview
- Task titles now render markdown via `MarkdownPipe` in list and board views
- Abbreviated description previews appear below task titles in both views
- **Simple/Detailed view toggle** in the filter bar of both views:
  - **Simple**: truncated plain text (80 chars list / 60 chars board) via `MarkdownPlainPipe`
  - **Detailed**: full rendered markdown with scrollable overflow
- Compact CSS for preview rendering (`.md-preview-content`, `.board-preview-content`, `.line-clamp-2`)

## Files Changed

| File | Change |
|------|--------|
| `task-detail-modal.component.ts` | Tag ring fix, removable chip badges, `selectedTagsArray`, `getTagColor` |
| `task-create-modal.component.ts` | Tag ring fix |
| `task-list-view.component.ts` | Markdown titles, description preview, Simple/Detailed toggle |
| `task-board-view.component.ts` | Description preview, Simple/Detailed toggle, preview CSS |

## Testing

- [x] Production build passes (`ng build --configuration production`)
- [x] Browser verification (toggle visible, descriptions render)
- [ ] Manual QA: tag removal flow
- [ ] Manual QA: markdown title rendering
- [ ] Manual QA: Simple/Detailed toggle in both views