### PR TITLE
Add drag-and-drop reordering for project groups with persistence

### DIFF
--- a/src/app/core/theme/text-scrambler.ts
+++ b/src/app/core/theme/text-scrambler.ts
@@ -5,8 +5,10 @@
  *
  * Usage: add `data-scramble` to any text element; call `bindScramble(el)`
  * once per element (guarded by a `data-scramble-bound` sentinel). The
- * element's `innerText` is captured fresh on each mouseenter, so edits
- * to task titles are picked up automatically on the next hover.
+ * element's original text is preserved across scrambles — the animation
+ * plays inside a sibling `<span class="scramble-overlay">` that sits on
+ * top of the original content, so Angular-managed text nodes keep their
+ * framework bindings and still update when inputs change after a hover.
  */
 
 const GLITCH_CHARS = '▓▒░█▄▀■□◆◇▲▼►◄!@#$%^&*()_+={}[]|\\:;"<>?,./`~';
@@ -100,6 +102,21 @@ export class TextScrambler {
 }
 
 /**
+ * Read the element's text while ignoring the dedicated scramble overlay.
+ * This matters for elements where Angular's text interpolation is the
+ * "real" content: we must not include the overlay's own characters when
+ * capturing the target text for the next scramble pass.
+ */
+function textExcludingOverlay(el: HTMLElement, overlay: HTMLElement): string {
+  let text = '';
+  el.childNodes.forEach((node) => {
+    if (node === overlay) return;
+    text += node.textContent ?? '';
+  });
+  return text;
+}
+
+/**
  * Wire a single element for scramble-on-hover. Idempotent — the
  * `data-scramble-bound` sentinel prevents double-binding when the
  * MutationObserver re-scans.
@@ -108,15 +125,25 @@ export function bindScramble(el: HTMLElement): void {
   if (el.dataset['scrambleBound'] === 'true') return;
   el.dataset['scrambleBound'] = 'true';
 
-  const scrambler = new TextScrambler(el);
+  // The overlay is what the scrambler mutates. Keeping our DOM writes
+  // inside a child element preserves the Angular-managed text node (or
+  // any other framework-managed content) inside `el` so bindings still
+  // update after the animation finishes.
+  const overlay = document.createElement('span');
+  overlay.className = 'scramble-overlay';
+  overlay.setAttribute('aria-hidden', 'true');
+  el.appendChild(overlay);
+
+  const scrambler = new TextScrambler(overlay);
   let isScrambling = false;
 
   el.addEventListener('mouseenter', () => {
     if (isScrambling) return;
     isScrambling = true;
 
-    // Fresh read: picks up edited task titles without extra plumbing.
-    const finalText = el.innerText;
+    // Fresh read: picks up edited text without extra plumbing, and
+    // deliberately excludes the (empty) overlay.
+    const finalText = textExcludingOverlay(el, overlay);
 
     // Width stabilization: capture the current bounding box so glyph
     // changes during the scramble (wide block-drawing chars ↔ narrow
@@ -126,19 +153,30 @@ export function bindScramble(el: HTMLElement): void {
     const rect = el.getBoundingClientRect();
     const originalMinWidth = el.style.minWidth;
     const originalDisplay = el.style.display;
-    const computedDisplay = window.getComputedStyle(el).display;
-    if (computedDisplay === 'inline') {
+    const computed = window.getComputedStyle(el);
+    if (computed.display === 'inline') {
       el.style.display = 'inline-block';
     }
     el.style.minWidth = `${Math.ceil(rect.width)}px`;
+
+    // Copy the element's resolved text styles onto the overlay before the
+    // parent's text is hidden via `.is-scrambling`. Without this, non-
+    // scrambled glyphs would inherit `color: transparent` from the parent
+    // and disappear mid-animation.
+    overlay.style.color = computed.color;
+    overlay.style.textShadow = computed.textShadow;
+
     el.classList.add('is-scrambling');
 
     scrambler
       .setText(finalText)
-      .then(() => {
-        el.innerText = finalText;
-      })
       .finally(() => {
+        // Clear the overlay so the underlying Angular/static text shows
+        // through cleanly again, and let the CSS hook (`.is-scrambling`)
+        // restore the element to its normal state.
+        overlay.innerHTML = '';
+        overlay.style.color = '';
+        overlay.style.textShadow = '';
         el.classList.remove('is-scrambling');
         el.style.minWidth = originalMinWidth;
         el.style.display = originalDisplay;

--- a/src/app/core/theme/text-scrambler.ts
+++ b/src/app/core/theme/text-scrambler.ts
@@ -166,6 +166,12 @@ export function bindScramble(el: HTMLElement): void {
     overlay.style.color = computed.color;
     overlay.style.textShadow = computed.textShadow;
 
+    // Seed the overlay with the current text so the scrambler reads it as
+    // the "from" state. Without this, the queue's from-chars default to
+    // an empty string and glyphs pop in from nothing during the pre-start
+    // frames instead of flickering in place.
+    overlay.textContent = finalText;
+
     el.classList.add('is-scrambling');
 
     scrambler
@@ -174,7 +180,7 @@ export function bindScramble(el: HTMLElement): void {
         // Clear the overlay so the underlying Angular/static text shows
         // through cleanly again, and let the CSS hook (`.is-scrambling`)
         // restore the element to its normal state.
-        overlay.innerHTML = '';
+        overlay.textContent = '';
         overlay.style.color = '';
         overlay.style.textShadow = '';
         el.classList.remove('is-scrambling');

--- a/src/app/core/utils/order.utils.ts
+++ b/src/app/core/utils/order.utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared helpers for applying a user's drag-and-drop preferred ordering
+ * on top of a computed list of groups. Used by the My Tasks list and the
+ * Available Tasks panels — wherever project-grouped "sections" are
+ * reorderable and the preference is persisted in localStorage.
+ */
+
+/**
+ * Reorder `groups` so IDs that appear in `preferred` come first in that
+ * relative order, followed by any groups the user hasn't yet positioned,
+ * sorted by the `fallback` comparator (default: tasks-count descending).
+ */
+export function applyPreferredOrder<T extends { projectId: string; tasks: readonly unknown[] }>(
+  groups: T[],
+  preferred: string[],
+  fallback: (a: T, b: T) => number = (a, b) => b.tasks.length - a.tasks.length,
+): T[] {
+  if (preferred.length === 0) {
+    return groups.slice().sort(fallback);
+  }
+  const byId = new Map(groups.map((g) => [g.projectId, g] as const));
+  const ordered: T[] = [];
+  const seen = new Set<string>();
+  for (const id of preferred) {
+    const g = byId.get(id);
+    if (g) {
+      ordered.push(g);
+      seen.add(id);
+    }
+  }
+  const leftovers = groups.filter((g) => !seen.has(g.projectId)).sort(fallback);
+  return ordered.concat(leftovers);
+}
+
+/**
+ * Fold the user's new visible-groups order into their stored preference
+ * without forgetting IDs that aren't currently on screen (e.g. a project
+ * the user filtered out). Visible IDs keep their new positions; absent
+ * IDs keep their previous relative order appended at the end.
+ */
+export function mergeOrders(visible: string[], previous: string[]): string[] {
+  const visibleSet = new Set(visible);
+  const tail = previous.filter((id) => !visibleSet.has(id));
+  return visible.concat(tail);
+}

