### PR TITLE
fix: override dashboard project title margin-top and fix MCP json parsing

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,8 +1,5 @@
 {
-  // Comprehensive MCP Server configuration for OmniTask (Angular 21 / Firebase / GCP)
-  "mcpServers": {
-    // Cleaned out unused/duplicate workspace servers to avoid 100-tool limit
-  },
+  "mcpServers": {},
   "inputs": [
     {
       "id": "github_token",

--- a/src/app/features/dashboard/components/dashboard-header.css
+++ b/src/app/features/dashboard/components/dashboard-header.css
@@ -1,0 +1,3 @@
+.dashboard-project-title {
+  margin-top: 0.65em !important;
+}

--- a/src/app/features/dashboard/components/dashboard-header.html
+++ b/src/app/features/dashboard/components/dashboard-header.html
@@ -19,7 +19,7 @@
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-4">
             <h1
-              class="text-xl font-bold flex items-center gap-2 leading-none mt-[0.65em]"
+              class="text-xl font-bold flex items-center gap-2 leading-none dashboard-project-title"
               [style.color]="project.color || defaultColor"
               [style.text-shadow]="'0 0 10px ' + getColorWithOpacity(project.color, 0.5)"
             >

--- a/src/app/features/dashboard/components/dashboard-header.ts
+++ b/src/app/features/dashboard/components/dashboard-header.ts
@@ -11,6 +11,7 @@ import { ProjectIconComponent } from '../../projects/components/project-icon.com
   standalone: true,
   imports: [CommonModule, RouterLink, ProjectIconComponent],
   templateUrl: './dashboard-header.html',
+  styleUrl: './dashboard-header.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DashboardHeaderComponent {


### PR DESCRIPTION
1. Removed inline Tailwind !important override for dashboard header title.
2. Extracted style to component-specific CSS using a custom class to correctly override global styles.
3. Linked the component CSS file via styleUrl in the component TS.
4. Fixed JSON parsing error in MCP configuration file by removing invalid comments.