### PR TITLE
Refactor: Migrate Legacy Angular APIs (Issue #80)

### DIFF
--- a/src/app/core/models/contact.model.ts
+++ b/src/app/core/models/contact.model.ts
@@ -1,0 +1,7 @@
+export interface Contact {
+  id: string; // email or uid
+  email: string;
+  displayName: string;
+  photoURL?: string;
+  source: 'workspace' | 'google-contacts' | 'google-directory' | 'default-domain' | 'cached';
+}

--- a/src/app/core/services/contacts.service.ts
+++ b/src/app/core/services/contacts.service.ts
@@ -24,7 +24,6 @@ import {
   forkJoin,
   switchMap,
   tap,
-  BehaviorSubject,
   firstValueFrom,
 } from 'rxjs';
 import { UserProfile } from '../models/user.model';
@@ -36,12 +35,7 @@ export interface Contact {
   email: string;
   displayName: string;
   photoURL?: string;
-  source:
-    | 'workspace'
-    | 'google-contacts'
-    | 'google-directory'
-    | 'default-domain'
-    | 'cached';
+  source: 'workspace' | 'google-contacts' | 'google-directory' | 'default-domain' | 'cached';
 }
 
 /**
@@ -68,8 +62,8 @@ export class ContactsService {
   private contactsCache$: Observable<Contact[]> | null = null;
 
   // Loading state
-  private readonly loadingSubject = new BehaviorSubject<boolean>(false);
-  loading$ = this.loadingSubject.asObservable();
+  private readonly loadingSignal = signal<boolean>(false);
+  loading = this.loadingSignal.asReadonly();
 
   // Default domain for omniflexfitness.com emails
   private readonly DEFAULT_DOMAIN = 'omniflexfitness.com';
@@ -108,7 +102,7 @@ export class ContactsService {
    */
   getContacts(): Observable<Contact[]> {
     if (!this.contactsCache$) {
-      this.loadingSubject.next(true);
+      this.loadingSignal.set(true);
 
       this.contactsCache$ = combineLatest([
         // 1. Cached contacts from Firestore (fast, primary source, user-scoped)
@@ -154,28 +148,20 @@ export class ContactsService {
         // 5. Always include preset domain members as fallback
         of(this.PRESET_DOMAIN_MEMBERS),
       ]).pipe(
-        map(
-          ([
-            cachedContacts,
-            directoryPeople,
-            googleContacts,
-            otherContacts,
-            presetMembers,
-          ]) => {
-            // Merge and deduplicate contacts by email
-            // Priority: google-directory > google-contacts > other-contacts > cached > default-domain
-            const allContacts = [
-              ...directoryPeople,
-              ...googleContacts,
-              ...otherContacts,
-              ...cachedContacts,
-              ...presetMembers,
-            ];
-            return this.deduplicateContacts(allContacts);
-          },
-        ),
+        map(([cachedContacts, directoryPeople, googleContacts, otherContacts, presetMembers]) => {
+          // Merge and deduplicate contacts by email
+          // Priority: google-directory > google-contacts > other-contacts > cached > default-domain
+          const allContacts = [
+            ...directoryPeople,
+            ...googleContacts,
+            ...otherContacts,
+            ...cachedContacts,
+            ...presetMembers,
+          ];
+          return this.deduplicateContacts(allContacts);
+        }),
         tap((contacts) => {
-          this.loadingSubject.next(false);
+          this.loadingSignal.set(false);
           // Sync fresh contacts to Firestore in background
           this.syncContactsToFirestore(contacts).catch((err) =>
             console.warn('Failed to sync contacts to Firestore:', err),
@@ -184,7 +170,7 @@ export class ContactsService {
         shareReplay(1),
         catchError((err) => {
           console.error('Failed to fetch contacts', err);
-          this.loadingSubject.next(false);
+          this.loadingSignal.set(false);
           return of([]);
         }),
       );

--- a/src/app/core/services/contacts.service.ts
+++ b/src/app/core/services/contacts.service.ts
@@ -30,13 +30,7 @@ import { UserProfile } from '../models/user.model';
 import { GoogleContactsService, GoogleContact } from './google-contacts.service';
 import { AuthService } from '../auth/auth.service';
 
-export interface Contact {
-  id: string; // email or uid
-  email: string;
-  displayName: string;
-  photoURL?: string;
-  source: 'workspace' | 'google-contacts' | 'google-directory' | 'default-domain' | 'cached';
-}
+import { Contact } from '../models/contact.model';
 
 /**
  * Stored contact in Firestore

--- a/src/app/features/projects/components/project-member-manager.component.ts
+++ b/src/app/features/projects/components/project-member-manager.component.ts
@@ -1,8 +1,9 @@
-import { Component, input, inject, signal, computed , ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ProjectService } from '../../../core/services/project.service';
-import { ContactsService, Contact } from '../../../core/services/contacts.service';
+import { ContactsService } from '../../../core/services/contacts.service';
+import { Contact } from '../../../core/models/contact.model';
 import { DialogService } from '../../../core/services/dialog.service';
 import { Project } from '../../../core/models/domain.model';
 import { toSignal } from '@angular/core/rxjs-interop';

--- a/src/app/features/tasks/task-create-modal.component.ts
+++ b/src/app/features/tasks/task-create-modal.component.ts
@@ -13,7 +13,8 @@ import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { TaskService } from '../../core/services/task.service';
 import { ProjectService } from '../../core/services/project.service';
 import { CustomFieldService } from '../../core/services/custom-field.service';
-import { ContactsService, Contact } from '../../core/services/contacts.service';
+import { ContactsService } from '../../core/services/contacts.service';
+import { Contact } from '../../core/models/contact.model';
 import { VertexAiService } from '../../core/services/vertex-ai.service';
 import {
   Task,

--- a/src/app/features/tasks/task-detail-modal.component.ts
+++ b/src/app/features/tasks/task-detail-modal.component.ts
@@ -13,7 +13,8 @@ import { ReactiveFormsModule, FormBuilder, Validators, FormsModule } from '@angu
 import { TaskService } from '../../core/services/task.service';
 import { ProjectService } from '../../core/services/project.service';
 import { DialogService } from '../../core/services/dialog.service';
-import { ContactsService, Contact } from '../../core/services/contacts.service';
+import { ContactsService } from '../../core/services/contacts.service';
+import { Contact } from '../../core/models/contact.model';
 import { VertexAiService } from '../../core/services/vertex-ai.service';
 import { CustomFieldService } from '../../core/services/custom-field.service';
 import { TaskDependencyService } from '../../core/services/task-dependency.service';


### PR DESCRIPTION
Closes #80. Migrated BehaviorSubject to signal in ContactsService. Note: The legacy *ngIf and @Input/@Output decorators mentioned in the issue were already migrated in previous commits.