--- a/src/app/features/dashboard/components/project-overview.component.html
+++ b/src/app/features/dashboard/components/project-overview.component.html
@@ -16,7 +16,7 @@
       <div class="flex-1 min-w-0">
         <div class="flex items-center gap-3 flex-wrap">
           <h2
-            class="text-2xl font-black leading-none truncate"
+            class="!m-0 text-2xl font-black !leading-none truncate"
             [style.color]="proj.color || defaultColor"
             [style.text-shadow]="'0 0 12px ' + accent(0.55)"
           >

--- a/src/app/features/my-tasks/components/available-tasks.component.css
+++ b/src/app/features/my-tasks/components/available-tasks.component.css
@@ -53,3 +53,16 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+/* Drag-and-drop affordances for reordering the project-group "sections". */
+.mytasks-group.cdk-drag-preview {
+  box-shadow: 0 12px 40px rgba(0, 210, 255, 0.35), 0 0 20px rgba(224, 64, 251, 0.25);
+}
+
+.mytasks-group.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.cdk-drop-list-dragging .mytasks-group:not(.cdk-drag-placeholder) {
+  transition: transform 200ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/app/features/my-tasks/components/available-tasks.component.html
+++ b/src/app/features/my-tasks/components/available-tasks.component.html
@@ -34,7 +34,8 @@
         ></div>
         <header
           cdkDragHandle
-          class="flex items-center justify-between gap-2 mb-3 flex-wrap cursor-grab active:cursor-grabbing select-none"
+          class="flex items-center justify-between gap-2 mb-3 flex-wrap select-none
+                 cursor-grab active:cursor-grabbing"
           title="Drag to reorder"
         >
           <div class="flex items-center gap-2 min-w-0">

--- a/src/app/features/my-tasks/components/available-tasks.component.html
+++ b/src/app/features/my-tasks/components/available-tasks.component.html
@@ -20,10 +20,34 @@
       </p>
     </div>
   } @else {
+    <div
+      cdkDropList
+      [cdkDropListData]="groupedTasks()"
+      (cdkDropListDropped)="onGroupDrop($event)"
+      class="space-y-4"
+    >
     @for (g of groupedTasks(); track g.projectId) {
-      <section class="ofx-panel p-4">
-        <header class="flex items-center justify-between gap-2 mb-3 flex-wrap">
+      <section cdkDrag [cdkDragData]="g" class="ofx-panel p-4 mytasks-group">
+        <div
+          *cdkDragPlaceholder
+          class="ofx-panel p-4 border border-dashed border-violet-500/40 bg-violet-500/5 h-24"
+        ></div>
+        <header
+          cdkDragHandle
+          class="flex items-center justify-between gap-2 mb-3 flex-wrap cursor-grab active:cursor-grabbing select-none"
+          title="Drag to reorder"
+        >
           <div class="flex items-center gap-2 min-w-0">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-3.5 w-3.5 text-slate-500 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
             <span
               class="w-2.5 h-2.5 rounded-sm flex-shrink-0"
               [style.background]="g.projectColor"
@@ -85,5 +109,6 @@
         </ul>
       </section>
     }
+    </div>
   }
 </div>

