### PR TITLE
Add granular permission management for admin dashboard

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -47,11 +47,14 @@ service cloud.firestore {
       // Allow reading own profile; admins/super-admins can read any profile.
       allow read: if request.auth.uid == userId || isAdmin() || isSuperAdmin();
 
-      // Prevent privilege escalation on self-create: a user creating their own
-      // profile may not mark themselves admin nor super-admin.
-      allow create: if isAdmin() || isSuperAdmin() || (
-        request.auth.uid == userId &&
-        request.resource.data.get('role', 'user') != 'admin' &&
+      // Prevent privilege escalation on create: only super-admins may create a
+      // user profile with `isSuperAdmin: true`. Regular admins and self-signups
+      // must have `isSuperAdmin` = false on the new document.
+      allow create: if isSuperAdmin() || (
+        (
+          isAdmin() ||
+          (request.auth.uid == userId && request.resource.data.get('role', 'user') != 'admin')
+        ) &&
         request.resource.data.get(['permissions', 'isSuperAdmin'], false) == false
       );
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -6,30 +6,75 @@ service cloud.firestore {
       return request.auth != null;
     }
 
+    // Hard-coded super-admin email. Matches SUPER_ADMIN_EMAIL in src/app/core/constants.ts.
+    function isSuperAdminEmail() {
+      return isAuthenticated() && request.auth.token.email == 'bertin.kenol@omniflexfitness.com';
+    }
+
+    // Load the current user's profile document once per request.
+    function currentUser() {
+      return get(/databases/$(database)/documents/users/$(request.auth.uid)).data;
+    }
+
     // Helper to check if user is an admin
     function isAdmin() {
-      return isAuthenticated() && 
-        get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == 'admin';
+      return isAuthenticated() && currentUser().role == 'admin';
+    }
+
+    // Super-admins are either the designated email or have permissions.isSuperAdmin == true.
+    function isSuperAdmin() {
+      return isSuperAdminEmail() || (
+        isAuthenticated() && currentUser().get(['permissions', 'isSuperAdmin'], false) == true
+      );
+    }
+
+    // Check a named permission on the signed-in user's profile. Defaults to `true`
+    // when the field is missing so that users created before this feature was
+    // deployed are not locked out of basic functionality.
+    function hasPermission(key) {
+      return isAuthenticated() && currentUser().get(['permissions', key], true) == true;
     }
 
     // Helper to check if user is owner or member of the resource
     function isMember(resourceData) {
       return isAuthenticated() && (
-        request.auth.uid == resourceData.ownerId || 
+        request.auth.uid == resourceData.ownerId ||
         request.auth.uid in resourceData.memberIds
       );
     }
-    
+
     match /users/{userId} {
-      // Allow reading own profile only
-      allow read: if request.auth.uid == userId || isAdmin();
-      
-      // Prevent privilege escalation: only admins can set or update the role to 'admin'
-      allow create: if isAdmin() || (request.auth.uid == userId && request.resource.data.get('role', 'user') != 'admin');
-      allow update: if isAdmin() || (request.auth.uid == userId && request.resource.data.get('role', '') == resource.data.get('role', ''));
-      allow delete: if request.auth.uid == userId || isAdmin();
+      // Allow reading own profile; admins/super-admins can read any profile.
+      allow read: if request.auth.uid == userId || isAdmin() || isSuperAdmin();
+
+      // Prevent privilege escalation on self-create: a user creating their own
+      // profile may not mark themselves admin nor super-admin.
+      allow create: if isAdmin() || isSuperAdmin() || (
+        request.auth.uid == userId &&
+        request.resource.data.get('role', 'user') != 'admin' &&
+        request.resource.data.get(['permissions', 'isSuperAdmin'], false) == false
+      );
+
+      // Users may update their own non-privileged fields (display name, last
+      // login, etc.). They may not change their role or any field of their
+      // permissions map — only admins/super-admins can do that.
+      //
+      // Admins can update anything except the `isSuperAdmin` flag, which is
+      // reserved for super-admins.
+      allow update: if isSuperAdmin() || (
+        isAdmin() &&
+        request.resource.data.get(['permissions', 'isSuperAdmin'], false) ==
+          resource.data.get(['permissions', 'isSuperAdmin'], false)
+      ) || (
+        request.auth.uid == userId &&
+        request.resource.data.get('role', '') == resource.data.get('role', '') &&
+        request.resource.data.get('permissions', null) ==
+          resource.data.get('permissions', null)
+      );
+
+      allow delete: if request.auth.uid == userId || isAdmin() || isSuperAdmin();
     }
-    
+
     // User's personal contacts cache - scoped to individual users
     match /users/{userId}/contacts/{contactId} {
       allow read, write: if request.auth.uid == userId;
@@ -49,38 +94,47 @@ service cloud.firestore {
     match /users/{userId}/customFields/{fieldId} {
       allow read, write: if request.auth.uid == userId;
     }
-    
+
     match /projects/{projectId} {
-      allow create: if isAuthenticated();
-      allow read: if isMember(resource.data) || isAdmin();
-      allow update: if isMember(resource.data) || isAdmin();
-      allow delete: if (isAuthenticated() && request.auth.uid == resource.data.ownerId) || isAdmin();
+      allow create: if isAuthenticated() && hasPermission('canCreateProjects');
+      allow read: if isMember(resource.data) || isAdmin() || isSuperAdmin();
+      allow update: if isMember(resource.data) || isAdmin() || isSuperAdmin();
+      allow delete: if isAdmin() || isSuperAdmin() || (
+        isAuthenticated() &&
+        request.auth.uid == resource.data.ownerId &&
+        hasPermission('canDeleteProjects')
+      );
     }
-    
+
     match /tasks/{taskId} {
       // Helper: Check if user is a member of the task's project (for existing tasks)
       function isProjectMember() {
         let project = get(/databases/$(database)/documents/projects/$(resource.data.projectId));
         return project != null && (
-          request.auth.uid == project.data.ownerId || 
-          request.auth.uid in project.data.memberIds
-        );
-      }
-      
-      // Helper: Check if user can create a task in the specified project (for new tasks)
-      function canCreateInProject() {
-        let project = get(/databases/$(database)/documents/projects/$(request.resource.data.projectId));
-        return project != null && (
-          request.auth.uid == project.data.ownerId || 
+          request.auth.uid == project.data.ownerId ||
           request.auth.uid in project.data.memberIds
         );
       }
 
-      allow create: if (isAuthenticated() && canCreateInProject()) || isAdmin();
-      allow read: if (isAuthenticated() && isProjectMember()) || isAdmin();
-      allow update, delete: if (isAuthenticated() && isProjectMember()) || isAdmin();
+      // Helper: Check if user can create a task in the specified project (for new tasks)
+      function canCreateInProject() {
+        let project = get(/databases/$(database)/documents/projects/$(request.resource.data.projectId));
+        return project != null && (
+          request.auth.uid == project.data.ownerId ||
+          request.auth.uid in project.data.memberIds
+        );
+      }
+
+      allow create: if isAdmin() || isSuperAdmin() || (
+        isAuthenticated() && canCreateInProject() && hasPermission('canCreateTasks')
+      );
+      allow read: if (isAuthenticated() && isProjectMember()) || isAdmin() || isSuperAdmin();
+      allow update: if (isAuthenticated() && isProjectMember()) || isAdmin() || isSuperAdmin();
+      allow delete: if isAdmin() || isSuperAdmin() || (
+        isAuthenticated() && isProjectMember() && hasPermission('canDeleteTasks')
+      );
     }
-    
+
     // Notifications - written by Cloud Functions, readable by recipient
     match /notifications/{notificationId} {
       // Cloud Functions uses admin SDK (bypasses rules)

--- a/firestore.rules
+++ b/firestore.rules
@@ -148,6 +148,37 @@ service cloud.firestore {
       );
     }
 
+    // Invites - created by super-admins, auto-applied on first sign-in of the
+    // invited email. An invitee must be able to read their own pending invite
+    // (by email match) and mark it accepted.
+    match /invites/{inviteId} {
+      // Super-admins and invitees can read. An invitee is an authenticated
+      // user whose token email matches the invite's email.
+      allow read: if isSuperAdmin() || isAdmin() || (
+        isAuthenticated() && request.auth.token.email == resource.data.email
+      );
+
+      // Only super-admins create or revoke invites.
+      allow create: if isSuperAdmin() &&
+        request.resource.data.status == 'pending' &&
+        request.resource.data.invitedByUid == request.auth.uid;
+
+      // Super-admins can update freely. Invitees can only transition a pending
+      // invite addressed to them into 'accepted' (e.g., on sign-in).
+      allow update: if isSuperAdmin() || (
+        isAuthenticated() &&
+        request.auth.token.email == resource.data.email &&
+        resource.data.status == 'pending' &&
+        request.resource.data.status == 'accepted' &&
+        request.resource.data.acceptedByUid == request.auth.uid &&
+        request.resource.data.email == resource.data.email &&
+        request.resource.data.role == resource.data.role &&
+        request.resource.data.permissions == resource.data.permissions
+      );
+
+      allow delete: if isSuperAdmin();
+    }
+
     // Notifications - written by Cloud Functions, readable by recipient
     match /notifications/{notificationId} {
       // Cloud Functions uses admin SDK (bypasses rules)

--- a/firestore.rules
+++ b/firestore.rules
@@ -99,9 +99,19 @@ service cloud.firestore {
     }
 
     match /projects/{projectId} {
-      allow create: if isAuthenticated() && hasPermission('canCreateProjects');
+      allow create: if isAdmin() || isSuperAdmin() || (
+        isAuthenticated() && hasPermission('canCreateProjects')
+      );
       allow read: if isMember(resource.data) || isAdmin() || isSuperAdmin();
-      allow update: if isMember(resource.data) || isAdmin() || isSuperAdmin();
+      // Members can update project fields freely, but changing `memberIds`
+      // additionally requires the `canInviteMembers` permission so the invite
+      // flag is actually enforced. Admins/super-admins bypass this.
+      allow update: if isAdmin() || isSuperAdmin() || (
+        isMember(resource.data) && (
+          !request.resource.data.diff(resource.data).affectedKeys().hasAny(['memberIds']) ||
+          hasPermission('canInviteMembers')
+        )
+      );
       allow delete: if isAdmin() || isSuperAdmin() || (
         isAuthenticated() &&
         request.auth.uid == resource.data.ownerId &&

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1393,3 +1393,63 @@ Only return the JSON object, no other text or markdown formatting around the JSO
     );
   }
 });
+
+// ---------------------------------------------------------------------------
+// Super-admin enforcement
+// ---------------------------------------------------------------------------
+
+/**
+ * Designated super-admin email. Must match SUPER_ADMIN_EMAIL in
+ * src/app/core/constants.ts. The Cloud Function below guarantees that whenever
+ * this user's document is created or modified it is forced back into an
+ * admin + isSuperAdmin state — so bertin cannot be accidentally demoted and
+ * is promoted immediately on first sign-in regardless of any client races.
+ */
+const SUPER_ADMIN_EMAIL = 'bertin.kenol@omniflexfitness.com';
+
+const SUPER_ADMIN_PERMISSIONS = {
+  canCreateProjects: true,
+  canCreateTasks: true,
+  canDeleteProjects: true,
+  canDeleteTasks: true,
+  canInviteMembers: true,
+  isSuperAdmin: true,
+};
+
+export const enforceSuperAdmin = onDocumentWritten(
+  {
+    document: 'users/{uid}',
+    memory: '256MiB',
+  },
+  async (event) => {
+    const after = event.data?.after?.data();
+    if (!after) return; // user deleted — nothing to do
+
+    const email: string | undefined = after.email;
+    if (email?.toLowerCase() !== SUPER_ADMIN_EMAIL.toLowerCase()) return;
+
+    const needsRoleFix = after.role !== 'admin';
+    const currentPerms = after.permissions || {};
+    const needsPermsFix = Object.keys(SUPER_ADMIN_PERMISSIONS).some(
+      (k) =>
+        (currentPerms as Record<string, boolean>)[k] !==
+        (SUPER_ADMIN_PERMISSIONS as Record<string, boolean>)[k],
+    );
+
+    if (!needsRoleFix && !needsPermsFix) return;
+
+    console.log(
+      `enforceSuperAdmin: reasserting admin/super-admin on ${email} ` +
+        `(roleFix=${needsRoleFix}, permsFix=${needsPermsFix})`,
+    );
+    await db
+      .doc(`users/${event.params.uid}`)
+      .set(
+        {
+          role: 'admin',
+          permissions: SUPER_ADMIN_PERMISSIONS,
+        },
+        { merge: true },
+      );
+  },
+);

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -246,7 +246,9 @@ export class AuthService {
         isSuperAdmin: true,
       };
       data.permissions = superPerms;
-    } else if (!existingData) {
+    } else if (!existingData || !existingData.permissions) {
+      // Seed defaults for brand-new users and for returning users whose
+      // profiles predate this feature (missing permissions field).
       data.permissions = { ...DEFAULT_USER_PERMISSIONS };
     }
 

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -9,7 +9,8 @@ import {
 } from '@angular/fire/auth';
 import { Firestore, doc, setDoc, getDoc, updateDoc } from '@angular/fire/firestore';
 import { Router } from '@angular/router';
-import { UserProfile } from '../models/user.model';
+import { DEFAULT_USER_PERMISSIONS, UserPermissions, UserProfile } from '../models/user.model';
+import { SUPER_ADMIN_EMAIL } from '../constants';
 import { DialogService } from '../services/dialog.service';
 import { switchMap, map } from 'rxjs/operators';
 import { of, from, Observable } from 'rxjs';
@@ -211,16 +212,43 @@ export class AuthService {
     // Use pop() to get the last part after splitting by '@' to handle edge cases
     const domain = user.email?.split('@').pop() || 'unknown';
 
-    const data: UserProfile = {
+    const isDesignatedSuperAdmin =
+      user.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase();
+
+    // Ensure the designated super-admin is always promoted to admin + super-admin
+    // on sign-in, regardless of their prior stored values.
+    const role: 'admin' | 'user' = isDesignatedSuperAdmin
+      ? 'admin'
+      : existingData?.role || 'user';
+
+    // Permissions map: seed defaults only on first creation (or force-refresh for
+    // the designated super-admin). For returning users we leave their stored
+    // permissions untouched so that admin-assigned rights are preserved and so
+    // that the Firestore update rule does not see a permissions-field change.
+    const data: Partial<UserProfile> & { uid: string; email: string } = {
       uid: user.uid,
       email: user.email!,
       displayName: user.displayName || 'User',
       photoURL: user.photoURL || '',
       domain,
-      role: existingData?.role || 'user', // Default to user, preserve if exists
+      role,
       createdAt: existingData?.createdAt || new Date(),
       lastLoginAt: new Date(),
     };
+
+    if (isDesignatedSuperAdmin) {
+      const superPerms: UserPermissions = {
+        canCreateProjects: true,
+        canCreateTasks: true,
+        canDeleteProjects: true,
+        canDeleteTasks: true,
+        canInviteMembers: true,
+        isSuperAdmin: true,
+      };
+      data.permissions = superPerms;
+    } else if (!existingData) {
+      data.permissions = { ...DEFAULT_USER_PERMISSIONS };
+    }
 
     // Create or Update
     return setDoc(userRef, data, { merge: true });

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -7,7 +7,17 @@ import {
   User,
   OAuthCredential,
 } from '@angular/fire/auth';
-import { Firestore, doc, setDoc, getDoc, updateDoc } from '@angular/fire/firestore';
+import {
+  Firestore,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from '@angular/fire/firestore';
 import { Router } from '@angular/router';
 import { DEFAULT_USER_PERMISSIONS, UserPermissions, UserProfile } from '../models/user.model';
 import { SUPER_ADMIN_EMAIL } from '../constants';
@@ -215,11 +225,18 @@ export class AuthService {
     const isDesignatedSuperAdmin =
       user.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase();
 
+    // Look up a pending invite for this email (if any) so that the very first
+    // sign-in applies the role + permission grants that the super-admin
+    // pre-configured. Errors here are non-fatal — we don't want a transient
+    // invite-lookup failure to block sign-in.
+    const pendingInvite = await this.findPendingInvite(user.email);
+
     // Ensure the designated super-admin is always promoted to admin + super-admin
-    // on sign-in, regardless of their prior stored values.
+    // on sign-in, regardless of their prior stored values. Otherwise use the
+    // invite's role (if any) > existing role > 'user'.
     const role: 'admin' | 'user' = isDesignatedSuperAdmin
       ? 'admin'
-      : existingData?.role || 'user';
+      : pendingInvite?.role || existingData?.role || 'user';
 
     // Permissions map: seed defaults only on first creation (or force-refresh for
     // the designated super-admin). For returning users we leave their stored
@@ -246,14 +263,54 @@ export class AuthService {
         isSuperAdmin: true,
       };
       data.permissions = superPerms;
+    } else if (pendingInvite) {
+      // Applying an invite: merge its permissions on top of whatever existed
+      // (or defaults for brand-new users).
+      const base = existingData?.permissions ?? { ...DEFAULT_USER_PERMISSIONS };
+      data.permissions = { ...DEFAULT_USER_PERMISSIONS, ...base, ...pendingInvite.permissions };
     } else if (!existingData || !existingData.permissions) {
       // Seed defaults for brand-new users and for returning users whose
       // profiles predate this feature (missing permissions field).
       data.permissions = { ...DEFAULT_USER_PERMISSIONS };
     }
 
-    // Create or Update
-    return setDoc(userRef, data, { merge: true });
+    // Create or Update the user profile
+    await setDoc(userRef, data, { merge: true });
+
+    // Mark the invite as accepted — best-effort, non-fatal if it fails.
+    if (pendingInvite?.id) {
+      updateDoc(doc(this.firestore, `invites/${pendingInvite.id}`), {
+        status: 'accepted',
+        acceptedAt: new Date(),
+        acceptedByUid: user.uid,
+      }).catch((err) => console.warn('Failed to mark invite accepted:', err));
+    }
+  }
+
+  /**
+   * Best-effort lookup of a pending invite for the given email. Returns null
+   * if not found or if the query fails (e.g., rules prevented the read).
+   */
+  private async findPendingInvite(
+    email: string | null,
+  ): Promise<{ id: string; role: 'admin' | 'user'; permissions: UserPermissions } | null> {
+    if (!email) return null;
+    try {
+      const invitesCol = collection(this.firestore, 'invites');
+      const q = query(
+        invitesCol,
+        where('email', '==', email.toLowerCase()),
+        where('status', '==', 'pending'),
+      );
+      const snap = await getDocs(q);
+      if (snap.empty) return null;
+      const first = snap.docs[0];
+      const data = first.data() as { role: 'admin' | 'user'; permissions: UserPermissions };
+      return { id: first.id, role: data.role, permissions: data.permissions };
+    } catch (err) {
+      console.warn('Invite lookup failed (continuing without invite):', err);
+      return null;
+    }
   }
 
   private getUserProfile(uid: string): Observable<UserProfile | null> {

--- a/src/app/core/constants.ts
+++ b/src/app/core/constants.ts
@@ -6,3 +6,16 @@
  * Default version number shown when version.json cannot be loaded
  */
 export const DEFAULT_VERSION = '0.0.01';
+
+/**
+ * Email of the designated super-admin. This user has implicit access to the
+ * admin dashboard and can grant or revoke permissions for any other user
+ * (and cannot be demoted through the UI).
+ */
+export const SUPER_ADMIN_EMAIL = 'bertin.kenol@omniflexfitness.com';
+
+/**
+ * Primary organization domain. Users with this email domain are highlighted
+ * in the permissions management UI.
+ */
+export const ORG_DOMAIN = 'omniflexfitness.com';

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -5,8 +5,9 @@ import { map, take, tap } from 'rxjs/operators';
 import { SUPER_ADMIN_EMAIL } from '../constants';
 
 /**
- * Guard for the admin dashboard. Admins (role === 'admin') and the
- * designated super-admin can access it.
+ * Guard for the admin dashboard. Admins (role === 'admin'), the designated
+ * super-admin email, and any user granted `permissions.isSuperAdmin` can
+ * access it.
  */
 export const adminGuard: CanActivateFn = (route, state) => {
   const auth = inject(AuthService);
@@ -14,12 +15,12 @@ export const adminGuard: CanActivateFn = (route, state) => {
 
   return auth.userProfile$.pipe(
     take(1),
-    map(
-      (profile) =>
-        !!profile &&
-        (profile.role === 'admin' ||
-          profile.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()),
-    ),
+    map((profile) => {
+      if (!profile) return false;
+      if (profile.role === 'admin') return true;
+      if (profile.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) return true;
+      return profile.permissions?.isSuperAdmin === true;
+    }),
     tap((allowed) => {
       if (!allowed) {
         router.navigate(['/']);

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -2,16 +2,49 @@ import { inject } from '@angular/core';
 import { Router, CanActivateFn } from '@angular/router';
 import { AuthService } from '../auth/auth.service';
 import { map, take, tap } from 'rxjs/operators';
+import { SUPER_ADMIN_EMAIL } from '../constants';
 
+/**
+ * Guard for the admin dashboard. Admins (role === 'admin') and the
+ * designated super-admin can access it.
+ */
 export const adminGuard: CanActivateFn = (route, state) => {
   const auth = inject(AuthService);
   const router = inject(Router);
 
   return auth.userProfile$.pipe(
     take(1),
-    map((profile) => !!profile && profile.role === 'admin'),
-    tap((isAdmin) => {
-      if (!isAdmin) {
+    map(
+      (profile) =>
+        !!profile &&
+        (profile.role === 'admin' ||
+          profile.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()),
+    ),
+    tap((allowed) => {
+      if (!allowed) {
+        router.navigate(['/']);
+      }
+    }),
+  );
+};
+
+/**
+ * Guard for super-admin-only areas (permissions management). Restricted
+ * to the designated super-admin email and users flagged `isSuperAdmin`.
+ */
+export const superAdminGuard: CanActivateFn = (route, state) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  return auth.userProfile$.pipe(
+    take(1),
+    map((profile) => {
+      if (!profile) return false;
+      if (profile.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) return true;
+      return profile.permissions?.isSuperAdmin === true;
+    }),
+    tap((allowed) => {
+      if (!allowed) {
         router.navigate(['/']);
       }
     }),

--- a/src/app/core/layout/navbar.component.html
+++ b/src/app/core/layout/navbar.component.html
@@ -194,6 +194,29 @@
               }}</span>
             </div>
 
+            <!-- Admin portal link (admins + super-admins) -->
+            @if (canSeeAdminLink()) {
+              <a
+                routerLink="/admin"
+                title="Admin Portal"
+                class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-purple-500/40 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 hover:text-purple-200 transition-colors text-xs font-semibold uppercase tracking-wider"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-4 w-4"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+                Admin
+              </a>
+            }
+
             <!-- Settings link -->
             <a
               routerLink="/settings"

--- a/src/app/core/layout/navbar.component.ts
+++ b/src/app/core/layout/navbar.component.ts
@@ -1,7 +1,9 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from '../auth/auth.service';
+import { PermissionsService } from '../services/permissions.service';
+import { SUPER_ADMIN_EMAIL } from '../constants';
 
 @Component({
   selector: 'app-navbar',
@@ -13,4 +15,17 @@ import { AuthService } from '../auth/auth.service';
 })
 export class NavbarComponent {
   readonly auth = inject(AuthService);
+  readonly permissions = inject(PermissionsService);
+
+  /**
+   * Admins, the designated super-admin email, and any user flagged
+   * `isSuperAdmin` see the Admin portal link in the top bar.
+   */
+  readonly canSeeAdminLink = computed(() => {
+    const user = this.auth.currentUserSig();
+    if (!user) return false;
+    if (user.role === 'admin') return true;
+    if (user.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) return true;
+    return this.permissions.currentPermissions().isSuperAdmin;
+  });
 }

--- a/src/app/core/models/invite.model.ts
+++ b/src/app/core/models/invite.model.ts
@@ -1,0 +1,23 @@
+import { UserPermissions } from './user.model';
+
+/**
+ * An invite lets a super-admin pre-configure the role and permissions that
+ * will be applied to a user the first time they sign in with the invited
+ * email. Matching happens in `AuthService.updateUserData` — we do not
+ * rely on a token-based acceptance link because sign-in is already gated
+ * by Google OAuth, so possession of the email is proof enough.
+ */
+export interface Invite {
+  id?: string;
+  /** Normalized (lower-cased, trimmed) email address. */
+  email: string;
+  role: 'admin' | 'user';
+  permissions: UserPermissions;
+  invitedByUid: string;
+  invitedByEmail: string;
+  invitedAt: Date;
+  status: 'pending' | 'accepted' | 'revoked';
+  acceptedAt?: Date | null;
+  acceptedByUid?: string | null;
+  note?: string;
+}

--- a/src/app/core/models/user.model.ts
+++ b/src/app/core/models/user.model.ts
@@ -1,3 +1,37 @@
+/**
+ * Granular feature-level permissions that can be toggled per user by a
+ * super-admin. When a field is undefined on a user document, the
+ * corresponding DEFAULT_USER_PERMISSIONS value is used.
+ */
+export interface UserPermissions {
+  canCreateProjects: boolean;
+  canCreateTasks: boolean;
+  canDeleteProjects: boolean;
+  canDeleteTasks: boolean;
+  canInviteMembers: boolean;
+  /**
+   * Grants access to the admin dashboard permissions management UI and the
+   * ability to modify other users' permissions / roles.
+   */
+  isSuperAdmin: boolean;
+}
+
+/**
+ * Defaults applied to any authenticated user whose profile does not yet
+ * define a permissions map. These are intentionally permissive for the
+ * basic "do work" actions so that existing users are not locked out after
+ * this feature is deployed — permissions can then be tightened per-user
+ * via the admin dashboard.
+ */
+export const DEFAULT_USER_PERMISSIONS: UserPermissions = {
+  canCreateProjects: true,
+  canCreateTasks: true,
+  canDeleteProjects: true,
+  canDeleteTasks: true,
+  canInviteMembers: true,
+  isSuperAdmin: false,
+};
+
 export interface UserProfile {
   uid: string;
   email: string;
@@ -7,6 +41,7 @@ export interface UserProfile {
   avatarColor?: string; // Custom color for placeholder avatars
   domain: string;
   role: 'admin' | 'user';
+  permissions?: UserPermissions;
   createdAt: Date;
   lastLoginAt: Date;
 
@@ -14,4 +49,12 @@ export interface UserProfile {
   hasGoogleTasksOfflineAccess?: boolean;
   googleTasksOfflineAccessGrantedAt?: Date;
   googleTasksRefreshToken?: string | null; // Encrypted refresh token for Cloud Functions
+}
+
+/**
+ * Resolve the effective permissions for a user, applying defaults for any
+ * unset fields. Accepts null/undefined and returns a fully populated map.
+ */
+export function resolvePermissions(user?: UserProfile | null): UserPermissions {
+  return { ...DEFAULT_USER_PERMISSIONS, ...(user?.permissions ?? {}) };
 }

--- a/src/app/core/services/invites.service.ts
+++ b/src/app/core/services/invites.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, Injector, inject, runInInjectionContext, signal } from '@angular/core';
+import {
+  Firestore,
+  addDoc,
+  collection,
+  collectionData,
+  doc,
+  getDocs,
+  query,
+  updateDoc,
+  where,
+} from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+
+import { AuthService } from '../auth/auth.service';
+import { Invite } from '../models/invite.model';
+import {
+  DEFAULT_USER_PERMISSIONS,
+  UserPermissions,
+  UserProfile,
+  resolvePermissions,
+} from '../models/user.model';
+
+/**
+ * CRUD + acceptance helpers for the `invites` collection. Invite creation is
+ * intentionally restricted to super-admins by Firestore rules — this service
+ * is just a typed wrapper around those writes.
+ */
+@Injectable({ providedIn: 'root' })
+export class InvitesService {
+  private firestore = inject(Firestore);
+  private auth = inject(AuthService);
+  private injector = inject(Injector);
+  private invitesCollection = collection(this.firestore, 'invites');
+
+  loading = signal(false);
+  error = signal<string | null>(null);
+
+  private normalizeEmail(email: string): string {
+    return email.trim().toLowerCase();
+  }
+
+  /** Stream of all invites. Readable by admins/super-admins. */
+  getAllInvites(): Observable<Invite[]> {
+    const q = query(this.invitesCollection);
+    return runInInjectionContext(this.injector, () => {
+      return collectionData(q, { idField: 'id' }) as Observable<Invite[]>;
+    });
+  }
+
+  /** Create a new pending invite for the given email. */
+  async createInvite(
+    email: string,
+    role: 'admin' | 'user',
+    permissions: Partial<UserPermissions>,
+    note?: string,
+  ): Promise<string> {
+    const inviter = this.auth.currentUserSig();
+    if (!inviter) throw new Error('Not authenticated');
+
+    const normalizedEmail = this.normalizeEmail(email);
+    if (!normalizedEmail || !normalizedEmail.includes('@')) {
+      throw new Error('A valid email is required.');
+    }
+
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const merged: UserPermissions = { ...DEFAULT_USER_PERMISSIONS, ...permissions };
+      const invite: Omit<Invite, 'id'> = {
+        email: normalizedEmail,
+        role,
+        permissions: merged,
+        invitedByUid: inviter.uid,
+        invitedByEmail: inviter.email,
+        invitedAt: new Date(),
+        status: 'pending',
+        acceptedAt: null,
+        acceptedByUid: null,
+        ...(note ? { note } : {}),
+      };
+
+      const ref = await addDoc(this.invitesCollection, invite);
+      return ref.id;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create invite';
+      this.error.set(message);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async revokeInvite(id: string): Promise<void> {
+    await updateDoc(doc(this.firestore, `invites/${id}`), {
+      status: 'revoked',
+    });
+  }
+
+  /**
+   * Look up a pending invite by email. Returns the first pending match, or
+   * null if none exists. Used at sign-in time to seed a new user's role and
+   * permissions from the invite.
+   */
+  async findPendingInviteByEmail(email: string): Promise<Invite | null> {
+    const normalized = this.normalizeEmail(email);
+    if (!normalized) return null;
+
+    const q = query(
+      this.invitesCollection,
+      where('email', '==', normalized),
+      where('status', '==', 'pending'),
+    );
+    const snap = await getDocs(q);
+    if (snap.empty) return null;
+    const docSnap = snap.docs[0];
+    return { id: docSnap.id, ...(docSnap.data() as Omit<Invite, 'id'>) };
+  }
+
+  /** Mark an invite as accepted by the given user. */
+  async markAccepted(inviteId: string, userUid: string): Promise<void> {
+    await updateDoc(doc(this.firestore, `invites/${inviteId}`), {
+      status: 'accepted',
+      acceptedAt: new Date(),
+      acceptedByUid: userUid,
+    });
+  }
+
+  /**
+   * Resolve the effective UserPermissions map that an invite should apply
+   * when an invited user first signs in. Exposed so that AuthService can
+   * compose the user profile without duplicating merge logic.
+   */
+  permissionsFromInvite(invite: Invite, existing?: UserProfile | null): UserPermissions {
+    const base = resolvePermissions(existing);
+    return { ...base, ...invite.permissions };
+  }
+}

--- a/src/app/core/services/permissions.service.ts
+++ b/src/app/core/services/permissions.service.ts
@@ -71,8 +71,8 @@ export class PermissionsService {
   requirePermission(key: keyof UserPermissions): void {
     if (!this.currentPermissions()[key]) {
       throw new Error(
-        `You do not have permission to perform this action (missing ${key}). ` +
-          `Please contact an administrator.`,
+        'You do not have permission to perform this action. ' +
+          'Please contact an administrator.',
       );
     }
   }

--- a/src/app/core/services/permissions.service.ts
+++ b/src/app/core/services/permissions.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { AuthService } from '../auth/auth.service';
+import {
+  DEFAULT_USER_PERMISSIONS,
+  UserPermissions,
+  UserProfile,
+  resolvePermissions,
+} from '../models/user.model';
+import { SUPER_ADMIN_EMAIL } from '../constants';
+
+/**
+ * Centralised permission resolution. All feature code should consult this
+ * service rather than reading `user.permissions` directly so that super-admin
+ * overrides and the legacy `role === 'admin'` grant stay in one place.
+ */
+@Injectable({ providedIn: 'root' })
+export class PermissionsService {
+  private auth = inject(AuthService);
+
+  /**
+   * Effective permissions for the currently signed-in user.
+   * Admins and the designated super-admin always receive full permissions.
+   */
+  readonly currentPermissions = computed<UserPermissions>(() => {
+    const user = this.auth.currentUserSig();
+    return this.resolveFor(user);
+  });
+
+  readonly isSuperAdmin = computed(() => this.currentPermissions().isSuperAdmin);
+
+  /**
+   * Resolve the effective permissions for an arbitrary user profile.
+   * The designated super-admin email and anyone with role === 'admin' are
+   * granted the full permission set regardless of their stored map.
+   */
+  resolveFor(user: UserProfile | null | undefined): UserPermissions {
+    if (!user) return { ...DEFAULT_USER_PERMISSIONS, isSuperAdmin: false };
+
+    const base = resolvePermissions(user);
+
+    if (user.email?.toLowerCase() === SUPER_ADMIN_EMAIL.toLowerCase()) {
+      return {
+        canCreateProjects: true,
+        canCreateTasks: true,
+        canDeleteProjects: true,
+        canDeleteTasks: true,
+        canInviteMembers: true,
+        isSuperAdmin: true,
+      };
+    }
+
+    if (user.role === 'admin') {
+      return {
+        canCreateProjects: true,
+        canCreateTasks: true,
+        canDeleteProjects: true,
+        canDeleteTasks: true,
+        canInviteMembers: true,
+        isSuperAdmin: base.isSuperAdmin,
+      };
+    }
+
+    return base;
+  }
+
+  /**
+   * Throw a user-facing error if the current user lacks the given permission.
+   * Used at the top of mutating service methods so that a denied Firestore
+   * write surfaces as a clear message rather than a cryptic rules error.
+   */
+  requirePermission(key: keyof UserPermissions): void {
+    if (!this.currentPermissions()[key]) {
+      throw new Error(
+        `You do not have permission to perform this action (missing ${key}). ` +
+          `Please contact an administrator.`,
+      );
+    }
+  }
+}

--- a/src/app/core/services/project.service.spec.ts
+++ b/src/app/core/services/project.service.spec.ts
@@ -4,9 +4,11 @@ import * as firestore from '@angular/fire/firestore';
 import { Firestore } from '@angular/fire/firestore';
 import { AuthService } from '../auth/auth.service';
 import { GoogleTasksSyncService } from './google-tasks-sync.service';
+import { PermissionsService } from './permissions.service';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
 import { Project, DEFAULT_SECTIONS } from '../models/domain.model';
+import { DEFAULT_USER_PERMISSIONS } from '../models/user.model';
 
 describe('ProjectService', () => {
   let service: ProjectService;
@@ -28,6 +30,13 @@ describe('ProjectService', () => {
       .and.returnValue(Promise.resolve()),
   };
 
+  const permissionsServiceMock: Partial<PermissionsService> = {
+    currentPermissions: signal({ ...DEFAULT_USER_PERMISSIONS }) as any,
+    isSuperAdmin: signal(false) as any,
+    resolveFor: () => ({ ...DEFAULT_USER_PERMISSIONS }),
+    requirePermission: jasmine.createSpy('requirePermission'),
+  };
+
   const safeSpy = (obj: any, method: string) =>
     obj[method]?.and ? obj[method] : spyOn(obj, method);
 
@@ -38,6 +47,7 @@ describe('ProjectService', () => {
         { provide: Firestore, useValue: firestoreMock },
         { provide: AuthService, useValue: authServiceMock },
         { provide: GoogleTasksSyncService, useValue: googleTasksSyncServiceMock },
+        { provide: PermissionsService, useValue: permissionsServiceMock },
       ],
     });
 

--- a/src/app/core/services/project.service.ts
+++ b/src/app/core/services/project.service.ts
@@ -284,6 +284,7 @@ export class ProjectService {
    * Add a member to a project
    */
   async addMember(projectId: string, userId: string): Promise<void> {
+    this.permissions.requirePermission('canInviteMembers');
     const project = await this.getProject(projectId);
     if (!project) throw new Error('Project not found');
 
@@ -297,6 +298,7 @@ export class ProjectService {
    * Remove a member from a project
    */
   async removeMember(projectId: string, userId: string): Promise<void> {
+    this.permissions.requirePermission('canInviteMembers');
     const project = await this.getProject(projectId);
     if (!project) throw new Error('Project not found');
 

--- a/src/app/core/services/project.service.ts
+++ b/src/app/core/services/project.service.ts
@@ -22,6 +22,7 @@ import {
 import { AuthService } from '../auth/auth.service';
 import { Observable, switchMap, of, map } from 'rxjs';
 import { GoogleTasksSyncService } from './google-tasks-sync.service';
+import { PermissionsService } from './permissions.service';
 
 @Injectable({
   providedIn: 'root',
@@ -30,6 +31,7 @@ export class ProjectService {
   private firestore = inject(Firestore);
   private auth = inject(AuthService);
   private googleTasksSyncService = inject(GoogleTasksSyncService);
+  private permissions = inject(PermissionsService);
   private injector = inject(Injector);
 
   private projectsCollection = collection(this.firestore, 'projects');
@@ -124,6 +126,7 @@ export class ProjectService {
     try {
       const user = this.auth.currentUserSig();
       if (!user) throw new Error('Not authenticated');
+      this.permissions.requirePermission('canCreateProjects');
 
       // Create default sections with unique IDs
       const sections: Section[] = DEFAULT_SECTIONS.map((s, i) => ({
@@ -185,6 +188,7 @@ export class ProjectService {
     this.error.set(null);
 
     try {
+      this.permissions.requirePermission('canDeleteProjects');
       const project = await this.getProject(id);
       if (!project) throw new Error('Project not found');
 

--- a/src/app/core/services/task.service.spec.ts
+++ b/src/app/core/services/task.service.spec.ts
@@ -6,8 +6,10 @@ import { AuthService } from '../auth/auth.service';
 import { GoogleTasksService } from './google-tasks.service';
 import { GoogleTasksSyncService } from './google-tasks-sync.service';
 import { ProjectService } from './project.service';
+import { PermissionsService } from './permissions.service';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
+import { DEFAULT_USER_PERMISSIONS } from '../models/user.model';
 
 /**
  * Unit tests for TaskService
@@ -42,6 +44,13 @@ describe('TaskService', () => {
     addMember: (projectId: string, userId: string): Promise<void> => Promise.resolve(),
   };
 
+  const permissionsServiceMock: Partial<PermissionsService> = {
+    currentPermissions: signal({ ...DEFAULT_USER_PERMISSIONS }) as any,
+    isSuperAdmin: signal(false) as any,
+    resolveFor: () => ({ ...DEFAULT_USER_PERMISSIONS }),
+    requirePermission: jasmine.createSpy('requirePermission'),
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
@@ -51,6 +60,7 @@ describe('TaskService', () => {
         { provide: GoogleTasksService, useValue: googleTasksServiceMock },
         { provide: GoogleTasksSyncService, useValue: googleTasksSyncServiceMock },
         { provide: ProjectService, useValue: projectServiceMock },
+        { provide: PermissionsService, useValue: permissionsServiceMock },
       ],
     });
 

--- a/src/app/core/services/task.service.ts
+++ b/src/app/core/services/task.service.ts
@@ -21,6 +21,7 @@ import { AuthService } from '../auth/auth.service';
 import { GoogleTasksService, GoogleTask } from './google-tasks.service';
 import { GoogleTasksSyncService } from './google-tasks-sync.service';
 import { ProjectService } from './project.service';
+import { PermissionsService } from './permissions.service';
 
 @Injectable({
   providedIn: 'root',
@@ -31,6 +32,7 @@ export class TaskService {
   private googleTasksService = inject(GoogleTasksService);
   private googleTasksSyncService = inject(GoogleTasksSyncService);
   private projectService = inject(ProjectService);
+  private permissions = inject(PermissionsService);
   private injector = inject(Injector);
   private tasksCollection = collection(this.firestore, 'tasks');
 
@@ -370,6 +372,7 @@ export class TaskService {
 
     try {
       const user = this.auth.currentUserSig();
+      this.permissions.requirePermission('canCreateTasks');
 
       // Reconcile derived fields for the new task
       const reconciled = await this.reconcileNewTaskFields(task);
@@ -488,6 +491,7 @@ export class TaskService {
     this.error.set(null);
 
     try {
+      this.permissions.requirePermission('canDeleteTasks');
       // Collect all descendant task IDs using BFS with cycle guard
       const toDelete: Task[] = [];
       const visited = new Set<string>();

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -7,7 +7,7 @@ import {
   query,
   collectionData,
 } from '@angular/fire/firestore';
-import { UserProfile } from '../models/user.model';
+import { DEFAULT_USER_PERMISSIONS, UserPermissions, UserProfile } from '../models/user.model';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -49,5 +49,44 @@ export class UserService {
     } finally {
       this.loading.set(false);
     }
+  }
+
+  /**
+   * Replace a user's permissions map. Any field not supplied falls back to
+   * the default permission value so the stored document is always fully
+   * populated and predictable for Firestore rules.
+   */
+  async updateUserPermissions(
+    uid: string,
+    permissions: Partial<UserPermissions>,
+  ): Promise<void> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const merged: UserPermissions = { ...DEFAULT_USER_PERMISSIONS, ...permissions };
+      const userRef = doc(this.firestore, 'users', uid);
+      await updateDoc(userRef, { permissions: merged });
+    } catch (err) {
+      const message = 'Failed to update user permissions';
+      console.error(`${message}:`, err);
+      this.error.set(message);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  /**
+   * Toggle a single permission flag on a user document. The rest of the
+   * permission map is preserved.
+   */
+  async setUserPermission(
+    user: UserProfile,
+    key: keyof UserPermissions,
+    value: boolean,
+  ): Promise<void> {
+    const current: UserPermissions = { ...DEFAULT_USER_PERMISSIONS, ...(user.permissions ?? {}) };
+    current[key] = value;
+    return this.updateUserPermissions(user.uid, current);
   }
 }

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -7,7 +7,12 @@ import {
   query,
   collectionData,
 } from '@angular/fire/firestore';
-import { DEFAULT_USER_PERMISSIONS, UserPermissions, UserProfile } from '../models/user.model';
+import {
+  DEFAULT_USER_PERMISSIONS,
+  UserPermissions,
+  UserProfile,
+  resolvePermissions,
+} from '../models/user.model';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -85,7 +90,7 @@ export class UserService {
     key: keyof UserPermissions,
     value: boolean,
   ): Promise<void> {
-    const current: UserPermissions = { ...DEFAULT_USER_PERMISSIONS, ...(user.permissions ?? {}) };
+    const current = resolvePermissions(user);
     current[key] = value;
     return this.updateUserPermissions(user.uid, current);
   }

--- a/src/app/features/admin/admin-dashboard.component.ts
+++ b/src/app/features/admin/admin-dashboard.component.ts
@@ -10,6 +10,8 @@ import { TaskService } from '../../core/services/task.service';
 import { DialogService } from '../../core/services/dialog.service';
 import { AuthService } from '../../core/auth/auth.service';
 import { PermissionsService } from '../../core/services/permissions.service';
+import { InvitesService } from '../../core/services/invites.service';
+import { Invite } from '../../core/models/invite.model';
 import {
   DEFAULT_USER_PERMISSIONS,
   UserPermissions,
@@ -18,7 +20,7 @@ import {
 } from '../../core/models/user.model';
 import { ORG_DOMAIN, SUPER_ADMIN_EMAIL } from '../../core/constants';
 
-type AdminTab = 'Users' | 'Projects' | 'Tasks' | 'Permissions';
+type AdminTab = 'Users' | 'Projects' | 'Tasks' | 'Permissions' | 'Invites';
 
 interface PermissionToggle {
   key: keyof UserPermissions;
@@ -422,6 +424,183 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
             </div>
           </div>
         </div>
+
+        <!-- Invites Tab (super-admin only) -->
+        <div *ngIf="activeTab() === 'Invites'" class="flex flex-col gap-4">
+          <div
+            class="rounded-xl p-5 border border-cyan-500/30 bg-gradient-to-br from-cyan-500/10 to-purple-500/5 flex items-start justify-between gap-4 flex-wrap"
+          >
+            <div>
+              <h2 class="text-lg font-semibold text-white">Invite users</h2>
+              <p class="text-sm text-gray-400 mt-1">
+                Pre-configure role and permissions for a user. The grants are applied
+                automatically the first time they sign in with that email.
+              </p>
+            </div>
+            <button
+              (click)="openInviteForm()"
+              class="px-4 py-2 bg-gradient-to-r from-cyan-500 to-purple-500 text-white text-sm font-semibold rounded-lg hover:shadow-[0_0_20px_rgba(0,210,255,0.5)] transition-all"
+            >
+              + New invite
+            </button>
+          </div>
+
+          <div
+            class="bg-black/40 border border-white/10 rounded-xl overflow-hidden backdrop-blur-md"
+          >
+            <table class="w-full text-left text-sm text-gray-300">
+              <thead class="text-xs uppercase bg-black/60 text-gray-400">
+                <tr>
+                  <th class="px-6 py-4">Email</th>
+                  <th class="px-6 py-4">Role</th>
+                  <th class="px-6 py-4">Status</th>
+                  <th class="px-6 py-4">Invited by</th>
+                  <th class="px-6 py-4">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  *ngFor="let invite of invites()"
+                  class="border-b border-white/5 hover:bg-white/5 transition-colors"
+                >
+                  <td class="px-6 py-4 font-medium text-white">{{ invite.email }}</td>
+                  <td class="px-6 py-4 capitalize">{{ invite.role }}</td>
+                  <td class="px-6 py-4">
+                    <span
+                      class="px-2.5 py-1 text-[10px] uppercase tracking-wider font-bold rounded-full border"
+                      [class.bg-amber-500/10]="invite.status === 'pending'"
+                      [class.border-amber-500/30]="invite.status === 'pending'"
+                      [class.text-amber-300]="invite.status === 'pending'"
+                      [class.bg-emerald-500/10]="invite.status === 'accepted'"
+                      [class.border-emerald-500/30]="invite.status === 'accepted'"
+                      [class.text-emerald-300]="invite.status === 'accepted'"
+                      [class.bg-rose-500/10]="invite.status === 'revoked'"
+                      [class.border-rose-500/30]="invite.status === 'revoked'"
+                      [class.text-rose-300]="invite.status === 'revoked'"
+                    >
+                      {{ invite.status }}
+                    </span>
+                  </td>
+                  <td class="px-6 py-4 text-xs text-gray-400">{{ invite.invitedByEmail }}</td>
+                  <td class="px-6 py-4">
+                    <button
+                      *ngIf="invite.status === 'pending'"
+                      (click)="revokeInvite(invite)"
+                      class="text-rose-400 hover:text-rose-300 font-medium transition-colors"
+                    >
+                      Revoke
+                    </button>
+                  </td>
+                </tr>
+                <tr *ngIf="invites().length === 0">
+                  <td colspan="5" class="px-6 py-12 text-center text-gray-500">
+                    No invites yet. Click “New invite” to pre-configure a user's access.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <!-- Invite modal -->
+      <div
+        *ngIf="showInviteForm()"
+        class="fixed inset-0 z-[9999] flex items-center justify-center"
+      >
+        <div
+          class="absolute inset-0 bg-black/70 backdrop-blur-sm"
+          (click)="closeInviteForm()"
+        ></div>
+        <div
+          class="relative bg-slate-900 border border-white/20 rounded-xl shadow-2xl max-w-lg w-full mx-4 overflow-hidden"
+        >
+          <div
+            class="px-6 py-4 border-b border-white/10 bg-gradient-to-r from-cyan-600/20 to-purple-600/20"
+          >
+            <h3 class="text-lg font-semibold text-white">Invite a user</h3>
+            <p class="text-xs text-gray-400 mt-1">
+              Role and permissions apply on the user's first sign-in.
+            </p>
+          </div>
+          <form (submit)="submitInvite($event)" class="px-6 py-5 flex flex-col gap-4">
+            <label class="flex flex-col gap-1">
+              <span class="text-xs uppercase tracking-wider text-gray-400">Email</span>
+              <input
+                name="email"
+                type="email"
+                required
+                [(ngModel)]="inviteEmail"
+                placeholder="user@omniflexfitness.com"
+                class="px-3 py-2 bg-black/40 border border-white/10 rounded-lg text-white focus:border-cyan-500 focus:ring-2 focus:ring-cyan-500/30 outline-none"
+              />
+            </label>
+
+            <label class="flex flex-col gap-1">
+              <span class="text-xs uppercase tracking-wider text-gray-400">Role</span>
+              <select
+                name="role"
+                [(ngModel)]="inviteRole"
+                class="px-3 py-2 bg-black/40 border border-white/10 rounded-lg text-white focus:border-cyan-500 focus:ring-2 focus:ring-cyan-500/30 outline-none"
+              >
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+              </select>
+            </label>
+
+            <div>
+              <div class="text-xs uppercase tracking-wider text-gray-400 mb-2">Permissions</div>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <label
+                  *ngFor="let toggle of invitableToggles"
+                  class="flex items-start gap-2 p-2 rounded-lg border border-white/5 bg-white/[0.02] cursor-pointer"
+                >
+                  <input
+                    #inviteToggle
+                    type="checkbox"
+                    class="mt-1 accent-cyan-400"
+                    [checked]="invitePermissions()[toggle.key]"
+                    (change)="setInvitePermission(toggle.key, inviteToggle.checked)"
+                  />
+                  <div class="flex flex-col">
+                    <span class="text-sm text-white">{{ toggle.label }}</span>
+                    <span class="text-[11px] text-gray-500">{{ toggle.description }}</span>
+                  </div>
+                </label>
+              </div>
+            </div>
+
+            <label class="flex flex-col gap-1">
+              <span class="text-xs uppercase tracking-wider text-gray-400"
+                >Note (optional)</span
+              >
+              <input
+                name="note"
+                type="text"
+                [(ngModel)]="inviteNote"
+                placeholder="Internal note, e.g. 'New PM on team'"
+                class="px-3 py-2 bg-black/40 border border-white/10 rounded-lg text-white focus:border-cyan-500 focus:ring-2 focus:ring-cyan-500/30 outline-none"
+              />
+            </label>
+
+            <div class="flex justify-end gap-3 pt-2">
+              <button
+                type="button"
+                (click)="closeInviteForm()"
+                class="px-4 py-2 rounded-lg border border-white/10 text-gray-300 hover:bg-white/5 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                [disabled]="inviteSubmitting()"
+                class="px-4 py-2 rounded-lg bg-gradient-to-r from-cyan-500 to-purple-500 text-white font-semibold disabled:opacity-50"
+              >
+                {{ inviteSubmitting() ? 'Sending…' : 'Send invite' }}
+              </button>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   `,
@@ -434,6 +613,7 @@ export class AdminDashboardComponent {
   readonly router = inject(Router);
   readonly authService = inject(AuthService);
   readonly permissionsService = inject(PermissionsService);
+  readonly invitesService = inject(InvitesService);
 
   currentUser = this.authService.currentUserSig;
   isSuperAdmin = this.permissionsService.isSuperAdmin;
@@ -441,6 +621,9 @@ export class AdminDashboardComponent {
   readonly superAdminEmail = SUPER_ADMIN_EMAIL;
   readonly orgDomain = ORG_DOMAIN;
   readonly toggles = PERMISSION_TOGGLES;
+  // Invite form hides the isSuperAdmin toggle — super-admin must be granted
+  // explicitly from the Permissions tab after a user exists.
+  readonly invitableToggles = PERMISSION_TOGGLES.filter((t) => t.key !== 'isSuperAdmin');
 
   activeTab = signal<AdminTab>('Users');
   orgDomainOnly = signal(true);
@@ -448,10 +631,19 @@ export class AdminDashboardComponent {
   users = toSignal(this.userService.getAllUsers(), { initialValue: [] });
   projects = toSignal(this.projectService.getAllProjects(), { initialValue: [] });
   tasks = toSignal(this.taskService.getAllTasks(), { initialValue: [] });
+  invites = toSignal(this.invitesService.getAllInvites(), { initialValue: [] as Invite[] });
+
+  // Invite form state
+  showInviteForm = signal(false);
+  inviteSubmitting = signal(false);
+  inviteEmail = '';
+  inviteRole: 'admin' | 'user' = 'user';
+  inviteNote = '';
+  invitePermissions = signal<UserPermissions>({ ...DEFAULT_USER_PERMISSIONS });
 
   visibleTabs = computed<AdminTab[]>(() => {
     const base: AdminTab[] = ['Users', 'Projects', 'Tasks'];
-    return this.isSuperAdmin() ? [...base, 'Permissions'] : base;
+    return this.isSuperAdmin() ? [...base, 'Permissions', 'Invites'] : base;
   });
 
   filteredUsers = computed(() => {
@@ -480,7 +672,7 @@ export class AdminDashboardComponent {
       await this.userService.setUserPermission(user, key, value);
     } catch (err) {
       console.error('Failed to update permission:', err);
-      this.dialogService.alert('Failed to update permission. Please try again.', 'Error');
+      this.dialogService.alert(this.friendlyWriteError(err), 'Error');
     }
   }
 
@@ -493,9 +685,10 @@ export class AdminDashboardComponent {
     ) {
       try {
         await this.userService.updateUserPermissions(user.uid, { ...DEFAULT_USER_PERMISSIONS });
+        this.dialogService.alert('Permissions reset to defaults.', 'Done');
       } catch (err) {
         console.error('Failed to reset permissions:', err);
-        this.dialogService.alert('Failed to reset permissions. Please try again.', 'Error');
+        this.dialogService.alert(this.friendlyWriteError(err), 'Error');
       }
     }
   }
@@ -511,9 +704,13 @@ export class AdminDashboardComponent {
         canInviteMembers: true,
         isSuperAdmin: false,
       });
+      this.dialogService.alert(
+        `${user.displayName || user.email} now has all permissions (except super-admin).`,
+        'Done',
+      );
     } catch (err) {
       console.error('Failed to grant permissions:', err);
-      this.dialogService.alert('Failed to grant permissions. Please try again.', 'Error');
+      this.dialogService.alert(this.friendlyWriteError(err), 'Error');
     }
   }
 
@@ -533,9 +730,10 @@ export class AdminDashboardComponent {
           canInviteMembers: false,
           isSuperAdmin: false,
         });
+        this.dialogService.alert('All permissions revoked.', 'Done');
       } catch (err) {
         console.error('Failed to revoke permissions:', err);
-        this.dialogService.alert('Failed to revoke permissions. Please try again.', 'Error');
+        this.dialogService.alert(this.friendlyWriteError(err), 'Error');
       }
     }
   }
@@ -548,9 +746,10 @@ export class AdminDashboardComponent {
     ) {
       try {
         await this.userService.updateUserRole(user.uid, 'admin');
+        this.dialogService.alert(`${user.displayName || user.email} is now an admin.`, 'Done');
       } catch (error) {
         console.error('Failed to promote user:', error);
-        this.dialogService.alert('Failed to promote user. Please try again.', 'Error');
+        this.dialogService.alert(this.friendlyWriteError(error), 'Error');
       }
     }
   }
@@ -575,10 +774,86 @@ export class AdminDashboardComponent {
     ) {
       try {
         await this.userService.updateUserRole(user.uid, 'user');
+        this.dialogService.alert(`${user.displayName || user.email} is now a regular user.`, 'Done');
       } catch (error) {
         console.error('Failed to demote user:', error);
-        this.dialogService.alert('Failed to demote user. Please try again.', 'Error');
+        this.dialogService.alert(this.friendlyWriteError(error), 'Error');
       }
     }
+  }
+
+  // --- Invites ---
+
+  openInviteForm() {
+    this.inviteEmail = '';
+    this.inviteRole = 'user';
+    this.inviteNote = '';
+    this.invitePermissions.set({ ...DEFAULT_USER_PERMISSIONS });
+    this.showInviteForm.set(true);
+  }
+
+  closeInviteForm() {
+    if (this.inviteSubmitting()) return;
+    this.showInviteForm.set(false);
+  }
+
+  setInvitePermission(key: keyof UserPermissions, value: boolean) {
+    this.invitePermissions.update((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async submitInvite(event: Event) {
+    event.preventDefault();
+    if (this.inviteSubmitting()) return;
+    const email = this.inviteEmail.trim();
+    if (!email) {
+      this.dialogService.alert('Please enter an email address.', 'Missing email');
+      return;
+    }
+
+    this.inviteSubmitting.set(true);
+    try {
+      await this.invitesService.createInvite(
+        email,
+        this.inviteRole,
+        this.invitePermissions(),
+        this.inviteNote.trim() || undefined,
+      );
+      this.showInviteForm.set(false);
+      this.dialogService.alert(
+        `Invite created for ${email}. Their role and permissions will be applied the next time they sign in.`,
+        'Invite sent',
+      );
+    } catch (err) {
+      console.error('Failed to create invite:', err);
+      this.dialogService.alert(this.friendlyWriteError(err), 'Error');
+    } finally {
+      this.inviteSubmitting.set(false);
+    }
+  }
+
+  async revokeInvite(invite: Invite) {
+    if (!invite.id) return;
+    if (!(await this.dialogService.confirm(`Revoke invite for ${invite.email}?`))) return;
+    try {
+      await this.invitesService.revokeInvite(invite.id);
+    } catch (err) {
+      console.error('Failed to revoke invite:', err);
+      this.dialogService.alert(this.friendlyWriteError(err), 'Error');
+    }
+  }
+
+  /**
+   * Map Firestore permission-denied errors to actionable guidance; otherwise
+   * surface the underlying message.
+   */
+  private friendlyWriteError(err: unknown): string {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/permission|insufficient|PERMISSION_DENIED/i.test(message)) {
+      return (
+        'The server rejected this change. Make sure Firestore rules are deployed ' +
+        '(`yarn deploy:firestore`) and that you are signed in as a super-admin.'
+      );
+    }
+    return message || 'Unknown error. Please try again.';
   }
 }

--- a/src/app/features/admin/admin-dashboard.component.ts
+++ b/src/app/features/admin/admin-dashboard.component.ts
@@ -326,9 +326,10 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
                 class="flex items-center gap-2 text-xs text-gray-300 bg-black/40 border border-white/10 rounded-lg px-3 py-2 cursor-pointer select-none"
               >
                 <input
+                  #orgOnly
                   type="checkbox"
                   [checked]="orgDomainOnly()"
-                  (change)="orgDomainOnly.set($any($event.target).checked)"
+                  (change)="orgDomainOnly.set(orgOnly.checked)"
                   class="accent-cyan-400"
                 />
                 Only show &#64;{{ orgDomain }}
@@ -398,11 +399,12 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
                   [class.opacity-60]="user.email === superAdminEmail && toggle.key !== 'isSuperAdmin'"
                 >
                   <input
+                    #permToggle
                     type="checkbox"
                     class="mt-1 accent-cyan-400 w-4 h-4"
                     [checked]="effective(user)[toggle.key]"
                     [disabled]="user.email === superAdminEmail"
-                    (change)="togglePermission(user, toggle.key, $any($event.target).checked)"
+                    (change)="togglePermission(user, toggle.key, permToggle.checked)"
                   />
                   <div class="flex flex-col">
                     <span class="text-sm text-white font-medium">{{ toggle.label }}</span>

--- a/src/app/features/admin/admin-dashboard.component.ts
+++ b/src/app/features/admin/admin-dashboard.component.ts
@@ -1,5 +1,6 @@
-import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 
@@ -8,13 +9,61 @@ import { ProjectService } from '../../core/services/project.service';
 import { TaskService } from '../../core/services/task.service';
 import { DialogService } from '../../core/services/dialog.service';
 import { AuthService } from '../../core/auth/auth.service';
-import { UserProfile } from '../../core/models/user.model';
+import { PermissionsService } from '../../core/services/permissions.service';
+import {
+  DEFAULT_USER_PERMISSIONS,
+  UserPermissions,
+  UserProfile,
+  resolvePermissions,
+} from '../../core/models/user.model';
+import { ORG_DOMAIN, SUPER_ADMIN_EMAIL } from '../../core/constants';
+
+type AdminTab = 'Users' | 'Projects' | 'Tasks' | 'Permissions';
+
+interface PermissionToggle {
+  key: keyof UserPermissions;
+  label: string;
+  description: string;
+}
+
+const PERMISSION_TOGGLES: PermissionToggle[] = [
+  {
+    key: 'canCreateProjects',
+    label: 'Create projects',
+    description: 'Create new projects in the workspace.',
+  },
+  {
+    key: 'canCreateTasks',
+    label: 'Create tasks',
+    description: 'Add tasks to any project they are a member of.',
+  },
+  {
+    key: 'canDeleteProjects',
+    label: 'Delete projects',
+    description: 'Delete projects they own.',
+  },
+  {
+    key: 'canDeleteTasks',
+    label: 'Delete tasks',
+    description: 'Delete tasks within their projects.',
+  },
+  {
+    key: 'canInviteMembers',
+    label: 'Invite members',
+    description: 'Add other users to projects.',
+  },
+  {
+    key: 'isSuperAdmin',
+    label: 'Super admin',
+    description: 'Manage permissions for every user (grant with care).',
+  },
+];
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-admin-dashboard',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   template: `
     <div class="h-screen overflow-y-auto bg-[#0a0a0a] text-gray-200">
       <div class="p-8 max-w-7xl mx-auto flex flex-col gap-8">
@@ -70,7 +119,7 @@ import { UserProfile } from '../../core/models/user.model';
         <!-- Navigation Tabs -->
         <div class="flex border-b border-white/10 gap-8">
           <button
-            *ngFor="let tab of tabs"
+            *ngFor="let tab of visibleTabs()"
             (click)="activeTab.set(tab)"
             [class.border-cyan-400]="activeTab() === tab"
             [class.text-cyan-400]="activeTab() === tab"
@@ -258,6 +307,119 @@ import { UserProfile } from '../../core/models/user.model';
             </table>
           </div>
         </div>
+
+        <!-- Permissions Tab (super-admin only) -->
+        <div *ngIf="activeTab() === 'Permissions'" class="flex flex-col gap-4">
+          <div
+            class="rounded-xl p-5 border border-purple-500/30 bg-gradient-to-br from-purple-500/10 to-cyan-500/5"
+          >
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h2 class="text-lg font-semibold text-white">User rights &amp; permissions</h2>
+                <p class="text-sm text-gray-400 mt-1">
+                  Grant granular rights to users &mdash; particularly those in the
+                  <span class="font-mono text-cyan-300">{{ orgDomain }}</span> domain who could not
+                  previously create projects or tasks. Changes apply immediately.
+                </p>
+              </div>
+              <label
+                class="flex items-center gap-2 text-xs text-gray-300 bg-black/40 border border-white/10 rounded-lg px-3 py-2 cursor-pointer select-none"
+              >
+                <input
+                  type="checkbox"
+                  [checked]="orgDomainOnly()"
+                  (change)="orgDomainOnly.set($any($event.target).checked)"
+                  class="accent-cyan-400"
+                />
+                Only show &#64;{{ orgDomain }}
+              </label>
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-4">
+            <div
+              *ngFor="let user of filteredUsers(); trackBy: trackByUid"
+              class="bg-black/40 border border-white/10 rounded-xl p-5 backdrop-blur-md"
+              [class.border-purple-500/40]="user.email === superAdminEmail"
+            >
+              <div class="flex items-start justify-between gap-4 flex-wrap">
+                <div class="flex items-center gap-3">
+                  <div
+                    class="w-10 h-10 rounded-full bg-cyan-500/20 border border-cyan-500/30 flex items-center justify-center text-cyan-200 font-semibold"
+                  >
+                    {{ user.displayName ? user.displayName.charAt(0) : 'U' }}
+                  </div>
+                  <div>
+                    <div class="text-white font-medium">
+                      {{ user.displayName || 'Unknown User' }}
+                      <span
+                        *ngIf="user.email === superAdminEmail"
+                        class="ml-2 text-[10px] uppercase tracking-wider text-purple-300 border border-purple-500/40 px-2 py-0.5 rounded-full"
+                      >
+                        Super Admin
+                      </span>
+                    </div>
+                    <div class="text-xs text-gray-400 mt-0.5">{{ user.email }}</div>
+                    <div class="text-[10px] text-gray-500 font-mono mt-0.5">
+                      domain: {{ user.domain }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                  <button
+                    (click)="resetToDefaults(user)"
+                    [disabled]="user.email === superAdminEmail"
+                    class="text-xs px-3 py-1.5 rounded-lg border border-white/10 text-gray-300 hover:bg-white/5 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Reset to defaults
+                  </button>
+                  <button
+                    (click)="grantAll(user)"
+                    [disabled]="user.email === superAdminEmail"
+                    class="text-xs px-3 py-1.5 rounded-lg border border-cyan-500/40 text-cyan-300 hover:bg-cyan-500/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Grant all
+                  </button>
+                  <button
+                    (click)="revokeAll(user)"
+                    [disabled]="user.email === superAdminEmail"
+                    class="text-xs px-3 py-1.5 rounded-lg border border-rose-500/40 text-rose-300 hover:bg-rose-500/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Revoke all
+                  </button>
+                </div>
+              </div>
+
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-2 mt-5">
+                <label
+                  *ngFor="let toggle of toggles"
+                  class="flex items-start gap-3 p-3 rounded-lg border border-white/5 bg-white/[0.02] hover:bg-white/[0.04] cursor-pointer transition-colors"
+                  [class.opacity-60]="user.email === superAdminEmail && toggle.key !== 'isSuperAdmin'"
+                >
+                  <input
+                    type="checkbox"
+                    class="mt-1 accent-cyan-400 w-4 h-4"
+                    [checked]="effective(user)[toggle.key]"
+                    [disabled]="user.email === superAdminEmail"
+                    (change)="togglePermission(user, toggle.key, $any($event.target).checked)"
+                  />
+                  <div class="flex flex-col">
+                    <span class="text-sm text-white font-medium">{{ toggle.label }}</span>
+                    <span class="text-xs text-gray-400">{{ toggle.description }}</span>
+                  </div>
+                </label>
+              </div>
+            </div>
+
+            <div
+              *ngIf="filteredUsers().length === 0"
+              class="text-center text-gray-500 py-12 border border-dashed border-white/10 rounded-xl"
+            >
+              No users match the current filter.
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   `,
@@ -269,14 +431,112 @@ export class AdminDashboardComponent {
   readonly dialogService = inject(DialogService);
   readonly router = inject(Router);
   readonly authService = inject(AuthService);
-  currentUser = this.authService.currentUserSig;
+  readonly permissionsService = inject(PermissionsService);
 
-  tabs = ['Users', 'Projects', 'Tasks'];
-  activeTab = signal('Users');
+  currentUser = this.authService.currentUserSig;
+  isSuperAdmin = this.permissionsService.isSuperAdmin;
+
+  readonly superAdminEmail = SUPER_ADMIN_EMAIL;
+  readonly orgDomain = ORG_DOMAIN;
+  readonly toggles = PERMISSION_TOGGLES;
+
+  activeTab = signal<AdminTab>('Users');
+  orgDomainOnly = signal(true);
 
   users = toSignal(this.userService.getAllUsers(), { initialValue: [] });
   projects = toSignal(this.projectService.getAllProjects(), { initialValue: [] });
   tasks = toSignal(this.taskService.getAllTasks(), { initialValue: [] });
+
+  visibleTabs = computed<AdminTab[]>(() => {
+    const base: AdminTab[] = ['Users', 'Projects', 'Tasks'];
+    return this.isSuperAdmin() ? [...base, 'Permissions'] : base;
+  });
+
+  filteredUsers = computed(() => {
+    const all = this.users();
+    if (!this.orgDomainOnly()) return all;
+    return all.filter((u) => u.domain?.toLowerCase() === ORG_DOMAIN);
+  });
+
+  trackByUid(_index: number, user: UserProfile) {
+    return user.uid;
+  }
+
+  effective(user: UserProfile): UserPermissions {
+    return resolvePermissions(user);
+  }
+
+  async togglePermission(user: UserProfile, key: keyof UserPermissions, value: boolean) {
+    if (user.email === SUPER_ADMIN_EMAIL) {
+      this.dialogService.alert(
+        'The super-admin account cannot have its permissions modified.',
+        'Action Not Allowed',
+      );
+      return;
+    }
+    try {
+      await this.userService.setUserPermission(user, key, value);
+    } catch (err) {
+      console.error('Failed to update permission:', err);
+      this.dialogService.alert('Failed to update permission. Please try again.', 'Error');
+    }
+  }
+
+  async resetToDefaults(user: UserProfile) {
+    if (user.email === SUPER_ADMIN_EMAIL) return;
+    if (
+      await this.dialogService.confirm(
+        `Reset ${user.displayName || user.email}'s permissions to defaults?`,
+      )
+    ) {
+      try {
+        await this.userService.updateUserPermissions(user.uid, { ...DEFAULT_USER_PERMISSIONS });
+      } catch (err) {
+        console.error('Failed to reset permissions:', err);
+        this.dialogService.alert('Failed to reset permissions. Please try again.', 'Error');
+      }
+    }
+  }
+
+  async grantAll(user: UserProfile) {
+    if (user.email === SUPER_ADMIN_EMAIL) return;
+    try {
+      await this.userService.updateUserPermissions(user.uid, {
+        canCreateProjects: true,
+        canCreateTasks: true,
+        canDeleteProjects: true,
+        canDeleteTasks: true,
+        canInviteMembers: true,
+        isSuperAdmin: false,
+      });
+    } catch (err) {
+      console.error('Failed to grant permissions:', err);
+      this.dialogService.alert('Failed to grant permissions. Please try again.', 'Error');
+    }
+  }
+
+  async revokeAll(user: UserProfile) {
+    if (user.email === SUPER_ADMIN_EMAIL) return;
+    if (
+      await this.dialogService.confirm(
+        `Revoke all permissions from ${user.displayName || user.email}?`,
+      )
+    ) {
+      try {
+        await this.userService.updateUserPermissions(user.uid, {
+          canCreateProjects: false,
+          canCreateTasks: false,
+          canDeleteProjects: false,
+          canDeleteTasks: false,
+          canInviteMembers: false,
+          isSuperAdmin: false,
+        });
+      } catch (err) {
+        console.error('Failed to revoke permissions:', err);
+        this.dialogService.alert('Failed to revoke permissions. Please try again.', 'Error');
+      }
+    }
+  }
 
   async promoteToAdmin(user: UserProfile) {
     if (
@@ -286,7 +546,6 @@ export class AdminDashboardComponent {
     ) {
       try {
         await this.userService.updateUserRole(user.uid, 'admin');
-        // Optionally show a success toast here
       } catch (error) {
         console.error('Failed to promote user:', error);
         this.dialogService.alert('Failed to promote user. Please try again.', 'Error');
@@ -297,6 +556,13 @@ export class AdminDashboardComponent {
   async demoteToUser(user: UserProfile) {
     if (user.uid === this.currentUser()?.uid) {
       this.dialogService.alert('You cannot demote your own account.', 'Action Not Allowed');
+      return;
+    }
+    if (user.email === SUPER_ADMIN_EMAIL) {
+      this.dialogService.alert(
+        'The designated super-admin cannot be demoted.',
+        'Action Not Allowed',
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary
Implement a comprehensive permission system that allows super-admins to grant or revoke granular feature-level permissions to individual users. This replaces the binary admin/user role model with fine-grained controls over project creation, task management, member invitations, and admin privileges.

## Key Changes

- **New Permission Model**: Introduced `UserPermissions` interface with six toggleable permissions:
  - `canCreateProjects`, `canCreateTasks`, `canDeleteProjects`, `canDeleteTasks`, `canInviteMembers`, `isSuperAdmin`
  - Defaults are intentionally permissive to avoid locking out existing users after deployment

- **Super-Admin Designation**: 
  - Hardcoded super-admin email (`bertin.kenol@omniflexfitness.com`) with implicit full permissions
  - Super-admin cannot be demoted and their permissions cannot be modified via UI
  - New `superAdminGuard` restricts permissions management UI to super-admins only

- **Admin Dashboard Permissions Tab**:
  - New "Permissions" tab visible only to super-admins
  - Filter users by organization domain (`omniflexfitness.com`)
  - Bulk actions: "Grant all", "Revoke all", "Reset to defaults"
  - Individual permission toggles with descriptions for each user
  - Super-admin account highlighted and protected from modification

- **Service Layer**:
  - New `PermissionsService` centralizes permission resolution with computed signals
  - `UserService.updateUserPermissions()` and `setUserPermission()` for granular updates
  - `resolvePermissions()` utility applies defaults to user profiles
  - `requirePermission()` method for enforcing checks in service methods

- **Firestore Rules**:
  - Added `isSuperAdmin()`, `hasPermission()`, and `currentUser()` helper functions
  - Project creation now requires `canCreateProjects` permission
  - Task creation/deletion gated by `canCreateTasks`/`canDeleteTasks`
  - Project deletion requires `canDeleteProjects` or admin/super-admin status
  - Users can only modify their own non-privileged fields; admins cannot grant `isSuperAdmin`

- **Auth Service**: 
  - Designated super-admin automatically promoted to admin role on sign-in
  - New users seeded with default permissions; returning users preserve admin-assigned rights

- **UI/UX**:
  - Added `FormsModule` for checkbox bindings
  - Computed `visibleTabs()` shows "Permissions" only to super-admins
  - Computed `filteredUsers()` for domain-based filtering
  - Disabled state and visual indicators for super-admin account

## Notable Implementation Details

- Permission defaults are stored in Firestore so rules can rely on fully populated documents
- Backward compatibility: missing permission fields default to `true` in rules, preserving access for pre-feature users
- Super-admin email is synchronized across `constants.ts`, `firestore.rules`, and `auth.service.ts`
- Admin guard updated to recognize both `role === 'admin'` and designated super-admin email

https://claude.ai/code/session_01WdUumWVqKxtNLed6k4Yg1U