### PR TITLE
feat(custom-fields): add edit and delete-from-library capabilities (Issue #20)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || github.event.action == 'assigned'))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || (github.event.action == 'assigned' && github.event.assignee.login == 'claude[bot]')))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    name: Claude Code
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || github.event.action == 'assigned'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.html
+++ b/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.html
@@ -197,9 +197,10 @@
           @for (opt of newFieldOptions(); track opt.id) {
           <div class="flex items-center gap-2">
             <input
+              #newColorInput
               type="color"
               [value]="opt.color"
-              (change)="opt.color = $any($event.target).value"
+              (change)="updateOptionColor(opt.id, newColorInput.value)"
               class="w-6 h-6 rounded cursor-pointer bg-transparent border-none p-0"
               title="Option Color"
             />
@@ -278,7 +279,8 @@
         >
         <input
           type="text"
-          [(ngModel)]="editFieldName"
+          [ngModel]="editFieldName()"
+          (ngModelChange)="editFieldName.set($event)"
           placeholder="Field name..."
           class="w-full bg-slate-900/50 border border-slate-700 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500 transition-colors placeholder:text-slate-600"
           [class.border-red-500]="isDuplicateEditName()"
@@ -299,7 +301,8 @@
         >
         <input
           type="text"
-          [(ngModel)]="editFieldCurrency"
+          [ngModel]="editFieldCurrency()"
+          (ngModelChange)="editFieldCurrency.set($event)"
           placeholder="$"
           class="w-24 bg-slate-900/50 border border-slate-700 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500 transition-colors placeholder:text-slate-600"
         />
@@ -316,9 +319,10 @@
           @for (opt of editFieldOptions(); track opt.id) {
           <div class="flex items-center gap-2">
             <input
+              #editColorInput
               type="color"
               [value]="opt.color"
-              (change)="opt.color = $any($event.target).value"
+              (change)="updateEditOptionColor(opt.id, editColorInput.value)"
               class="w-6 h-6 rounded cursor-pointer bg-transparent border-none p-0"
               title="Option Color"
             />

--- a/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.html
+++ b/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.html
@@ -26,13 +26,22 @@
         </div>
       </div>
 
-      <button
-        (click)="confirmUnlinkField(field)"
-        class="text-slate-500 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all p-2"
-        title="Unlink Field from Project"
-      >
-        <i class="fas fa-times"></i>
-      </button>
+      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-all">
+        <button
+          (click)="startEditing(field)"
+          class="text-slate-500 hover:text-amber-400 transition-colors p-2"
+          title="Edit Field"
+        >
+          <i class="fas fa-pencil-alt text-xs"></i>
+        </button>
+        <button
+          (click)="confirmUnlinkField(field)"
+          class="text-slate-500 hover:text-red-400 transition-colors p-2"
+          title="Unlink Field from Project"
+        >
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
     </div>
     } @empty {
     <div
@@ -238,6 +247,137 @@
         >
           Create & Add to Project
         </button>
+      </div>
+    </div>
+  </div>
+  }
+
+  <!-- Edit Field Mode ('edit') -->
+  @if (mode() === 'edit' && fieldToEdit()) {
+  <div
+    class="bg-slate-800 p-4 rounded-lg border border-amber-500/30 shadow-[0_0_15px_rgba(245,158,11,0.1)] relative overflow-hidden"
+  >
+    <div class="absolute top-0 left-0 w-1 h-full bg-amber-500"></div>
+
+    <div class="space-y-4">
+      <!-- Read-only type badge -->
+      <div class="flex items-center gap-2">
+        <div class="w-8 h-8 rounded bg-slate-700 flex items-center justify-center text-slate-400">
+          <i [class]="getFieldIcon(fieldToEdit()!.type)"></i>
+        </div>
+        <div>
+          <div class="text-xs text-slate-400 uppercase tracking-wider font-semibold">{{ fieldToEdit()!.type }}</div>
+          <div class="text-xs text-slate-600 italic">Type cannot be changed</div>
+        </div>
+      </div>
+
+      <!-- Field Name -->
+      <div>
+        <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1"
+          >Field Name</label
+        >
+        <input
+          type="text"
+          [(ngModel)]="editFieldName"
+          placeholder="Field name..."
+          class="w-full bg-slate-900/50 border border-slate-700 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500 transition-colors placeholder:text-slate-600"
+          [class.border-red-500]="isDuplicateEditName()"
+          (keyup.enter)="saveEdit()"
+        />
+        @if (isDuplicateEditName()) {
+        <p class="mt-1 text-xs text-red-400">
+          A custom field with this name already exists in your library.
+        </p>
+        }
+      </div>
+
+      <!-- Currency Symbol (currency type only) -->
+      @if (fieldToEdit()!.type === 'currency') {
+      <div>
+        <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1"
+          >Currency Symbol</label
+        >
+        <input
+          type="text"
+          [(ngModel)]="editFieldCurrency"
+          placeholder="$"
+          class="w-24 bg-slate-900/50 border border-slate-700 rounded px-3 py-2 text-sm text-white focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500 transition-colors placeholder:text-slate-600"
+        />
+      </div>
+      }
+
+      <!-- Options (dropdown / status / multi-select only) -->
+      @if (fieldToEdit()!.type === 'dropdown' || fieldToEdit()!.type === 'status' || fieldToEdit()!.type === 'multi-select') {
+      <div>
+        <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-1"
+          >Options</label
+        >
+        <div class="space-y-2">
+          @for (opt of editFieldOptions(); track opt.id) {
+          <div class="flex items-center gap-2">
+            <input
+              type="color"
+              [value]="opt.color"
+              (change)="opt.color = $any($event.target).value"
+              class="w-6 h-6 rounded cursor-pointer bg-transparent border-none p-0"
+              title="Option Color"
+            />
+            <span class="text-sm text-slate-300 flex-1">{{ opt.label }}</span>
+            <button (click)="removeEditOption(opt.id)" class="text-slate-500 hover:text-red-400">
+              <i class="fas fa-times"></i>
+            </button>
+          </div>
+          }
+          <div class="flex gap-2">
+            <input
+              #editOptInput
+              type="text"
+              placeholder="Add option..."
+              class="flex-1 bg-slate-900/50 border border-slate-700 rounded px-2 py-1 text-sm text-white focus:outline-none focus:border-amber-500 placeholder:text-slate-600"
+              (keyup.enter)="addEditOption(editOptInput.value); editOptInput.value = ''"
+            />
+            <button
+              (click)="addEditOption(editOptInput.value); editOptInput.value = ''"
+              class="px-2 py-1 bg-slate-700 hover:bg-slate-600 rounded text-slate-300"
+            >
+              <i class="fas fa-plus"></i>
+            </button>
+          </div>
+          @if (editFieldOptions().length === 0) {
+          <p class="mt-1 text-xs text-amber-400">
+            <i class="fas fa-exclamation-triangle mr-1"></i>At least one option is required.
+          </p>
+          }
+        </div>
+      </div>
+      }
+
+      <!-- Footer -->
+      <div class="flex items-center justify-between pt-2 border-t border-slate-700">
+        <button
+          (click)="deleteFromLibrary()"
+          [disabled]="saving()"
+          class="px-3 py-1.5 text-sm font-medium text-red-400 hover:text-white hover:bg-red-500/20 border border-red-500/30 rounded transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5"
+        >
+          <i class="fas fa-trash-alt text-xs"></i>
+          Delete from Library
+        </button>
+
+        <div class="flex gap-2">
+          <button
+            (click)="mode.set('list'); fieldToEdit.set(null)"
+            class="px-3 py-1.5 text-sm font-medium text-slate-400 hover:text-white transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            (click)="saveEdit()"
+            [disabled]="!canSaveEdit() || saving()"
+            class="px-3 py-1.5 text-sm font-medium bg-amber-500/10 text-amber-400 border border-amber-500/50 rounded hover:bg-amber-500 hover:text-black transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {{ saving() ? 'Saving...' : 'Save Changes' }}
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.ts
+++ b/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.ts
@@ -38,7 +38,7 @@ export class CustomFieldManagerComponent {
   globalFields = signal<CustomFieldDefinition[]>([]);
 
   // UI states
-  mode = signal<'list' | 'create' | 'link'>('list');
+  mode = signal<'list' | 'create' | 'link' | 'edit'>('list');
 
   newFieldType = signal<CustomFieldType>('text');
   newFieldName = '';
@@ -46,6 +46,13 @@ export class CustomFieldManagerComponent {
   newFieldCurrency = '$';
   fieldToDelete = signal<CustomFieldDefinition | null>(null);
   deleting = signal(false);
+
+  // Edit mode state
+  fieldToEdit = signal<CustomFieldDefinition | null>(null);
+  editFieldName = '';
+  editFieldOptions = signal<CustomFieldOption[]>([]);
+  editFieldCurrency = '$';
+  saving = signal(false);
 
   fieldTypes: { value: CustomFieldType; label: string; icon: string }[] = [
     { value: 'text', label: 'Text', icon: 'fas fa-align-left' },
@@ -99,6 +106,24 @@ export class CustomFieldManagerComponent {
     return true;
   });
 
+  isDuplicateEditName = computed(() => {
+    const field = this.fieldToEdit();
+    if (!field) return false;
+    const name = this.editFieldName.trim().toLowerCase();
+    if (!name) return false;
+    return this.globalFields().some((f) => f.name.toLowerCase() === name && f.id !== field.id);
+  });
+
+  canSaveEdit = computed(() => {
+    const field = this.fieldToEdit();
+    if (!field || !this.editFieldName.trim() || this.isDuplicateEditName()) return false;
+    const type = field.type;
+    if (type === 'dropdown' || type === 'status' || type === 'multi-select') {
+      return this.editFieldOptions().length > 0;
+    }
+    return true;
+  });
+
   getFieldIcon(type: CustomFieldType): string {
     return this.fieldTypes.find((t) => t.value === type)?.icon || 'fas fa-circle';
   }
@@ -108,6 +133,7 @@ export class CustomFieldManagerComponent {
     this.newFieldType.set('text');
     this.newFieldOptions.set([]);
     this.newFieldCurrency = '$';
+    this.fieldToEdit.set(null);
     this.mode.set('create');
   }
 
@@ -123,6 +149,80 @@ export class CustomFieldManagerComponent {
 
   removeOption(id: string) {
     this.newFieldOptions.update((opts) => opts.filter((o) => o.id !== id));
+  }
+
+  startEditing(field: CustomFieldDefinition) {
+    this.fieldToEdit.set(field);
+    this.editFieldName = field.name;
+    this.editFieldOptions.set(field.options ? [...field.options] : []);
+    this.editFieldCurrency = field.currencySymbol ?? '$';
+    this.mode.set('edit');
+  }
+
+  addEditOption(label: string) {
+    if (!label.trim()) return;
+    const opt: CustomFieldOption = {
+      id: crypto.randomUUID(),
+      label: label.trim(),
+      color: '#64748b',
+    };
+    this.editFieldOptions.update((opts) => [...opts, opt]);
+  }
+
+  removeEditOption(id: string) {
+    this.editFieldOptions.update((opts) => opts.filter((o) => o.id !== id));
+  }
+
+  async saveEdit() {
+    if (!this.canSaveEdit()) return;
+    const field = this.fieldToEdit();
+    if (!field) return;
+
+    this.saving.set(true);
+    try {
+      const data: Partial<Omit<CustomFieldDefinition, 'id' | 'userId' | 'createdAt' | 'updatedAt'>> = {
+        name: this.editFieldName.trim(),
+      };
+
+      const type = field.type;
+      if (type === 'dropdown' || type === 'status' || type === 'multi-select') {
+        data.options = this.editFieldOptions();
+      }
+      if (type === 'currency') {
+        data.currencySymbol = this.editFieldCurrency;
+      }
+
+      await this.customFieldService.updateCustomField(field.id, data);
+      this.mode.set('list');
+      this.fieldToEdit.set(null);
+    } catch (err) {
+      console.error('Failed to update field', err);
+      await this.dialogService.alert('Failed to update custom field. Please try again.', 'Error');
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  async deleteFromLibrary() {
+    const field = this.fieldToEdit();
+    if (!field) return;
+
+    const confirmed = await this.dialogService.confirm(
+      `Permanently delete "${field.name}" from your library? This cannot be undone. Existing task values for this field will no longer be accessible.`,
+    );
+    if (!confirmed) return;
+
+    this.saving.set(true);
+    try {
+      await this.customFieldService.deleteCustomField(field.id);
+      this.mode.set('list');
+      this.fieldToEdit.set(null);
+    } catch (err) {
+      console.error('Failed to delete field from library', err);
+      await this.dialogService.alert('Failed to delete custom field. Please try again.', 'Error');
+    } finally {
+      this.saving.set(false);
+    }
   }
 
   async createField() {

--- a/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.ts
+++ b/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.ts
@@ -49,9 +49,9 @@ export class CustomFieldManagerComponent {
 
   // Edit mode state
   fieldToEdit = signal<CustomFieldDefinition | null>(null);
-  editFieldName = '';
+  editFieldName = signal('');
   editFieldOptions = signal<CustomFieldOption[]>([]);
-  editFieldCurrency = '$';
+  editFieldCurrency = signal('$');
   saving = signal(false);
 
   fieldTypes: { value: CustomFieldType; label: string; icon: string }[] = [
@@ -109,14 +109,14 @@ export class CustomFieldManagerComponent {
   isDuplicateEditName = computed(() => {
     const field = this.fieldToEdit();
     if (!field) return false;
-    const name = this.editFieldName.trim().toLowerCase();
+    const name = this.editFieldName().trim().toLowerCase();
     if (!name) return false;
     return this.globalFields().some((f) => f.name.toLowerCase() === name && f.id !== field.id);
   });
 
   canSaveEdit = computed(() => {
     const field = this.fieldToEdit();
-    if (!field || !this.editFieldName.trim() || this.isDuplicateEditName()) return false;
+    if (!field || !this.editFieldName().trim() || this.isDuplicateEditName()) return false;
     const type = field.type;
     if (type === 'dropdown' || type === 'status' || type === 'multi-select') {
       return this.editFieldOptions().length > 0;
@@ -137,6 +137,10 @@ export class CustomFieldManagerComponent {
     this.mode.set('create');
   }
 
+  updateOptionColor(id: string, color: string): void {
+    this.newFieldOptions.update((opts) => opts.map((o) => (o.id === id ? { ...o, color } : o)));
+  }
+
   addOption(label: string) {
     if (!label.trim()) return;
     const opt: CustomFieldOption = {
@@ -151,12 +155,16 @@ export class CustomFieldManagerComponent {
     this.newFieldOptions.update((opts) => opts.filter((o) => o.id !== id));
   }
 
-  startEditing(field: CustomFieldDefinition) {
+  startEditing(field: CustomFieldDefinition): void {
     this.fieldToEdit.set(field);
-    this.editFieldName = field.name;
+    this.editFieldName.set(field.name);
     this.editFieldOptions.set(field.options ? [...field.options] : []);
-    this.editFieldCurrency = field.currencySymbol ?? '$';
+    this.editFieldCurrency.set(field.currencySymbol ?? '$');
     this.mode.set('edit');
+  }
+
+  updateEditOptionColor(id: string, color: string): void {
+    this.editFieldOptions.update((opts) => opts.map((o) => (o.id === id ? { ...o, color } : o)));
   }
 
   addEditOption(label: string) {
@@ -180,8 +188,9 @@ export class CustomFieldManagerComponent {
 
     this.saving.set(true);
     try {
-      const data: Partial<Omit<CustomFieldDefinition, 'id' | 'userId' | 'createdAt' | 'updatedAt'>> = {
-        name: this.editFieldName.trim(),
+      const data: Partial<Omit<CustomFieldDefinition,
+        'id' | 'userId' | 'createdAt' | 'updatedAt'>> = {
+        name: this.editFieldName().trim(),
       };
 
       const type = field.type;
@@ -189,7 +198,7 @@ export class CustomFieldManagerComponent {
         data.options = this.editFieldOptions();
       }
       if (type === 'currency') {
-        data.currencySymbol = this.editFieldCurrency;
+        data.currencySymbol = this.editFieldCurrency();
       }
 
       await this.customFieldService.updateCustomField(field.id, data);

--- a/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.ts
+++ b/src/app/features/projects/components/custom-field-manager/custom-field-manager.component.ts
@@ -202,6 +202,10 @@ export class CustomFieldManagerComponent {
       }
 
       await this.customFieldService.updateCustomField(field.id, data);
+      if (this.customFieldService.error()) {
+        await this.dialogService.alert('Failed to update custom field. Please try again.', 'Error');
+        return;
+      }
       this.mode.set('list');
       this.fieldToEdit.set(null);
     } catch (err) {
@@ -216,14 +220,19 @@ export class CustomFieldManagerComponent {
     const field = this.fieldToEdit();
     if (!field) return;
 
-    const confirmed = await this.dialogService.confirm(
-      `Permanently delete "${field.name}" from your library? This cannot be undone. Existing task values for this field will no longer be accessible.`,
-    );
+    const msg =
+      `Permanently delete "${field.name}" from your library? ` +
+      `This cannot be undone. Existing task values for this field will no longer be accessible.`;
+    const confirmed = await this.dialogService.confirm(msg);
     if (!confirmed) return;
 
     this.saving.set(true);
     try {
       await this.customFieldService.deleteCustomField(field.id);
+      if (this.customFieldService.error()) {
+        await this.dialogService.alert('Failed to delete custom field. Please try again.', 'Error');
+        return;
+      }
       this.mode.set('list');
       this.fieldToEdit.set(null);
     } catch (err) {


### PR DESCRIPTION
## Summary

Closes #20 (partial — builds on top of PR #106 which delivered the core custom fields infrastructure).

The previous implementation added `updateCustomField()` and `deleteCustomField()` to `CustomFieldService`, but neither method was ever called from the UI. Users could create, link, and unlink fields but had no way to rename them, update their options, or permanently remove them from their library. This PR wires those two service methods to a new edit mode in `CustomFieldManagerComponent`.

### Changes

- **Edit mode UI** — Each field row in the Custom Fields settings panel now shows a pencil icon on hover (alongside the existing unlink button). Clicking it opens an amber-accented edit panel inline.
- **Edit panel features**:
  - Read-only type badge (type cannot be changed — doing so would silently corrupt stored `customFieldValues` on tasks)
  - Editable name field with real-time duplicate-name detection
  - Currency symbol input (shown only for `currency` type)
  - Option add/remove list (shown only for `dropdown`, `status`, `multi-select` types)
  - "Delete from Library" button (red, left) with a confirmation dialog
  - Cancel / Save Changes buttons with loading state
- **`CustomFieldManagerComponent` TypeScript**:
  - Mode signal extended to `'list' | 'create' | 'link' | 'edit'`
  - `fieldToEdit`, `editFieldName`, `editFieldOptions`, `editFieldCurrency`, `saving` state signals
  - `isDuplicateEditName` and `canSaveEdit` computed guards
  - `startEditing()`, `addEditOption()`, `removeEditOption()`, `saveEdit()`, `deleteFromLibrary()` methods
- **Claude Code GitHub Actions workflow** — Added `.github/workflows/claude.yml` so `@claude` mentions in issues and PR comments trigger Claude Code automatically using the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret.

## Test plan

- [ ] Navigate to a project's Settings → Custom Fields section
- [ ] Create a `dropdown` field named "Priority" with options A, B, C
- [ ] Click the pencil icon — edit panel opens with amber accent, type shown as read-only
- [ ] Rename the field and add a new option → click "Save Changes" → list resumes with updated data
- [ ] Open a task in the project → `TaskDetailModal` reflects the renamed field and updated options
- [ ] Return to Settings → click pencil → click "Delete from Library" → confirm dialog → field disappears
- [ ] Open a task → the deleted field is no longer rendered
- [ ] Verify the `users/{uid}/customFields/{fieldId}` document is removed in Firebase Console

https://claude.ai/code/session_01RRZjtyxV7Gm4FciJXpWdcv