--- a/src/app/features/my-tasks/components/available-tasks.component.ts
+++ b/src/app/features/my-tasks/components/available-tasks.component.ts
@@ -10,6 +10,7 @@ import { CommonModule, DatePipe } from '@angular/common';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 
 import { Project, Task, CYBERPUNK_COLORS } from '../../../core/models/domain.model';
+import { applyPreferredOrder, mergeOrders } from '../../../core/utils/order.utils';
 
 interface AvailableGroup {
   projectId: string;
@@ -83,7 +84,7 @@ export class AvailableTasksComponent {
     return ordered;
   });
 
-  onGroupDrop(event: CdkDragDrop<AvailableGroup[]>) {
+  onGroupDrop(event: CdkDragDrop<AvailableGroup[]>): void {
     if (event.previousIndex === event.currentIndex) return;
     const groups = [...this.groupedTasks()];
     moveItemInArray(groups, event.previousIndex, event.currentIndex);
@@ -157,32 +158,4 @@ export class AvailableTasksComponent {
     const d = this.asDate(value);
     return d ? d.getTime() : Number.POSITIVE_INFINITY;
   }
-}
-
-function applyPreferredOrder<T extends { projectId: string; tasks: readonly unknown[] }>(
-  groups: T[],
-  preferred: string[],
-  fallback: (a: T, b: T) => number = (a, b) => b.tasks.length - a.tasks.length,
-): T[] {
-  if (preferred.length === 0) {
-    return groups.slice().sort(fallback);
-  }
-  const byId = new Map(groups.map((g) => [g.projectId, g] as const));
-  const ordered: T[] = [];
-  const seen = new Set<string>();
-  for (const id of preferred) {
-    const g = byId.get(id);
-    if (g) {
-      ordered.push(g);
-      seen.add(id);
-    }
-  }
-  const leftovers = groups.filter((g) => !seen.has(g.projectId)).sort(fallback);
-  return ordered.concat(leftovers);
-}
-
-function mergeOrders(visible: string[], previous: string[]): string[] {
-  const visibleSet = new Set(visible);
-  const tail = previous.filter((id) => !visibleSet.has(id));
-  return visible.concat(tail);
 }

--- a/src/app/features/my-tasks/components/available-tasks.component.ts
+++ b/src/app/features/my-tasks/components/available-tasks.component.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
+import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 
 import { Project, Task, CYBERPUNK_COLORS } from '../../../core/models/domain.model';
 
@@ -17,6 +18,8 @@ interface AvailableGroup {
   tasks: Task[];
 }
 
+const GROUP_ORDER_STORAGE_KEY = 'omnitask:available:projectGroupOrder';
+
 /**
  * "Pick-up queue" for the My Tasks dashboard. Shows unassigned tasks across
  * every project the user is a member of, grouped by project, with a single
@@ -25,7 +28,7 @@ interface AvailableGroup {
 @Component({
   selector: 'app-available-tasks',
   standalone: true,
-  imports: [CommonModule, DatePipe],
+  imports: [CommonModule, DatePipe, DragDropModule],
   templateUrl: './available-tasks.component.html',
   styleUrls: ['./available-tasks.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -43,6 +46,13 @@ export class AvailableTasksComponent {
    * fast so this is really just to prevent double-clicks.
    */
   claiming = signal<Set<string>>(new Set());
+
+  /**
+   * User-preferred drag-and-drop order for the project-grouped sections.
+   * Persisted in localStorage; absent project IDs fall back to the
+   * tasks-count-descending default.
+   */
+  groupOrder = signal<string[]>(this.loadGroupOrder());
 
   readonly defaultColor = CYBERPUNK_COLORS.TODO;
 
@@ -69,8 +79,38 @@ export class AvailableTasksComponent {
         return this.toMillis(a.dueDate) - this.toMillis(b.dueDate);
       });
     }
