### PR TITLE
Remove data-scramble attributes from UI elements

### DIFF
--- a/src/app/core/theme/glitch-fx.ts
+++ b/src/app/core/theme/glitch-fx.ts
@@ -19,12 +19,16 @@
 import { PowerGlitch } from 'powerglitch';
 import { bindScramble } from './text-scrambler';
 
+// `shake: false` disables the whole-element translate animation that
+// read as an "earthquake" on hover. The slice (chromatic-aberration
+// band displacement) is what actually sells the glitch look, so we
+// keep that. `iterations: 1` + `playMode: 'hover'` means one run per
+// mouseenter — it does not loop while the cursor sits on the element.
 const POWERGLITCH_CONFIG = {
   playMode: 'hover' as const,
   createContainers: true,
   hideOverflow: false,
   timing: {
-    // ~2x snappier than the demo default.
     duration: 400,
     iterations: 1,
   },
@@ -32,18 +36,12 @@ const POWERGLITCH_CONFIG = {
     start: 0,
     end: 0.6,
   },
-  shake: {
-    velocity: 15,
-    amplitudeX: 0.08,
-    amplitudeY: 0.08,
-  },
+  shake: false as const,
   slice: {
     count: 3,
     velocity: 18,
     minHeight: 0.05,
     maxHeight: 0.15,
-    // Keep the element's native palette — no rainbow hue rotation, so
-    // a rose/amber/cyan button stays rose/amber/cyan while it slices.
     hueRotate: false,
   },
 };

--- a/src/app/core/theme/glitch-fx.ts
+++ b/src/app/core/theme/glitch-fx.ts
@@ -29,6 +29,7 @@ const POWERGLITCH_CONFIG = {
   createContainers: true,
   hideOverflow: false,
   timing: {
+    // ~2x snappier than the demo default.
     duration: 400,
     iterations: 1,
   },
@@ -42,6 +43,8 @@ const POWERGLITCH_CONFIG = {
     velocity: 18,
     minHeight: 0.05,
     maxHeight: 0.15,
+    // Keep the element's native palette — no rainbow hue rotation, so
+    // a rose/amber/cyan button stays rose/amber/cyan while it slices.
     hueRotate: false,
   },
 };

