### PR TITLE
feat: Add Admin Dashboard and RBAC features

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,6 +6,12 @@ service cloud.firestore {
       return request.auth != null;
     }
 
+    // Helper to check if user is an admin
+    function isAdmin() {
+      return isAuthenticated() && 
+        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+    }
+
     // Helper to check if user is owner or member of the resource
     function isMember(resourceData) {
       return isAuthenticated() && (
@@ -16,8 +22,8 @@ service cloud.firestore {
     
     match /users/{userId} {
       // Allow reading own profile only
-      allow read: if request.auth.uid == userId;
-      allow write: if request.auth.uid == userId;
+      allow read: if request.auth.uid == userId || isAdmin();
+      allow write: if request.auth.uid == userId || isAdmin();
     }
     
     // User's personal contacts cache - scoped to individual users
@@ -37,9 +43,9 @@ service cloud.firestore {
     
     match /projects/{projectId} {
       allow create: if isAuthenticated();
-      allow read: if isMember(resource.data);
-      allow update: if isMember(resource.data);
-      allow delete: if isAuthenticated() && request.auth.uid == resource.data.ownerId;
+      allow read: if isMember(resource.data) || isAdmin();
+      allow update: if isMember(resource.data) || isAdmin();
+      allow delete: if (isAuthenticated() && request.auth.uid == resource.data.ownerId) || isAdmin();
     }
     
     match /tasks/{taskId} {
@@ -61,9 +67,9 @@ service cloud.firestore {
         );
       }
 
-      allow create: if isAuthenticated() && canCreateInProject();
-      allow read: if isAuthenticated() && isProjectMember();
-      allow update, delete: if isAuthenticated() && isProjectMember();
+      allow create: if (isAuthenticated() && canCreateInProject()) || isAdmin();
+      allow read: if (isAuthenticated() && isProjectMember()) || isAdmin();
+      allow update, delete: if (isAuthenticated() && isProjectMember()) || isAdmin();
     }
     
     // Notifications - written by Cloud Functions, readable by recipient

--- a/firestore.rules
+++ b/firestore.rules
@@ -23,7 +23,11 @@ service cloud.firestore {
     match /users/{userId} {
       // Allow reading own profile only
       allow read: if request.auth.uid == userId || isAdmin();
-      allow write: if request.auth.uid == userId || isAdmin();
+      
+      // Prevent privilege escalation: only admins can set or update the role to 'admin'
+      allow create: if isAdmin() || (request.auth.uid == userId && request.resource.data.get('role', 'user') != 'admin');
+      allow update: if isAdmin() || (request.auth.uid == userId && request.resource.data.get('role', '') == resource.data.get('role', ''));
+      allow delete: if request.auth.uid == userId || isAdmin();
     }
     
     // User's personal contacts cache - scoped to individual users
@@ -38,6 +42,11 @@ service cloud.firestore {
 
     // Weekly schedule blocks - scoped to individual users
     match /users/{userId}/weeklyBlocks/{blockId} {
+      allow read, write: if request.auth.uid == userId;
+    }
+
+    // Custom Fields - scoped to individual users
+    match /users/{userId}/customFields/{fieldId} {
       allow read, write: if request.auth.uid == userId;
     }
     

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { authGuard } from './core/auth/auth.guard';
+import { adminGuard } from './core/guards/admin.guard';
 
 export const routes: Routes = [
   {
@@ -48,6 +49,14 @@ export const routes: Routes = [
         path: 'settings',
         loadComponent: () =>
           import('./features/settings/settings.component').then((m) => m.SettingsComponent),
+      },
+      {
+        path: 'admin',
+        canActivate: [adminGuard],
+        loadComponent: () =>
+          import('./features/admin/admin-dashboard.component').then(
+            (m) => m.AdminDashboardComponent,
+          ),
       },
     ],
   },

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -44,6 +44,14 @@ export class AuthService {
   private destroyRef = inject(DestroyRef);
 
   user$ = user(this.auth);
+
+  userProfile$: Observable<UserProfile | null> = this.user$.pipe(
+    switchMap((firebaseUser) => {
+      if (!firebaseUser) return of(null);
+      return this.getUserProfile(firebaseUser.uid);
+    }),
+  );
+
   currentUserSig = signal<UserProfile | null>(null);
 
   // Google Tasks API access token for authenticated API calls
@@ -53,21 +61,13 @@ export class AuthService {
   hasOfflineAccess = signal<boolean>(false);
 
   constructor() {
-    this.user$
-      .pipe(
-        switchMap((firebaseUser) => {
-          if (!firebaseUser) return of(null);
-          return this.getUserProfile(firebaseUser.uid);
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe((profile) => {
-        this.currentUserSig.set(profile);
-        // Check if user has stored refresh token
-        if (profile?.hasGoogleTasksOfflineAccess) {
-          this.hasOfflineAccess.set(true);
-        }
-      });
+    this.userProfile$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((profile) => {
+      this.currentUserSig.set(profile);
+      // Check if user has stored refresh token
+      if (profile?.hasGoogleTasksOfflineAccess) {
+        this.hasOfflineAccess.set(true);
+      }
+    });
 
     // Security Note: Access token is kept in-memory only (not sessionStorage) to prevent XSS attacks.
     // User will need to re-authenticate for Google Tasks after page refresh.

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -1,0 +1,22 @@
+import { inject } from '@angular/core';
+import { Router, CanActivateFn } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
+import { map, take, tap } from 'rxjs/operators';
+
+export const adminGuard: CanActivateFn = (route, state) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  return auth.user$.pipe(
+    take(1),
+    map(() => {
+      const user = auth.currentUserSig();
+      return !!user && user.role === 'admin';
+    }),
+    tap((isAdmin) => {
+      if (!isAdmin) {
+        router.navigate(['/']);
+      }
+    }),
+  );
+};

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -7,14 +7,9 @@ export const adminGuard: CanActivateFn = (route, state) => {
   const auth = inject(AuthService);
   const router = inject(Router);
 
-  return auth.user$.pipe(
+  return auth.userProfile$.pipe(
     take(1),
-    map((firebaseUser) => {
-      if (!firebaseUser) return false;
-      const user = auth.currentUserSig();
-      // This check helps ensure the profile in the signal corresponds to the user from the auth stream.
-      return !!user && user.uid === firebaseUser.uid && user.role === 'admin';
-    }),
+    map((profile) => !!profile && profile.role === 'admin'),
     tap((isAdmin) => {
       if (!isAdmin) {
         router.navigate(['/']);

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -9,9 +9,11 @@ export const adminGuard: CanActivateFn = (route, state) => {
 
   return auth.user$.pipe(
     take(1),
-    map(() => {
+    map((firebaseUser) => {
+      if (!firebaseUser) return false;
       const user = auth.currentUserSig();
-      return !!user && user.role === 'admin';
+      // This check helps ensure the profile in the signal corresponds to the user from the auth stream.
+      return !!user && user.uid === firebaseUser.uid && user.role === 'admin';
     }),
     tap((isAdmin) => {
       if (!isAdmin) {

--- a/src/app/core/services/project.service.ts
+++ b/src/app/core/services/project.service.ts
@@ -42,6 +42,16 @@ export class ProjectService {
   selectedProjectId = signal<string | null>(null);
 
   /**
+   * Get all projects globally (for Admin view)
+   */
+  getAllProjects(): Observable<Project[]> {
+    const q = query(this.projectsCollection);
+    return runInInjectionContext(this.injector, () => {
+      return collectionData(q, { idField: 'id' }) as Observable<Project[]>;
+    });
+  }
+
+  /**
    * Get all projects for the current user
    */
   getMyProjects(): Observable<Project[]> {

--- a/src/app/core/services/task.service.ts
+++ b/src/app/core/services/task.service.ts
@@ -247,6 +247,16 @@ export class TaskService {
   }
 
   /**
+   * Get all tasks globally (for Admin view)
+   */
+  getAllTasks(): Observable<Task[]> {
+    const q = query(this.tasksCollection, orderBy('createdAt', 'desc'));
+    return runInInjectionContext(this.injector, () => {
+      return collectionData(q, { idField: 'id' }) as Observable<Task[]>;
+    });
+  }
+
+  /**
    * Get all tasks for a project, sorted by order
    */
   getTasksByProject(projectId: string): Observable<Task[]> {

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, inject, signal, Injector, runInInjectionContext } from '@angular/core';
+import {
+  Firestore,
+  collection,
+  doc,
+  updateDoc,
+  query,
+  collectionData,
+} from '@angular/fire/firestore';
+import { UserProfile } from '../models/user.model';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserService {
+  private firestore = inject(Firestore);
+  private injector = inject(Injector);
+  private usersCollection = collection(this.firestore, 'users');
+
+  loading = signal(false);
+  error = signal<string | null>(null);
+
+  /**
+   * Get all users.
+   * NOTE: Only works if the user has read access to all users (e.g., is an admin).
+   */
+  getAllUsers(): Observable<UserProfile[]> {
+    const q = query(this.usersCollection);
+    return runInInjectionContext(this.injector, () => {
+      return collectionData(q, { idField: 'uid' }) as Observable<UserProfile[]>;
+    });
+  }
+
+  /**
+   * Update a user's role.
+   */
+  async updateUserRole(uid: string, role: 'admin' | 'user'): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const userRef = doc(this.firestore, `users/${uid}`);
+      await updateDoc(userRef, { role });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update user role';
+      this.error.set(message);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -39,10 +39,11 @@ export class UserService {
     this.loading.set(true);
     this.error.set(null);
     try {
-      const userRef = doc(this.firestore, `users/${uid}`);
+      const userRef = doc(this.firestore, 'users', uid);
       await updateDoc(userRef, { role });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update user role';
+      const message = 'Failed to update user role';
+      console.error(`${message}:`, err);
       this.error.set(message);
       throw err;
     } finally {

--- a/src/app/features/admin/admin-dashboard.component.ts
+++ b/src/app/features/admin/admin-dashboard.component.ts
@@ -1,0 +1,297 @@
+import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+
+import { UserService } from '../../core/services/user.service';
+import { ProjectService } from '../../core/services/project.service';
+import { TaskService } from '../../core/services/task.service';
+import { DialogService } from '../../core/services/dialog.service';
+import { UserProfile } from '../../core/models/user.model';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'app-admin-dashboard',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="h-screen overflow-y-auto bg-[#0a0a0a] text-gray-200">
+      <div class="p-8 max-w-7xl mx-auto flex flex-col gap-8">
+        <!-- Header -->
+        <div class="flex items-center justify-between">
+          <div>
+            <h1
+              class="text-4xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-cyan-400"
+            >
+              Admin Dashboard
+            </h1>
+            <p class="text-gray-400 mt-2">Manage users, projects, and global tasks.</p>
+          </div>
+          <button
+            (click)="router.navigate(['/'])"
+            class="px-4 py-2 bg-white/5 border border-white/10 rounded-lg hover:bg-white/10 transition-colors focus:ring-2 focus:ring-cyan-500/50 outline-none"
+          >
+            Back to App
+          </button>
+        </div>
+
+        <!-- Stats Cards -->
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div
+            class="bg-black/30 border border-white/10 rounded-xl p-6 relative overflow-hidden group hover:border-purple-500/50 transition-colors"
+          >
+            <div
+              class="absolute inset-0 bg-gradient-to-br from-purple-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <h3 class="text-gray-400 font-medium">Total Users</h3>
+            <p class="text-4xl font-bold mt-2 text-white">{{ users().length }}</p>
+          </div>
+          <div
+            class="bg-black/30 border border-white/10 rounded-xl p-6 relative overflow-hidden group hover:border-cyan-500/50 transition-colors"
+          >
+            <div
+              class="absolute inset-0 bg-gradient-to-br from-cyan-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <h3 class="text-gray-400 font-medium">Total Projects</h3>
+            <p class="text-4xl font-bold mt-2 text-white">{{ projects().length }}</p>
+          </div>
+          <div
+            class="bg-black/30 border border-white/10 rounded-xl p-6 relative overflow-hidden group hover:border-blue-500/50 transition-colors"
+          >
+            <div
+              class="absolute inset-0 bg-gradient-to-br from-blue-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity"
+            ></div>
+            <h3 class="text-gray-400 font-medium">Total Tasks</h3>
+            <p class="text-4xl font-bold mt-2 text-white">{{ tasks().length }}</p>
+          </div>
+        </div>
+
+        <!-- Navigation Tabs -->
+        <div class="flex border-b border-white/10 gap-8">
+          <button
+            *ngFor="let tab of tabs"
+            (click)="activeTab.set(tab)"
+            [class.border-cyan-400]="activeTab() === tab"
+            [class.text-cyan-400]="activeTab() === tab"
+            [class.border-transparent]="activeTab() !== tab"
+            [class.text-gray-400]="activeTab() !== tab"
+            [class.hover:text-white]="activeTab() !== tab"
+            class="pb-3 border-b-2 font-medium transition-colors outline-none"
+          >
+            {{ tab }}
+          </button>
+        </div>
+
+        <!-- Users Tab -->
+        <div *ngIf="activeTab() === 'Users'" class="flex flex-col gap-4">
+          <div
+            class="bg-black/40 border border-white/10 rounded-xl overflow-hidden backdrop-blur-md"
+          >
+            <table class="w-full text-left text-sm text-gray-300">
+              <thead class="text-xs uppercase bg-black/60 text-gray-400">
+                <tr>
+                  <th class="px-6 py-4">User</th>
+                  <th class="px-6 py-4">Email</th>
+                  <th class="px-6 py-4">Role</th>
+                  <th class="px-6 py-4">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  *ngFor="let user of users()"
+                  class="border-b border-white/5 hover:bg-white/5 transition-colors"
+                >
+                  <td class="px-6 py-4 font-medium text-white flex items-center gap-4">
+                    <div
+                      class="w-10 h-10 rounded-full bg-purple-500/20 flex items-center justify-center border border-purple-500/30 text-purple-200"
+                    >
+                      {{ user.displayName ? user.displayName.charAt(0) : 'U' }}
+                    </div>
+                    <div>
+                      <div class="font-medium">{{ user.displayName || 'Unknown User' }}</div>
+                      <div class="text-xs text-gray-500 mt-0.5">ID: {{ user.uid }}</div>
+                    </div>
+                  </td>
+                  <td class="px-6 py-4">{{ user.email }}</td>
+                  <td class="px-6 py-4">
+                    <span
+                      class="px-3 py-1 text-xs font-semibold rounded-full border"
+                      [class.bg-purple-500/10]="user.role === 'admin'"
+                      [class.border-purple-500/30]="user.role === 'admin'"
+                      [class.text-purple-400]="user.role === 'admin'"
+                      [class.bg-white/5]="user.role !== 'admin'"
+                      [class.border-white/10]="user.role !== 'admin'"
+                      [class.text-gray-400]="user.role !== 'admin'"
+                    >
+                      {{ user.role === 'admin' ? 'Admin' : 'User' }}
+                    </span>
+                  </td>
+                  <td class="px-6 py-4">
+                    <button
+                      *ngIf="user.role !== 'admin'"
+                      (click)="promoteToAdmin(user)"
+                      class="text-cyan-400 hover:text-cyan-300 font-medium transition-colors"
+                    >
+                      Promote to Admin
+                    </button>
+                    <button
+                      *ngIf="user.role === 'admin'"
+                      (click)="demoteToUser(user)"
+                      class="text-rose-400 hover:text-rose-300 font-medium transition-colors"
+                    >
+                      Demote
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Projects Tab -->
+        <div *ngIf="activeTab() === 'Projects'" class="flex flex-col gap-4">
+          <div
+            class="bg-black/40 border border-white/10 rounded-xl overflow-hidden backdrop-blur-md"
+          >
+            <table class="w-full text-left text-sm text-gray-300">
+              <thead class="text-xs uppercase bg-black/60 text-gray-400">
+                <tr>
+                  <th class="px-6 py-4">Project Name</th>
+                  <th class="px-6 py-4">Status</th>
+                  <th class="px-6 py-4">Owner ID</th>
+                  <th class="px-6 py-4">Members</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  *ngFor="let project of projects()"
+                  class="border-b border-white/5 hover:bg-white/5 transition-colors"
+                >
+                  <td class="px-6 py-4 font-medium text-white flex items-center gap-3">
+                    <div
+                      class="w-4 h-4 rounded-full"
+                      [style.backgroundColor]="project.color || '#6366f1'"
+                    ></div>
+                    <div>
+                      <div>{{ project.name }}</div>
+                      <div class="text-xs text-gray-500 font-normal mt-0.5">
+                        ID: {{ project.id }}
+                      </div>
+                    </div>
+                  </td>
+                  <td class="px-6 py-4">
+                    <span
+                      class="px-2.5 py-1 text-[10px] font-semibold tracking-wider rounded-full bg-white/5 border border-white/10 uppercase"
+                    >
+                      {{ project.status }}
+                    </span>
+                  </td>
+                  <td class="px-6 py-4 font-mono text-xs text-gray-400">{{ project.ownerId }}</td>
+                  <td class="px-6 py-4">
+                    <span class="px-2 py-1 bg-white/5 rounded text-xs font-mono">{{
+                      project.memberIds.length
+                    }}</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- Tasks Tab -->
+        <div *ngIf="activeTab() === 'Tasks'" class="flex flex-col gap-4">
+          <div
+            class="bg-black/40 border border-white/10 rounded-xl overflow-hidden backdrop-blur-md"
+          >
+            <table class="w-full text-left text-sm text-gray-300">
+              <thead class="text-xs uppercase bg-black/60 text-gray-400">
+                <tr>
+                  <th class="px-6 py-4">Task Title</th>
+                  <th class="px-6 py-4">Status</th>
+                  <th class="px-6 py-4">Priority</th>
+                  <th class="px-6 py-4">Project ID</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  *ngFor="let task of tasks()"
+                  class="border-b border-white/5 hover:bg-white/5 transition-colors"
+                >
+                  <td class="px-6 py-4">
+                    <div class="font-medium text-white">{{ task.title }}</div>
+                    <div class="text-[10px] text-gray-500 font-mono mt-1">ID: {{ task.id }}</div>
+                  </td>
+                  <td class="px-6 py-4">
+                    <span class="flex items-center gap-2">
+                      <span
+                        class="w-2 h-2 rounded-full"
+                        [class.bg-gray-500]="task.status === 'todo'"
+                        [class.bg-cyan-500]="task.status === 'in-progress'"
+                        [class.bg-purple-500]="task.status === 'done'"
+                      ></span>
+                      <span
+                        class="text-xs uppercase font-medium"
+                        [class.text-gray-400]="task.status === 'todo'"
+                        [class.text-cyan-400]="task.status === 'in-progress'"
+                        [class.text-purple-400]="task.status === 'done'"
+                        >{{ task.status }}</span
+                      >
+                    </span>
+                  </td>
+                  <td class="px-6 py-4">
+                    <span
+                      class="px-2 py-1 text-[10px] uppercase font-bold rounded"
+                      [class.bg-rose-500/20]="task.priority === 'high'"
+                      [class.text-rose-400]="task.priority === 'high'"
+                      [class.bg-amber-500/20]="task.priority === 'medium'"
+                      [class.text-amber-400]="task.priority === 'medium'"
+                      [class.bg-blue-500/20]="task.priority === 'low'"
+                      [class.text-blue-400]="task.priority === 'low'"
+                    >
+                      {{ task.priority }}
+                    </span>
+                  </td>
+                  <td class="px-6 py-4 font-mono text-xs opacity-70">{{ task.projectId }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class AdminDashboardComponent {
+  userService = inject(UserService);
+  projectService = inject(ProjectService);
+  taskService = inject(TaskService);
+  dialogService = inject(DialogService);
+  router = inject(Router);
+
+  tabs = ['Users', 'Projects', 'Tasks'];
+  activeTab = signal('Users');
+
+  users = toSignal(this.userService.getAllUsers(), { initialValue: [] });
+  projects = toSignal(this.projectService.getAllProjects(), { initialValue: [] });
+  tasks = toSignal(this.taskService.getAllTasks(), { initialValue: [] });
+
+  async promoteToAdmin(user: UserProfile) {
+    if (
+      await this.dialogService.confirm(
+        `Are you sure you want to promote ${user.displayName} to Admin?`,
+      )
+    ) {
+      await this.userService.updateUserRole(user.uid, 'admin');
+    }
+  }
+
+  async demoteToUser(user: UserProfile) {
+    if (
+      await this.dialogService.confirm(
+        `Are you sure you want to demote ${user.displayName} to User?`,
+      )
+    ) {
+      await this.userService.updateUserRole(user.uid, 'user');
+    }
+  }
+}

--- a/src/app/features/admin/admin-dashboard.component.ts
+++ b/src/app/features/admin/admin-dashboard.component.ts
@@ -7,6 +7,7 @@ import { UserService } from '../../core/services/user.service';
 import { ProjectService } from '../../core/services/project.service';
 import { TaskService } from '../../core/services/task.service';
 import { DialogService } from '../../core/services/dialog.service';
+import { AuthService } from '../../core/auth/auth.service';
 import { UserProfile } from '../../core/models/user.model';
 
 @Component({
@@ -262,11 +263,13 @@ import { UserProfile } from '../../core/models/user.model';
   `,
 })
 export class AdminDashboardComponent {
-  userService = inject(UserService);
-  projectService = inject(ProjectService);
-  taskService = inject(TaskService);
-  dialogService = inject(DialogService);
-  router = inject(Router);
+  readonly userService = inject(UserService);
+  readonly projectService = inject(ProjectService);
+  readonly taskService = inject(TaskService);
+  readonly dialogService = inject(DialogService);
+  readonly router = inject(Router);
+  readonly authService = inject(AuthService);
+  currentUser = this.authService.currentUserSig;
 
   tabs = ['Users', 'Projects', 'Tasks'];
   activeTab = signal('Users');
@@ -281,17 +284,33 @@ export class AdminDashboardComponent {
         `Are you sure you want to promote ${user.displayName} to Admin?`,
       )
     ) {
-      await this.userService.updateUserRole(user.uid, 'admin');
+      try {
+        await this.userService.updateUserRole(user.uid, 'admin');
+        // Optionally show a success toast here
+      } catch (error) {
+        console.error('Failed to promote user:', error);
+        this.dialogService.alert('Failed to promote user. Please try again.', 'Error');
+      }
     }
   }
 
   async demoteToUser(user: UserProfile) {
+    if (user.uid === this.currentUser()?.uid) {
+      this.dialogService.alert('You cannot demote your own account.', 'Action Not Allowed');
+      return;
+    }
+
     if (
       await this.dialogService.confirm(
         `Are you sure you want to demote ${user.displayName} to User?`,
       )
     ) {
-      await this.userService.updateUserRole(user.uid, 'user');
+      try {
+        await this.userService.updateUserRole(user.uid, 'user');
+      } catch (error) {
+        console.error('Failed to demote user:', error);
+        this.dialogService.alert('Failed to demote user. Please try again.', 'Error');
+      }
     }
   }
 }

--- a/src/app/features/settings/settings.component.html
+++ b/src/app/features/settings/settings.component.html
@@ -181,6 +181,23 @@
               <span class="text-slate-400">Role</span>
               <span class="text-white capitalize">{{ currentUser()?.role }}</span>
             </div>
+
+            @if (currentUser()?.role === 'admin') {
+              <div class="mt-6 pt-6 border-t border-white/10 flex justify-between items-center">
+                <div>
+                  <h3 class="text-white font-medium mb-1 flex items-center gap-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-purple-400" viewBox="0 0 20 20" fill="currentColor">
+                      <path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                    </svg>
+                    Admin Dashboard
+                  </h3>
+                  <p class="text-xs text-slate-400">Manage all users, projects, and tasks</p>
+                </div>
+                <a routerLink="/admin" class="px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium rounded-lg transition-colors cursor-pointer outline-none focus:ring-2 focus:ring-purple-500/50">
+                  Open Admin
+                </a>
+              </div>
+            }
           </div>
         </section>
       </div>

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -1,6 +1,14 @@
-import { Component, inject, signal, computed, effect , ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  inject,
+  signal,
+  computed,
+  effect,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
 import { AuthService } from '../../core/auth/auth.service';
 import { Firestore, doc, updateDoc } from '@angular/fire/firestore';
 
@@ -21,7 +29,7 @@ const AVATAR_COLORS = [
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RouterLink],
   templateUrl: './settings.component.html',
 })
 export class SettingsComponent {


### PR DESCRIPTION
## Description

This PR introduces an Admin Dashboard and RBAC features.

- Added `isAdmin()` helper to Firestore rules and granted admins global read/write access to users, projects, and tasks.
- Created `adminGuard` to protect the new `/admin` route.
- Implemented `UserService` to manage user roles and added global fetch methods to `ProjectService` and `TaskService`.
- Built an `AdminDashboardComponent` to allow admins to manage users, projects, and tasks.
- Added a link to the Admin Dashboard from the user settings page for users with the `admin` role.