-    return Array.from(groups.values()).sort((a, b) => b.tasks.length - a.tasks.length);
+    const ordered = applyPreferredOrder(Array.from(groups.values()), this.groupOrder());
+    return ordered;
   });
+
+  onGroupDrop(event: CdkDragDrop<AvailableGroup[]>) {
+    if (event.previousIndex === event.currentIndex) return;
+    const groups = [...this.groupedTasks()];
+    moveItemInArray(groups, event.previousIndex, event.currentIndex);
+    const visibleIds = groups.map((g) => g.projectId);
+    const next = mergeOrders(visibleIds, this.groupOrder());
+    this.groupOrder.set(next);
+    this.saveGroupOrder(next);
+  }
+
+  private loadGroupOrder(): string[] {
+    try {
+      const raw = globalThis.localStorage?.getItem(GROUP_ORDER_STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private saveGroupOrder(order: string[]): void {
+    try {
+      globalThis.localStorage?.setItem(GROUP_ORDER_STORAGE_KEY, JSON.stringify(order));
+    } catch {
+      // Drag still works for the current session — persistence is a bonus.
+    }
+  }
 
   async onClaim(task: Task) {
     // Optimistically mark as claiming so the button disables immediately.
@@ -117,4 +157,32 @@ export class AvailableTasksComponent {
     const d = this.asDate(value);
     return d ? d.getTime() : Number.POSITIVE_INFINITY;
   }
+}
+
+function applyPreferredOrder<T extends { projectId: string; tasks: readonly unknown[] }>(
+  groups: T[],
+  preferred: string[],
+  fallback: (a: T, b: T) => number = (a, b) => b.tasks.length - a.tasks.length,
+): T[] {
+  if (preferred.length === 0) {
+    return groups.slice().sort(fallback);
+  }
+  const byId = new Map(groups.map((g) => [g.projectId, g] as const));
+  const ordered: T[] = [];
+  const seen = new Set<string>();
+  for (const id of preferred) {
+    const g = byId.get(id);
+    if (g) {
+      ordered.push(g);
+      seen.add(id);
+    }
+  }
+  const leftovers = groups.filter((g) => !seen.has(g.projectId)).sort(fallback);
+  return ordered.concat(leftovers);
+}
+
+function mergeOrders(visible: string[], previous: string[]): string[] {
+  const visibleSet = new Set(visible);
+  const tail = previous.filter((id) => !visibleSet.has(id));
+  return visible.concat(tail);
 }

--- a/src/app/features/my-tasks/components/my-tasks-list.component.css
+++ b/src/app/features/my-tasks/components/my-tasks-list.component.css
@@ -93,3 +93,16 @@
 .mytasks-title-btn:focus {
   outline: none;
 }
+
+/* Drag-and-drop affordances for reordering the project-group "sections". */
+.mytasks-group.cdk-drag-preview {
+  box-shadow: 0 12px 40px rgba(0, 210, 255, 0.35), 0 0 20px rgba(224, 64, 251, 0.25);
+}
+
+.mytasks-group.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.cdk-drop-list-dragging .mytasks-group:not(.cdk-drag-placeholder) {
+  transition: transform 200ms cubic-bezier(0, 0, 0.2, 1);
+}

--- a/src/app/features/my-tasks/components/my-tasks-list.component.html
+++ b/src/app/features/my-tasks/components/my-tasks-list.component.html
@@ -39,10 +39,34 @@
       </button>
     </div>
   } @else {
+    <div
+      cdkDropList
+      [cdkDropListData]="groupedTasks()"
+      (cdkDropListDropped)="onGroupDrop($event)"
+      class="space-y-4"
+    >
     @for (g of groupedTasks(); track g.projectId) {
-      <section class="ofx-panel p-4">
-        <header class="flex items-center justify-between gap-2 mb-3 flex-wrap">
+      <section cdkDrag [cdkDragData]="g" class="ofx-panel p-4 mytasks-group">
+        <div
+          *cdkDragPlaceholder
+          class="ofx-panel p-4 border border-dashed border-violet-500/40 bg-violet-500/5 h-24"
+        ></div>
+        <header
+          cdkDragHandle
+          class="flex items-center justify-between gap-2 mb-3 flex-wrap cursor-grab active:cursor-grabbing select-none"
+          title="Drag to reorder"
+        >
           <div class="flex items-center gap-2 min-w-0">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-3.5 w-3.5 text-slate-500 flex-shrink-0"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
             <span
               class="w-2.5 h-2.5 rounded-sm flex-shrink-0"
               [style.background]="g.projectColor"
@@ -53,7 +77,7 @@
           </div>
           <button
             class="text-[11px] text-violet-400 hover:text-violet-300"
-            (click)="createTaskInProject.emit(g.projectId)"
+            (click)="createTaskInProject.emit(g.projectId); $event.stopPropagation()"
           >
             + Task
           </button>
@@ -114,5 +138,6 @@
         </ul>
       </section>
     }
+    </div>
   }
 </div>

--- a/src/app/features/my-tasks/components/my-tasks-list.component.html
+++ b/src/app/features/my-tasks/components/my-tasks-list.component.html
@@ -53,7 +53,8 @@
         ></div>
         <header
           cdkDragHandle
-          class="flex items-center justify-between gap-2 mb-3 flex-wrap cursor-grab active:cursor-grabbing select-none"
+          class="flex items-center justify-between gap-2 mb-3 flex-wrap select-none
+                 cursor-grab active:cursor-grabbing"
           title="Drag to reorder"
         >
           <div class="flex items-center gap-2 min-w-0">

--- a/src/app/features/my-tasks/components/my-tasks-list.component.ts
+++ b/src/app/features/my-tasks/components/my-tasks-list.component.ts
@@ -10,6 +10,7 @@ import { CommonModule, DatePipe } from '@angular/common';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 
 import { Project, Task, CYBERPUNK_COLORS } from '../../../core/models/domain.model';
+import { applyPreferredOrder, mergeOrders } from '../../../core/utils/order.utils';
 
 type StatusFilter = 'all' | 'open' | 'todo' | 'in-progress' | 'done';
 
@@ -21,45 +22,6 @@ interface TaskGroup {
 }
 
 const GROUP_ORDER_STORAGE_KEY = 'omnitask:myTasks:projectGroupOrder';
-
-/**
- * Reorder `groups` so IDs that appear in `preferred` come first in that
- * relative order, followed by any groups the user hasn't yet positioned,
- * sorted by the `fallback` comparator (default: tasks-count descending).
- */
-function applyPreferredOrder<T extends { projectId: string; tasks: readonly unknown[] }>(
-  groups: T[],
-  preferred: string[],
-  fallback: (a: T, b: T) => number = (a, b) => b.tasks.length - a.tasks.length,
-): T[] {
-  if (preferred.length === 0) {
-    return groups.slice().sort(fallback);
-  }
-  const byId = new Map(groups.map((g) => [g.projectId, g] as const));
-  const ordered: T[] = [];
-  const seen = new Set<string>();
-  for (const id of preferred) {
-    const g = byId.get(id);
-    if (g) {
-      ordered.push(g);
-      seen.add(id);
-    }
-  }
-  const leftovers = groups.filter((g) => !seen.has(g.projectId)).sort(fallback);
-  return ordered.concat(leftovers);
-}
-
-/**
- * Fold the user's new visible-groups order into their stored preference
- * without forgetting IDs that aren't currently on screen (e.g. a project
- * the user filtered out). Visible IDs keep their new positions; absent
- * IDs keep their previous relative order appended at the end.
- */
-function mergeOrders(visible: string[], previous: string[]): string[] {
-  const visibleSet = new Set(visible);
-  const tail = previous.filter((id) => !visibleSet.has(id));
-  return visible.concat(tail);
-}
 
 /**
  * Compact, cross-project list of the user's tasks. Grouped by project so the
@@ -158,7 +120,7 @@ export class MyTasksListComponent {
    * in their new order — unseen projects stay where their old preference
    * (if any) put them so the user's memory of the layout stays stable.
    */
-  onGroupDrop(event: CdkDragDrop<TaskGroup[]>) {
+  onGroupDrop(event: CdkDragDrop<TaskGroup[]>): void {
     if (event.previousIndex === event.currentIndex) return;
     const groups = [...this.groupedTasks()];
     moveItemInArray(groups, event.previousIndex, event.currentIndex);

--- a/src/app/features/my-tasks/components/my-tasks-list.component.ts
+++ b/src/app/features/my-tasks/components/my-tasks-list.component.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
+import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 
 import { Project, Task, CYBERPUNK_COLORS } from '../../../core/models/domain.model';
 
@@ -19,16 +20,57 @@ interface TaskGroup {
   tasks: Task[];
 }
 
+const GROUP_ORDER_STORAGE_KEY = 'omnitask:myTasks:projectGroupOrder';
+
+/**
+ * Reorder `groups` so IDs that appear in `preferred` come first in that
+ * relative order, followed by any groups the user hasn't yet positioned,
+ * sorted by the `fallback` comparator (default: tasks-count descending).
+ */
+function applyPreferredOrder<T extends { projectId: string; tasks: readonly unknown[] }>(
+  groups: T[],
+  preferred: string[],
+  fallback: (a: T, b: T) => number = (a, b) => b.tasks.length - a.tasks.length,
+): T[] {
+  if (preferred.length === 0) {
+    return groups.slice().sort(fallback);
+  }
+  const byId = new Map(groups.map((g) => [g.projectId, g] as const));
+  const ordered: T[] = [];
+  const seen = new Set<string>();
+  for (const id of preferred) {
+    const g = byId.get(id);
+    if (g) {
+      ordered.push(g);
+      seen.add(id);
+    }
+  }
+  const leftovers = groups.filter((g) => !seen.has(g.projectId)).sort(fallback);
+  return ordered.concat(leftovers);
+}
+
+/**
+ * Fold the user's new visible-groups order into their stored preference
+ * without forgetting IDs that aren't currently on screen (e.g. a project
+ * the user filtered out). Visible IDs keep their new positions; absent
+ * IDs keep their previous relative order appended at the end.
+ */
+function mergeOrders(visible: string[], previous: string[]): string[] {
+  const visibleSet = new Set(visible);
+  const tail = previous.filter((id) => !visibleSet.has(id));
+  return visible.concat(tail);
+}
+
 /**
  * Compact, cross-project list of the user's tasks. Grouped by project so the
- * user can see at a glance where their workload sits. Unlike the project
- * dashboard's list view, we don't drag/drop here — the focus is on triage
- * (mark done, open detail).
+ * user can see at a glance where their workload sits. Groups ("sections")
+ * are reorderable via drag-and-drop on the header, and the preferred order
+ * is persisted per-browser so the layout sticks across sessions.
  */
 @Component({
   selector: 'app-my-tasks-list',
   standalone: true,
-  imports: [CommonModule, DatePipe],
+  imports: [CommonModule, DatePipe, DragDropModule],
   templateUrl: './my-tasks-list.component.html',
   styleUrls: ['./my-tasks-list.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -47,6 +89,13 @@ export class MyTasksListComponent {
 
   /** Text filter applied across title + project name. Empty means no filter. */
   search = signal('');
+
+  /**
+   * User-preferred order for the project-grouped "sections". Persisted in
+   * localStorage and consulted when computing `groupedTasks`. Project IDs
+   * not present here fall to the natural order (tasks-count descending).
+   */
+  groupOrder = signal<string[]>(this.loadGroupOrder());
 
   readonly defaultColor = CYBERPUNK_COLORS.TODO;
 
@@ -82,7 +131,9 @@ export class MyTasksListComponent {
   /**
    * Group filtered tasks by project. Projects with no matching tasks are
    * dropped from the view entirely so the list doesn't show empty sections.
-   * Order: most tasks first so the user's busy projects surface at the top.
+   * Order: the user's saved drag-and-drop preference first (for IDs we
+   * recognise), then remaining groups by tasks-count descending so busy
+   * projects bubble up until the user drags them somewhere else.
    */
   groupedTasks = computed<TaskGroup[]>(() => {
     const projects = this.projectsById();
@@ -98,8 +149,44 @@ export class MyTasksListComponent {
       existing.tasks.push(t);
       groups.set(t.projectId, existing);
     }
-    return Array.from(groups.values()).sort((a, b) => b.tasks.length - a.tasks.length);
+    return applyPreferredOrder(Array.from(groups.values()), this.groupOrder());
   });
+
+  /**
+   * Persist a new project-group ordering after the user drops a section
+   * into a new slot. We record the IDs of the currently-visible groups
+   * in their new order — unseen projects stay where their old preference
+   * (if any) put them so the user's memory of the layout stays stable.
+   */
+  onGroupDrop(event: CdkDragDrop<TaskGroup[]>) {
+    if (event.previousIndex === event.currentIndex) return;
+    const groups = [...this.groupedTasks()];
+    moveItemInArray(groups, event.previousIndex, event.currentIndex);
+    const visibleIds = groups.map((g) => g.projectId);
+    const next = mergeOrders(visibleIds, this.groupOrder());
+    this.groupOrder.set(next);
+    this.saveGroupOrder(next);
+  }
+
+  private loadGroupOrder(): string[] {
+    try {
+      const raw = globalThis.localStorage?.getItem(GROUP_ORDER_STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private saveGroupOrder(order: string[]): void {
+    try {
+      globalThis.localStorage?.setItem(GROUP_ORDER_STORAGE_KEY, JSON.stringify(order));
+    } catch {
+      // localStorage may be unavailable (private mode, quota, SSR). Drag
+      // still works for the current session — persistence is a bonus.
+    }
+  }
 
   setFilter(f: StatusFilter) {
     this.statusFilter.set(f);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1448,6 +1448,7 @@ textarea:focus {
 
 [data-scramble] {
   cursor: default;
+  position: relative;
 }
 
 [data-scramble].is-scrambling {
@@ -1456,6 +1457,32 @@ textarea:focus {
 
 [data-scramble].is-scrambling span {
   font-family: inherit;
+}
+
+/* Overlay the scrambler mutates so the element's real (framework-managed)
+   text node stays intact and keeps receiving updates across hovers. */
+[data-scramble] > .scramble-overlay {
+  position: absolute;
+  inset: 0;
+  display: block;
+  pointer-events: none;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-shadow: inherit;
+  white-space: inherit;
+}
+
+[data-scramble] > .scramble-overlay:empty {
+  display: none;
+}
+
+/* Hide the original text only while the overlay is actively animating.
+   Using color: transparent (rather than visibility) keeps the element's
+   layout box identical before/during/after the scramble. */
+[data-scramble].is-scrambling {
+  color: transparent !important;
+  text-shadow: none !important;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
This PR adds drag-and-drop functionality to reorder project-grouped task sections in the "My Tasks" and "Available Tasks" views, with the user's preferred ordering persisted to localStorage across browser sessions.

## Key Changes

- **Drag-and-drop reordering**: Both `MyTasksListComponent` and `AvailableTasksComponent` now support dragging section headers to reorder project groups. The CDK drag-drop module is integrated with visual feedback (glowing shadow on drag preview, dashed placeholder).

- **Order persistence**: User preferences are saved to localStorage under component-specific keys (`omnitask:myTasks:projectGroupOrder` and `omnitask:available:projectGroupOrder`). The ordering is restored on page load and updated whenever groups are reordered.

- **Smart order merging**: New utility functions `applyPreferredOrder()` and `mergeOrders()` ensure that:
  - Visible groups appear first in the user's preferred order
  - Groups not currently visible (e.g., filtered out) retain their previous relative position
  - New groups fall back to the default sort (task count descending)

- **Text scrambler overlay refactor**: The text-scrambler animation now renders into a dedicated `<span class="scramble-overlay">` sibling element instead of mutating the element's `innerText`. This preserves Angular's text node bindings so dynamic content updates continue to work after hover animations complete.

- **UI enhancements**:
  - Added drag handle icon (≡) to section headers with visual cursor feedback (`cursor-grab` / `cursor-grabbing`)
  - Added `title="Drag to reorder"` tooltip on headers
  - Prevented event propagation on the "+ Task" button to avoid triggering drag during clicks
  - Added CSS styling for drag preview (cyan/magenta glow) and smooth transitions during reordering

- **Accessibility**: Overlay elements are marked with `aria-hidden="true"` and the scrambler respects computed text styles (color, text-shadow) to maintain visual consistency during animations.

## Implementation Details

- Both components share identical `applyPreferredOrder()` and `mergeOrders()` utility functions (duplicated in both files for now; could be extracted to a shared utility in future refactoring)
- localStorage access is wrapped in try-catch to gracefully handle unavailable storage (private mode, quota exceeded, SSR environments)
- The drag-drop list wraps all group sections and uses `cdkDropList` / `cdkDrag` / `cdkDragHandle` directives
- Text scrambler now uses `textExcludingOverlay()` helper to read the "real" text content while ignoring the animation overlay

https://claude.ai/code/session_01DaaUmQT4gymHU7pEVAWrUc