--- a/src/app/core/theme/text-scrambler.ts
+++ b/src/app/core/theme/text-scrambler.ts
@@ -120,8 +120,8 @@ function textExcludingOverlay(el: HTMLElement, overlay: HTMLElement): string {
  * Wire a single element for scramble-on-hover. Idempotent — the
  * `data-scramble-bound` sentinel prevents double-binding when the
  * MutationObserver re-scans. The scramble only fires once per page
- * load per element: after the first successful run, the mouseenter
- * listener unbinds itself so the decode does not repeat.
+ * load per element: on the first hover, the mouseenter listener
+ * unbinds itself so the decode does not repeat.
  */
 export function bindScramble(el: HTMLElement): void {
   if (el.dataset['scrambleBound'] === 'true') return;
@@ -137,11 +137,8 @@ export function bindScramble(el: HTMLElement): void {
   el.appendChild(overlay);
 
   const scrambler = new TextScrambler(overlay);
-  let hasPlayed = false;
 
-  const onEnter = () => {
-    if (hasPlayed) return;
-    hasPlayed = true;
+  const onEnter = (): void => {
     el.removeEventListener('mouseenter', onEnter);
 
     // Fresh read: picks up edited text without extra plumbing, and

--- a/src/app/core/theme/text-scrambler.ts
+++ b/src/app/core/theme/text-scrambler.ts
@@ -119,7 +119,9 @@ function textExcludingOverlay(el: HTMLElement, overlay: HTMLElement): string {
 /**
  * Wire a single element for scramble-on-hover. Idempotent — the
  * `data-scramble-bound` sentinel prevents double-binding when the
- * MutationObserver re-scans.
+ * MutationObserver re-scans. The scramble only fires once per page
+ * load per element: after the first successful run, the mouseenter
+ * listener unbinds itself so the decode does not repeat.
  */
 export function bindScramble(el: HTMLElement): void {
   if (el.dataset['scrambleBound'] === 'true') return;
@@ -135,11 +137,12 @@ export function bindScramble(el: HTMLElement): void {
   el.appendChild(overlay);
 
   const scrambler = new TextScrambler(overlay);
-  let isScrambling = false;
+  let hasPlayed = false;
 
-  el.addEventListener('mouseenter', () => {
-    if (isScrambling) return;
-    isScrambling = true;
+  const onEnter = () => {
+    if (hasPlayed) return;
+    hasPlayed = true;
+    el.removeEventListener('mouseenter', onEnter);
 
     // Fresh read: picks up edited text without extra plumbing, and
     // deliberately excludes the (empty) overlay.
@@ -186,7 +189,8 @@ export function bindScramble(el: HTMLElement): void {
         el.classList.remove('is-scrambling');
         el.style.minWidth = originalMinWidth;
         el.style.display = originalDisplay;
-        isScrambling = false;
       });
-  });
+  };
+
+  el.addEventListener('mouseenter', onEnter);
 }

--- a/src/app/features/dashboard/components/dashboard-header.html
+++ b/src/app/features/dashboard/components/dashboard-header.html
@@ -23,7 +23,7 @@
               [style.color]="project.color || defaultColor"
               [style.text-shadow]="'0 0 10px ' + getColorWithOpacity(project.color, 0.5)"
             >
-              <span data-scramble>{{ project.name }}</span>
+              <span>{{ project.name }}</span>
             </h1>
 
             <div class="flex items-center gap-2">

--- a/src/app/features/dashboard/components/project-overview.component.html
+++ b/src/app/features/dashboard/components/project-overview.component.html
@@ -20,7 +20,7 @@
             [style.color]="proj.color || defaultColor"
             [style.text-shadow]="'0 0 12px ' + accent(0.55)"
           >
-            <span data-scramble>{{ proj.name }}</span>
+            <span>{{ proj.name }}</span>
           </h2>
           @if (proj.status === 'archived') {
             <span class="ofx-chip bg-gray-700/50 text-gray-300">Archived</span>
@@ -135,7 +135,7 @@
   <section class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
     <!-- Status donut -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">Status Breakdown</h3>
+      <h3 class="ofx-section-title mb-4">Status Breakdown</h3>
       @if (total === 0) {
         <p class="text-slate-500 text-sm py-6 text-center">No tasks yet.</p>
       } @else {
@@ -175,7 +175,7 @@
 
     <!-- Completion gauge -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">Completion</h3>
+      <h3 class="ofx-section-title mb-4">Completion</h3>
       <div class="flex flex-col items-center justify-center py-2">
         <div class="gauge-number text-cyber-gradient">{{ pct }}<span class="text-2xl">%</span></div>
         <div class="w-full mt-4 h-3 rounded-full overflow-hidden border border-white/10 bg-slate-900/60">
@@ -197,7 +197,7 @@
 
     <!-- Priority bars -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">Priority Distribution</h3>
+      <h3 class="ofx-section-title mb-4">Priority Distribution</h3>
       @if (total === 0) {
         <p class="text-slate-500 text-sm py-6 text-center">No tasks yet.</p>
       } @else {
@@ -231,7 +231,7 @@
     <!-- Sections progress -->
     <div class="ofx-panel p-5 lg:col-span-2">
       <div class="flex items-center justify-between mb-4">
-        <h3 data-scramble class="ofx-section-title">Sections</h3>
+        <h3 class="ofx-section-title">Sections</h3>
         <button
           class="omni-glitch-btn text-xs text-cyan-400 hover:text-cyan-300"
           (click)="viewModeChange.emit('board')"
@@ -281,7 +281,7 @@
 
     <!-- Tag cloud -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">Tags in use</h3>
+      <h3 class="ofx-section-title mb-4">Tags in use</h3>
       @if (!tagStats().length) {
         <p class="text-slate-500 text-sm py-6 text-center">No tags defined yet.</p>
       } @else {
@@ -308,7 +308,7 @@
   <section class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
     <!-- Upcoming deadlines -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">Upcoming deadlines</h3>
+      <h3 class="ofx-section-title mb-4">Upcoming deadlines</h3>
       @if (!upcomingTasks().length) {
         <p class="text-slate-500 text-sm py-6 text-center">Nothing scheduled.</p>
       } @else {
@@ -342,7 +342,7 @@
 
     <!-- Recent activity -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">Recent activity</h3>
+      <h3 class="ofx-section-title mb-4">Recent activity</h3>
       @if (!recentActivity().length) {
         <p class="text-slate-500 text-sm py-6 text-center">No activity yet.</p>
       } @else {
@@ -380,7 +380,7 @@
     <!-- Top assignees -->
     <div class="ofx-panel p-5">
       <div class="flex items-center justify-between mb-4">
-        <h3 data-scramble class="ofx-section-title">Top assignees</h3>
+        <h3 class="ofx-section-title">Top assignees</h3>
         <button
           class="omni-glitch-btn text-xs text-cyan-400 hover:text-cyan-300"
           (click)="togglePanel('members')"
@@ -429,7 +429,7 @@
   <!-- Management: tabbed managers -->
   <section class="ofx-panel p-5 mb-6">
     <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
-      <h3 data-scramble class="ofx-section-title">Manage project structure</h3>
+      <h3 class="ofx-section-title">Manage project structure</h3>
       <div class="flex flex-wrap gap-2">
         <button
           class="omni-glitch-btn manage-tab"

--- a/src/app/features/my-tasks/components/available-tasks.component.html
+++ b/src/app/features/my-tasks/components/available-tasks.component.html
@@ -2,7 +2,7 @@
   <header class="ofx-panel p-4 flex items-start justify-between gap-3 flex-wrap">
     <div>
       <h3 class="text-sm font-bold text-slate-100">
-        <span data-scramble>Available to pick up</span>
+        <span>Available to pick up</span>
       </h3>
       <p class="text-xs text-slate-400 mt-1 max-w-prose">
         Unassigned tasks across projects you're part of. Claim one to add it to your queue.

--- a/src/app/features/my-tasks/components/my-tasks-overview.component.html
+++ b/src/app/features/my-tasks/components/my-tasks-overview.component.html
@@ -24,7 +24,7 @@
       <div class="flex-1 min-w-0">
         <div class="flex flex-wrap items-center gap-2">
           <h2 class="text-2xl font-black text-white truncate">
-            <span data-scramble>{{ u?.displayName || u?.email || 'My workspace' }}</span>
+            <span>{{ u?.displayName || u?.email || 'My workspace' }}</span>
           </h2>
           <span class="cyber-badge">You</span>
           @if (u?.role === 'admin') {
@@ -115,7 +115,7 @@
   <section class="grid grid-cols-1 lg:grid-cols-3 gap-6">
     <!-- Status breakdown -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">My Status Breakdown</h3>
+      <h3 class="ofx-section-title mb-4">My Status Breakdown</h3>
       @if (counts.total === 0) {
         <p class="text-slate-500 text-sm py-6 text-center">
           No tasks yet. Click "+ Add task to my queue" to get going.
@@ -157,7 +157,7 @@
 
     <!-- Completion gauge -->
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">My Completion</h3>
+      <h3 class="ofx-section-title mb-4">My Completion</h3>
       <div class="flex flex-col items-center justify-center py-2">
         <div class="mt-gauge-number text-cyber-gradient">{{ completionPct() }}<span class="text-2xl">%</span></div>
         <div class="w-full mt-4 h-3 rounded-full overflow-hidden border border-white/10 bg-slate-900/60">
@@ -177,7 +177,7 @@
     <!-- Who I report to -->
     <div class="ofx-panel p-5">
       <div class="flex items-center justify-between mb-4">
-        <h3 data-scramble class="ofx-section-title">Who I report to</h3>
+        <h3 class="ofx-section-title">Who I report to</h3>
         @if (!editingReportsTo()) {
           <button class="text-xs text-cyan-400 hover:text-cyan-300" (click)="startEditReportsTo()">
             {{ u?.reportsToId ? 'Edit' : 'Set' }}
@@ -249,7 +249,7 @@
   <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
     <div class="ofx-panel p-5">
       <div class="flex items-center justify-between mb-4">
-        <h3 data-scramble class="ofx-section-title">Upcoming deadlines</h3>
+        <h3 class="ofx-section-title">Upcoming deadlines</h3>
         <button class="text-xs text-cyan-400 hover:text-cyan-300" (click)="viewChange.emit('list')">View all →</button>
       </div>
       @if (!upcomingTasks().length) {
@@ -279,7 +279,7 @@
     </div>
 
     <div class="ofx-panel p-5">
-      <h3 data-scramble class="ofx-section-title mb-4">Recently completed</h3>
+      <h3 class="ofx-section-title mb-4">Recently completed</h3>
       @if (!recentlyCompleted().length) {
         <p class="text-slate-500 text-sm py-6 text-center">Nothing completed yet — stay hungry.</p>
       } @else {
@@ -303,7 +303,7 @@
   <!-- Row: projects I'm part of -->
   <section class="ofx-panel p-5">
     <div class="flex items-center justify-between mb-4 flex-wrap gap-2">
-      <h3 data-scramble class="ofx-section-title">My Projects &amp; Contributions</h3>
+      <h3 class="ofx-section-title">My Projects &amp; Contributions</h3>
       <span class="text-[11px] text-slate-500 uppercase tracking-wider font-semibold">
         {{ activeProjects().length }} active · {{ archivedProjects().length }} archived
       </span>

--- a/src/app/features/projects/project-detail.component.html
+++ b/src/app/features/projects/project-detail.component.html
@@ -45,7 +45,7 @@
                 </div>
                 <div>
                   <h1 class="text-xl font-bold text-white flex items-center gap-2">
-                    <span data-scramble>{{ project.name }}</span>
+                    <span>{{ project.name }}</span>
                     @if (project.status === 'archived') {
                       <span
                         class="px-2 py-0.5 text-[10px] uppercase font-bold tracking-wider bg-amber-500/20 text-amber-500 rounded-full border border-amber-500/20"
@@ -148,7 +148,7 @@
               >
                 <!-- Stats -->
                 <section>
-                  <h2 data-scramble class="text-lg font-semibold text-white mb-4">Project Status</h2>
+                  <h2 class="text-lg font-semibold text-white mb-4">Project Status</h2>
                   <app-project-stats-card [tasks]="tasks()"></app-project-stats-card>
                 </section>
 
@@ -157,7 +157,7 @@
                   <div class="lg:col-span-2 space-y-6">
                     <!-- Description Card -->
                     <section class="bg-slate-900/50 rounded-xl border border-white/5 p-6">
-                      <h3 data-scramble class="text-sm font-semibold text-slate-200 mb-3">About this project</h3>
+                      <h3 class="text-sm font-semibold text-slate-200 mb-3">About this project</h3>
                       @if (project.description) {
                         <p class="text-slate-400 leading-relaxed">{{ project.description }}</p>
                       } @else {
@@ -182,7 +182,7 @@
                   <div class="space-y-6">
                     <!-- Mini Team Card -->
                     <section class="bg-slate-900/50 rounded-xl border border-white/5 p-6">
-                      <h3 data-scramble class="text-sm font-semibold text-slate-200 mb-3">Team</h3>
+                      <h3 class="text-sm font-semibold text-slate-200 mb-3">Team</h3>
                       <div class="flex -space-x-2 overflow-hidden py-1">
                         <!-- Placeholder since we don't have user profiles yet -->
                         <div
@@ -205,7 +205,7 @@
                 <!-- Project Tasks (full list) -->
                 <section>
                   <div class="flex items-center justify-between mb-4">
-                    <h2 data-scramble class="text-lg font-semibold text-white">Tasks</h2>
+                    <h2 class="text-lg font-semibold text-white">Tasks</h2>
                     <button
                       class="omni-glitch-btn ofx-neon-button text-sm px-4 py-2"
                       (click)="openCreateTaskModal()"

--- a/src/app/features/projects/project-form-modal.component.html
+++ b/src/app/features/projects/project-form-modal.component.html
@@ -4,7 +4,7 @@
 >
   <div class="ofx-modal" (click)="$event.stopPropagation()">
     <header class="ofx-modal-header">
-      <h2 data-scramble class="text-xl font-bold text-white">
+      <h2 class="text-xl font-bold text-white">
         {{ editProject() ? 'Edit Project' : 'New Project' }}
       </h2>
       <button class="ofx-icon-button" (click)="close.emit()">

--- a/src/app/features/projects/projects-list.component.html
+++ b/src/app/features/projects/projects-list.component.html
@@ -78,7 +78,6 @@
               <!-- Project Info -->
               <div class="mt-2">
                 <h3
-                  data-scramble
                   class="text-lg font-bold text-white mb-1 group-hover:text-cyan-400 transition-colors"
                 >
                   {{ project.name }}

--- a/src/app/features/projects/projects-list.component.html
+++ b/src/app/features/projects/projects-list.component.html
@@ -65,7 +65,6 @@
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           @for (project of filteredProjects(); track project.id) {
             <div
-              data-fx-glitch-hover
               class="group relative bg-slate-900/80 border border-white/10 rounded-xl p-5 hover:border-cyan-500/40 transition-all duration-300 hover:shadow-lg hover:shadow-cyan-500/20 cursor-pointer"
               (click)="openProject(project)"
             >

--- a/src/app/features/settings/settings.component.html
+++ b/src/app/features/settings/settings.component.html
@@ -21,7 +21,7 @@
                 clip-rule="evenodd"
               />
             </svg>
-            <span data-scramble>Profile</span>
+            <span>Profile</span>
           </h2>
 
           <!-- Current Avatar Preview + Upload -->
@@ -206,7 +206,7 @@
                 clip-rule="evenodd"
               />
             </svg>
-            <span data-scramble>Account Information</span>
+            <span>Account Information</span>
           </h2>
           <div class="space-y-3 text-sm">
             <div class="flex justify-between">

--- a/src/app/features/tasks/task-board-view.component.html
+++ b/src/app/features/tasks/task-board-view.component.html
@@ -498,7 +498,7 @@
                           : 'none'
                       "
                     >
-                      <span data-scramble>{{ task.title }}</span>
+                      <span>{{ task.title }}</span>
                       @if (task.googleTaskId) {
                         <svg
                           xmlns="http://www.w3.org/2000/svg"

--- a/src/app/shared/components/dialog.component.html
+++ b/src/app/shared/components/dialog.component.html
@@ -18,7 +18,7 @@
                 'bg-amber-600/15': dialogService.dialog().type === 'warning',
               }"
             >
-              <h3 data-scramble class="text-lg font-semibold text-white">
+              <h3 class="text-lg font-semibold text-white">
                 {{ dialogService.dialog().title }}
               </h3>
             </div>


### PR DESCRIPTION
## Summary
This PR removes the `data-scramble` attribute from various UI elements across the application, effectively disabling the text scramble-on-hover animation for most heading and title elements while keeping the underlying scrambler infrastructure intact.

## Key Changes
- **Removed `data-scramble` attributes** from 30+ heading elements across multiple components:
  - Project names in dashboard and project detail views
  - Section titles (Status Breakdown, Completion, Priority Distribution, etc.)
  - Panel headers (Tags, Deadlines, Activity, Assignees, etc.)
  - Modal and dialog titles
  - Settings page section headers
  - Task board titles

- **Updated text-scrambler.ts** to improve scramble behavior:
  - Changed from repeating scramble animation to single-play-per-page-load
  - Renamed `isScrambling` flag to `hasPlayed` for clarity
  - Added `removeEventListener` call after first animation to prevent re-triggering
  - Updated JSDoc comments to document the new single-play behavior

- **Simplified glitch-fx.ts configuration**:
  - Disabled shake animation (`shake: false`) to remove the "earthquake" effect
  - Kept slice/chromatic-aberration effect for visual glitch appearance
  - Removed velocity and amplitude shake parameters
  - Added clarifying comments about the configuration choices

## Implementation Details
The changes preserve the scrambler binding infrastructure but effectively disable the animation for most UI elements by removing the `data-scramble` attribute. Elements without this attribute won't trigger the scramble animation even if the `bindScramble()` function is called on them. The scrambler still exists in the codebase for potential future use or for any remaining elements that might have the attribute.

The text-scrambler now implements a "fire-once" pattern where the animation plays exactly once per page load per element, then unbinds the event listener to prevent repeated animations on subsequent hovers.

https://claude.ai/code/session_014hFiX3Xw1kzCJZKyTHVQam