### PR TITLE
Add user groups feature for bulk user assignment

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -209,8 +209,9 @@ service cloud.firestore {
         isAdmin() || isSuperAdmin()
       );
 
-      // The creator must be the signed-in user. Admin/super-admin bypass is
-      // intentional for seed scripts and support tooling.
+      // The creator must be the signed-in user — groups are always self-owned
+      // at creation time. Admins that need to reassign ownership can do so via
+      // the update path, which permits admins/super-admins to rewrite any field.
       allow create: if isAuthenticated() &&
         request.resource.data.ownerId == request.auth.uid;
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -198,6 +198,29 @@ service cloud.firestore {
       allow delete: if isSuperAdmin();
     }
 
+    // User groups - reusable collections of users that can be applied to
+    // projects, tasks, and other assignment targets.
+    match /userGroups/{groupId} {
+      // Any authenticated user can read shared groups or groups they own.
+      // Admins/super-admins can read everything.
+      allow read: if isAuthenticated() && (
+        resource.data.ownerId == request.auth.uid ||
+        resource.data.get('shared', true) == true ||
+        isAdmin() || isSuperAdmin()
+      );
+
+      // The creator must be the signed-in user. Admin/super-admin bypass is
+      // intentional for seed scripts and support tooling.
+      allow create: if isAuthenticated() &&
+        request.resource.data.ownerId == request.auth.uid;
+
+      // Only the owner (or admins/super-admins) can mutate a group.
+      allow update, delete: if isAuthenticated() && (
+        resource.data.ownerId == request.auth.uid ||
+        isAdmin() || isSuperAdmin()
+      );
+    }
+
     // Notifications - written by Cloud Functions, readable by recipient
     match /notifications/{notificationId} {
       // Cloud Functions uses admin SDK (bypasses rules)

--- a/src/app/core/models/user-group.model.ts
+++ b/src/app/core/models/user-group.model.ts
@@ -1,0 +1,48 @@
+import { Timestamp } from '@angular/fire/firestore';
+
+type FirestoreDate = Timestamp | Date;
+
+/**
+ * Cached details for a group member, used to render the group in the UI
+ * without having to re-fetch every contact. The canonical identifier is
+ * {@link id} which is a {@link Contact.id} — either a UID (for authenticated
+ * app users) or an email address (for Google Directory / preset contacts).
+ */
+export interface UserGroupMember {
+  id: string;
+  email: string;
+  displayName: string;
+  photoURL?: string;
+}
+
+/**
+ * A named collection of users that can be invoked to bulk-assign people to
+ * a project, a task, or anywhere an individual user can be referenced.
+ *
+ * Groups are lightweight references — they expand into their member IDs at
+ * assignment time rather than being stored on the target entity. This
+ * preserves the existing shape of {@link Project.memberIds} and
+ * {@link Task.assigneeIds} while letting the UI apply a whole group in one
+ * click.
+ */
+export interface UserGroup {
+  id: string;
+  name: string;
+  description?: string;
+  /** Accent color for group chips in the UI. */
+  color?: string;
+  /** Canonical list of member IDs (Contact.id) ready for assignment. */
+  memberIds: string[];
+  /** Cached member details for display — kept in sync on add/remove. */
+  members: UserGroupMember[];
+  /** UID of the user who created the group. */
+  ownerId: string;
+  /**
+   * When true, every authenticated user can read and apply this group.
+   * When false, only the owner (and admins/super-admins) can see it.
+   * Defaults to true so teams get a shared namespace by default.
+   */
+  shared: boolean;
+  createdAt: FirestoreDate;
+  updatedAt: FirestoreDate;
+}

--- a/src/app/core/services/user-group.service.ts
+++ b/src/app/core/services/user-group.service.ts
@@ -93,9 +93,8 @@ export class UserGroupService {
       const ref = await addDoc(this.groupsCollection, payload);
       return ref.id;
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to create group';
-      console.error(message, err);
-      this.error.set(message);
+      console.error('Failed to create group:', err);
+      this.error.set('Failed to create group. Please try again.');
       throw err;
     } finally {
       this.loading.set(false);

--- a/src/app/core/services/user-group.service.ts
+++ b/src/app/core/services/user-group.service.ts
@@ -24,11 +24,11 @@ import { UserGroup, UserGroupMember } from '../models/user-group.model';
  */
 @Injectable({ providedIn: 'root' })
 export class UserGroupService {
-  private firestore = inject(Firestore);
-  private auth = inject(AuthService);
-  private injector = inject(Injector);
+  private readonly firestore = inject(Firestore);
+  private readonly auth = inject(AuthService);
+  private readonly injector = inject(Injector);
 
-  private groupsCollection = collection(this.firestore, 'userGroups');
+  private readonly groupsCollection = collection(this.firestore, 'userGroups');
 
   loading = signal(false);
   error = signal<string | null>(null);
@@ -153,7 +153,7 @@ export class UserGroupService {
       if (!m?.id) continue;
       if (!seen.has(m.id)) seen.set(m.id, m);
     }
-    return Array.from(seen.values()).sort((a, b) =>
+    return [...seen.values()].sort((a, b) =>
       (a.displayName || a.email || '').localeCompare(b.displayName || b.email || ''),
     );
   }

--- a/src/app/core/services/user-group.service.ts
+++ b/src/app/core/services/user-group.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, inject, signal, Injector, runInInjectionContext } from '@angular/core';
+import {
+  Firestore,
+  collection,
+  addDoc,
+  doc,
+  updateDoc,
+  deleteDoc,
+  getDoc,
+  query,
+  where,
+  or,
+  collectionData,
+  Timestamp,
+} from '@angular/fire/firestore';
+import { Observable, of, switchMap, map } from 'rxjs';
+import { AuthService } from '../auth/auth.service';
+import { UserGroup, UserGroupMember } from '../models/user-group.model';
+
+/**
+ * CRUD for user groups. Groups are lightweight saved selections that can be
+ * applied to anywhere the app accepts a list of assignees (project members,
+ * task assignees, and so on).
+ */
+@Injectable({ providedIn: 'root' })
+export class UserGroupService {
+  private firestore = inject(Firestore);
+  private auth = inject(AuthService);
+  private injector = inject(Injector);
+
+  private groupsCollection = collection(this.firestore, 'userGroups');
+
+  loading = signal(false);
+  error = signal<string | null>(null);
+
+  /**
+   * Groups visible to the current user: groups they own plus any group
+   * marked as shared. Sorted alphabetically.
+   */
+  getMyGroups(): Observable<UserGroup[]> {
+    return this.auth.user$.pipe(
+      switchMap((user) => {
+        if (!user) return of([] as UserGroup[]);
+        const q = query(
+          this.groupsCollection,
+          or(where('ownerId', '==', user.uid), where('shared', '==', true)),
+        );
+        return runInInjectionContext(this.injector, () => {
+          return collectionData(q, { idField: 'id' }) as Observable<UserGroup[]>;
+        });
+      }),
+      map((groups) => groups.sort((a, b) => a.name.localeCompare(b.name))),
+    );
+  }
+
+  async getGroup(id: string): Promise<UserGroup | null> {
+    try {
+      const ref = doc(this.firestore, `userGroups/${id}`);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) return null;
+      return { id: snap.id, ...(snap.data() as Omit<UserGroup, 'id'>) };
+    } catch (err) {
+      console.error('Failed to fetch group:', err);
+      return null;
+    }
+  }
+
+  async createGroup(
+    name: string,
+    members: UserGroupMember[] = [],
+    options: { description?: string; color?: string; shared?: boolean } = {},
+  ): Promise<string> {
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const user = this.auth.currentUserSig();
+      if (!user) throw new Error('Not authenticated');
+      const trimmed = name.trim();
+      if (!trimmed) throw new Error('Group name cannot be empty');
+
+      const dedupedMembers = this.dedupeMembers(members);
+      const payload: Omit<UserGroup, 'id'> = {
+        name: trimmed,
+        description: options.description?.trim() || '',
+        color: options.color || '#8b5cf6',
+        memberIds: dedupedMembers.map((m) => m.id),
+        members: dedupedMembers,
+        ownerId: user.uid,
+        shared: options.shared ?? true,
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      };
+      const ref = await addDoc(this.groupsCollection, payload);
+      return ref.id;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create group';
+      console.error(message, err);
+      this.error.set(message);
+      throw err;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async updateGroup(
+    id: string,
+    updates: Partial<Pick<UserGroup, 'name' | 'description' | 'color' | 'shared'>>,
+  ): Promise<void> {
+    const ref = doc(this.firestore, `userGroups/${id}`);
+    const payload: Record<string, unknown> = { updatedAt: Timestamp.now() };
+    if (updates.name !== undefined) payload['name'] = updates.name.trim();
+    if (updates.description !== undefined) payload['description'] = updates.description.trim();
+    if (updates.color !== undefined) payload['color'] = updates.color;
+    if (updates.shared !== undefined) payload['shared'] = updates.shared;
+    await updateDoc(ref, payload);
+  }
+
+  async deleteGroup(id: string): Promise<void> {
+    const ref = doc(this.firestore, `userGroups/${id}`);
+    await deleteDoc(ref);
+  }
+
+  async addMember(groupId: string, member: UserGroupMember): Promise<void> {
+    const group = await this.getGroup(groupId);
+    if (!group) throw new Error('Group not found');
+    if (group.memberIds.includes(member.id)) return;
+    const members = this.dedupeMembers([...(group.members || []), member]);
+    await this.writeMembers(groupId, members);
+  }
+
+  async removeMember(groupId: string, memberId: string): Promise<void> {
+    const group = await this.getGroup(groupId);
+    if (!group) throw new Error('Group not found');
+    const members = (group.members || []).filter((m) => m.id !== memberId);
+    await this.writeMembers(groupId, members);
+  }
+
+  async setMembers(groupId: string, members: UserGroupMember[]): Promise<void> {
+    await this.writeMembers(groupId, this.dedupeMembers(members));
+  }
+
+  private async writeMembers(groupId: string, members: UserGroupMember[]): Promise<void> {
+    const ref = doc(this.firestore, `userGroups/${groupId}`);
+    await updateDoc(ref, {
+      memberIds: members.map((m) => m.id),
+      members,
+      updatedAt: Timestamp.now(),
+    });
+  }
+
+  private dedupeMembers(members: UserGroupMember[]): UserGroupMember[] {
+    const seen = new Map<string, UserGroupMember>();
+    for (const m of members) {
+      if (!m?.id) continue;
+      if (!seen.has(m.id)) seen.set(m.id, m);
+    }
+    return Array.from(seen.values()).sort((a, b) =>
+      (a.displayName || a.email || '').localeCompare(b.displayName || b.email || ''),
+    );
+  }
+}

--- a/src/app/features/admin/admin-dashboard.component.ts
+++ b/src/app/features/admin/admin-dashboard.component.ts
@@ -19,8 +19,9 @@ import {
   resolvePermissions,
 } from '../../core/models/user.model';
 import { ORG_DOMAIN, SUPER_ADMIN_EMAIL } from '../../core/constants';
+import { UserGroupManagerComponent } from '../user-groups/user-group-manager.component';
 
-type AdminTab = 'Users' | 'Projects' | 'Tasks' | 'Permissions' | 'Invites';
+type AdminTab = 'Users' | 'Projects' | 'Tasks' | 'Groups' | 'Permissions' | 'Invites';
 
 interface PermissionToggle {
   key: keyof UserPermissions;
@@ -65,7 +66,7 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-admin-dashboard',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, UserGroupManagerComponent],
   template: `
     <div class="h-screen overflow-y-auto bg-[#0a0a0a] text-gray-200">
       <div class="p-8 max-w-7xl mx-auto flex flex-col gap-8">
@@ -309,6 +310,13 @@ const PERMISSION_TOGGLES: PermissionToggle[] = [
                 </tr>
               </tbody>
             </table>
+          </div>
+        </div>
+
+        <!-- Groups Tab -->
+        <div *ngIf="activeTab() === 'Groups'" class="flex flex-col gap-4">
+          <div class="bg-black/40 border border-white/10 rounded-xl p-6">
+            <app-user-group-manager></app-user-group-manager>
           </div>
         </div>
 
@@ -646,7 +654,7 @@ export class AdminDashboardComponent {
   invitePermissions = signal<UserPermissions>({ ...DEFAULT_USER_PERMISSIONS });
 
   visibleTabs = computed<AdminTab[]>(() => {
-    const base: AdminTab[] = ['Users', 'Projects', 'Tasks'];
+    const base: AdminTab[] = ['Users', 'Projects', 'Tasks', 'Groups'];
     return this.isSuperAdmin() ? [...base, 'Permissions', 'Invites'] : base;
   });
 

--- a/src/app/features/projects/components/project-member-manager.component.html
+++ b/src/app/features/projects/components/project-member-manager.component.html
@@ -1,7 +1,14 @@
 <div class="space-y-6">
       <!-- Add Member Section -->
       <div class="bg-[#0f172a]/50 border border-white/5 rounded-xl p-4">
-        <h3 class="text-sm font-bold text-white mb-3">Add Team Members</h3>
+        <div class="flex items-center justify-between gap-3 mb-3">
+          <h3 class="text-sm font-bold text-white">Add Team Members</h3>
+          <app-group-picker
+            [label]="'Add from group'"
+            [compact]="true"
+            (applyGroup)="applyGroup($event)"
+          ></app-group-picker>
+        </div>
 
         <div class="relative">
           <div class="flex items-center gap-2">

--- a/src/app/features/projects/components/project-member-manager.component.ts
+++ b/src/app/features/projects/components/project-member-manager.component.ts
@@ -6,15 +6,17 @@ import { ContactsService } from '../../../core/services/contacts.service';
 import { Contact } from '../../../core/models/contact.model';
 import { DialogService } from '../../../core/services/dialog.service';
 import { Project } from '../../../core/models/domain.model';
+import { UserGroupMember } from '../../../core/models/user-group.model';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { debounceTime, distinctUntilChanged, switchMap, map, startWith } from 'rxjs';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { GroupPickerComponent } from '../../../shared/components/group-picker/group-picker.component';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-project-member-manager',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, GroupPickerComponent],
   templateUrl: './project-member-manager.component.html',
 })
 export class ProjectMemberManagerComponent {
@@ -23,6 +25,8 @@ export class ProjectMemberManagerComponent {
   projectService = inject(ProjectService);
   contactsService = inject(ContactsService);
   dialogService = inject(DialogService);
+
+  applyingGroup = signal(false);
 
   // Search Control
   searchControl = new FormControl('');
@@ -67,6 +71,32 @@ export class ProjectMemberManagerComponent {
       await this.projectService.addMember(this.project().id, user.id);
     } catch (err) {
       console.error('Failed to add member', err);
+    }
+  }
+
+  /**
+   * Apply a user group: add every member of the group to the project's
+   * memberIds. Already-present members are skipped. We batch the update so
+   * applying a large group doesn't produce N separate writes.
+   */
+  async applyGroup(members: UserGroupMember[]) {
+    if (!members?.length || this.applyingGroup()) return;
+    this.applyingGroup.set(true);
+    try {
+      const project = this.project();
+      const existing = new Set(project.memberIds || []);
+      const toAdd = members.map((m) => m.id).filter((id) => id && !existing.has(id));
+      if (toAdd.length === 0) return;
+      const newMemberIds = [...(project.memberIds || []), ...toAdd];
+      await this.projectService.updateProject(project.id, { memberIds: newMemberIds });
+    } catch (err) {
+      console.error('Failed to apply group to project', err);
+      await this.dialogService.alert(
+        err instanceof Error ? err.message : 'Failed to apply group.',
+        'Error',
+      );
+    } finally {
+      this.applyingGroup.set(false);
     }
   }
 

--- a/src/app/features/projects/components/project-member-manager.component.ts
+++ b/src/app/features/projects/components/project-member-manager.component.ts
@@ -92,7 +92,7 @@ export class ProjectMemberManagerComponent {
     } catch (err) {
       console.error('Failed to apply group to project', err);
       await this.dialogService.alert(
-        err instanceof Error ? err.message : 'Failed to apply group.',
+        'Failed to apply group to project. Please try again.',
         'Error',
       );
     } finally {

--- a/src/app/features/projects/project-detail.component.html
+++ b/src/app/features/projects/project-detail.component.html
@@ -180,24 +180,48 @@
                   </div>
 
                   <div class="space-y-6">
-                    <!-- Mini Team Card -->
+                    <!-- Team Card (with inline member manager) -->
                     <section class="bg-slate-900/50 rounded-xl border border-white/5 p-6">
-                      <h3 data-scramble class="text-sm font-semibold text-slate-200 mb-3">Team</h3>
-                      <div class="flex -space-x-2 overflow-hidden py-1">
-                        <!-- Placeholder since we don't have user profiles yet -->
-                        <div
-                          class="inline-block h-8 w-8 rounded-full ring-2 ring-slate-900 bg-cyan-500/20 flex items-center justify-center text-xs font-bold text-cyan-400"
+                      <div class="flex items-center justify-between mb-3">
+                        <h3 data-scramble class="text-sm font-semibold text-slate-200">
+                          Team
+                          <span class="ml-2 text-xs font-normal text-slate-500">
+                            ({{ project.memberIds.length || 0 }} member{{ (project.memberIds.length || 0) === 1 ? '' : 's' }})
+                          </span>
+                        </h3>
+                        <button
+                          type="button"
+                          class="omni-glitch-btn text-xs px-2.5 py-1 rounded-lg border border-cyan-500/40 bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 transition-colors"
+                          (click)="toggleMemberManager()"
                         >
-                          {{ project.ownerId.charAt(0).toUpperCase() || 'U' }}
-                        </div>
-                        @if ((project.memberIds.length || 0) > 1) {
-                          <div
-                            class="inline-block h-8 w-8 rounded-full ring-2 ring-slate-900 bg-slate-700 flex items-center justify-center text-xs font-bold text-slate-300"
-                          >
-                            +{{ (project.memberIds.length || 1) - 1 }}
-                          </div>
-                        }
+                          {{ showMemberManager() ? 'Hide' : 'Manage' }}
+                        </button>
                       </div>
+
+                      @if (!showMemberManager()) {
+                        <div class="flex -space-x-2 overflow-hidden py-1">
+                          <div
+                            class="inline-block h-8 w-8 rounded-full ring-2 ring-slate-900 bg-cyan-500/20 flex items-center justify-center text-xs font-bold text-cyan-400"
+                          >
+                            {{ project.ownerId.charAt(0).toUpperCase() || 'U' }}
+                          </div>
+                          @if ((project.memberIds.length || 0) > 1) {
+                            <div
+                              class="inline-block h-8 w-8 rounded-full ring-2 ring-slate-900 bg-slate-700 flex items-center justify-center text-xs font-bold text-slate-300"
+                            >
+                              +{{ (project.memberIds.length || 1) - 1 }}
+                            </div>
+                          }
+                        </div>
+                        <p class="text-xs text-slate-500 mt-3">
+                          Click <span class="text-cyan-400 font-semibold">Manage</span> to add or
+                          remove people — or apply a saved user group.
+                        </p>
+                      } @else {
+                        <app-project-member-manager
+                          [project]="project"
+                        ></app-project-member-manager>
+                      }
                     </section>
                   </div>
                 </div>

--- a/src/app/features/projects/project-detail.component.ts
+++ b/src/app/features/projects/project-detail.component.ts
@@ -20,6 +20,7 @@ import { Project, Task, TaskViewMode } from '../../core/models/domain.model';
 
 import { ProjectStatsCardComponent } from './components/project-stats-card.component';
 import { ProjectSettingsPanelComponent } from './components/project-settings-panel.component';
+import { ProjectMemberManagerComponent } from './components/project-member-manager.component';
 import { TaskListViewComponent } from '../tasks/task-list-view.component';
 import { TaskBoardViewComponent } from '../tasks/task-board-view.component';
 import { TaskCalendarViewComponent } from '../tasks/task-calendar-view.component';
@@ -35,6 +36,7 @@ type ProjectTab = 'overview' | 'tasks' | 'settings';
     CommonModule,
     ProjectStatsCardComponent,
     ProjectSettingsPanelComponent,
+    ProjectMemberManagerComponent,
     TaskListViewComponent,
     TaskBoardViewComponent,
     TaskCalendarViewComponent,
@@ -83,6 +85,13 @@ export class ProjectDetailComponent implements OnDestroy {
   showCreateModal = signal(false);
   createModalSectionId = signal<string | null>(null);
   createModalDueDate = signal<Date | null>(null);
+
+  // Overview inline member management
+  showMemberManager = signal(false);
+
+  toggleMemberManager() {
+    this.showMemberManager.update((v) => !v);
+  }
 
   // Reactive query params
   queryParams = toSignal(this.route.queryParamMap);

--- a/src/app/features/settings/settings.component.html
+++ b/src/app/features/settings/settings.component.html
@@ -191,6 +191,11 @@
           }
         </section>
 
+        <!-- User Groups -->
+        <section class="bg-slate-900/50 border border-white/10 rounded-2xl p-6 mb-6">
+          <app-user-group-manager></app-user-group-manager>
+        </section>
+
         <!-- Account Info -->
         <section class="bg-slate-900/50 border border-white/10 rounded-2xl p-6">
           <h2 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -11,6 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '../../core/auth/auth.service';
 import { Storage, ref, uploadBytes, getDownloadURL, deleteObject } from '@angular/fire/storage';
+import { UserGroupManagerComponent } from '../user-groups/user-group-manager.component';
 
 const AVATAR_COLORS = [
   { name: 'Purple', value: '#8b5cf6' },
@@ -29,7 +30,7 @@ const AVATAR_COLORS = [
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, UserGroupManagerComponent],
   templateUrl: './settings.component.html',
 })
 export class SettingsComponent {

--- a/src/app/features/tasks/components/task-fields-sidebar.html
+++ b/src/app/features/tasks/components/task-fields-sidebar.html
@@ -1,7 +1,14 @@
 <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-4 mb-8" [formGroup]="form()">
   <!-- Assignees -->
   <div class="flex flex-col gap-1 sm:col-span-2">
-    <label class="text-xs font-semibold text-slate-500 uppercase tracking-widest">Assignees</label>
+    <div class="flex items-center justify-between gap-2">
+      <label class="text-xs font-semibold text-slate-500 uppercase tracking-widest">Assignees</label>
+      <app-group-picker
+        [label]="'Add group'"
+        [compact]="true"
+        (applyGroup)="applyGroup.emit($event)"
+      ></app-group-picker>
+    </div>
     @if (selectedAssignees().length > 0) {
       <div class="flex flex-wrap gap-1.5 mb-1">
         @for (assignee of selectedAssignees(); track assignee.id) {

--- a/src/app/features/tasks/components/task-fields-sidebar.ts
+++ b/src/app/features/tasks/components/task-fields-sidebar.ts
@@ -11,6 +11,8 @@ import {
 } from '../../../shared/components/custom-select/custom-select.component';
 import { CustomDatePickerComponent } from '../../../shared/components/custom-date-picker/custom-date-picker.component';
 import { Task, CustomFieldDefinition } from '../../../core/models/domain.model';
+import { GroupPickerComponent } from '../../../shared/components/group-picker/group-picker.component';
+import { UserGroupMember } from '../../../core/models/user-group.model';
 
 @Component({
   selector: 'app-task-fields-sidebar',
@@ -21,6 +23,7 @@ import { Task, CustomFieldDefinition } from '../../../core/models/domain.model';
     AutocompleteInputComponent,
     CustomSelectComponent,
     CustomDatePickerComponent,
+    GroupPickerComponent,
   ],
   templateUrl: './task-fields-sidebar.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -43,6 +46,7 @@ export class TaskFieldsSidebarComponent {
   assigneeSelected = output<AutocompleteOption | string>();
   assigneeRemoved = output<string>();
   notifyAssigneesChange = output<boolean>();
+  applyGroup = output<UserGroupMember[]>();
 
   customFieldUpdated = output<{ fieldId: string; value: any }>();
 

--- a/src/app/features/tasks/components/task-form-fields.html
+++ b/src/app/features/tasks/components/task-form-fields.html
@@ -76,9 +76,16 @@
 
   <!-- Assignees -->
   <div>
-    <label class="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1">
-      Assignees
-    </label>
+    <div class="flex items-center justify-between mb-1">
+      <label class="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest">
+        Assignees
+      </label>
+      <app-group-picker
+        [label]="'Add group'"
+        [compact]="true"
+        (applyGroup)="applyGroup.emit($event)"
+      ></app-group-picker>
+    </div>
     <!-- Selected Assignee Chips -->
     @if (selectedAssignees().length > 0) {
       <div class="flex flex-wrap gap-1.5 mb-2">

--- a/src/app/features/tasks/components/task-form-fields.ts
+++ b/src/app/features/tasks/components/task-form-fields.ts
@@ -11,6 +11,8 @@ import {
 } from '../../../shared/components/custom-select/custom-select.component';
 import { CustomDatePickerComponent } from '../../../shared/components/custom-date-picker/custom-date-picker.component';
 import { MarkdownEditorComponent } from '../../../shared/components/markdown-editor/markdown-editor.component';
+import { GroupPickerComponent } from '../../../shared/components/group-picker/group-picker.component';
+import { UserGroupMember } from '../../../core/models/user-group.model';
 
 @Component({
   selector: 'app-task-form-fields',
@@ -22,6 +24,7 @@ import { MarkdownEditorComponent } from '../../../shared/components/markdown-edi
     CustomSelectComponent,
     CustomDatePickerComponent,
     MarkdownEditorComponent,
+    GroupPickerComponent,
   ],
   templateUrl: './task-form-fields.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -38,6 +41,7 @@ export class TaskFormFieldsComponent {
   assigneeSelected = output<AutocompleteOption | string>();
   assigneeRemoved = output<string>();
   notifyAssigneesChange = output<boolean>();
+  applyGroup = output<UserGroupMember[]>();
 
   onNotifyAssigneesChange(event: Event) {
     const isChecked = (event.target as HTMLInputElement).checked;

--- a/src/app/features/tasks/task-create-modal.component.html
+++ b/src/app/features/tasks/task-create-modal.component.html
@@ -26,6 +26,7 @@
         (assigneeSelected)="onAssigneeSelected($event)"
         (assigneeRemoved)="removeAssignee($event)"
         (notifyAssigneesChange)="notifyAssignees.set($event)"
+        (applyGroup)="applyGroupToAssignees($event)"
       >
         <!-- Projected Priority AI Action -->
         <app-task-ai-suggestions

--- a/src/app/features/tasks/task-create-modal.component.ts
+++ b/src/app/features/tasks/task-create-modal.component.ts
@@ -36,6 +36,7 @@ import {
 } from '../../shared/components/custom-select/custom-select.component';
 import { CustomDatePickerComponent } from '../../shared/components/custom-date-picker/custom-date-picker.component';
 import { BehaviorSubject } from 'rxjs';
+import { UserGroupMember } from '../../core/models/user-group.model';
 
 import { TaskFormFieldsComponent } from './components/task-form-fields';
 import { TaskAiSuggestionsComponent } from './components/task-ai-suggestions';
@@ -307,6 +308,31 @@ export class TaskCreateModalComponent {
    */
   removeAssignee(id: string): void {
     this.selectedAssignees.update((list) => list.filter((a) => a.id !== id));
+  }
+
+  /**
+   * Merge every member of a selected user group into the current assignee
+   * list, skipping anyone already assigned.
+   */
+  applyGroupToAssignees(members: UserGroupMember[]): void {
+    if (!members?.length) return;
+    const current = this.selectedAssignees();
+    const seen = new Set(current.map((a) => a.id));
+    const additions: AutocompleteOption[] = [];
+    for (const m of members) {
+      if (!m?.id || seen.has(m.id)) continue;
+      seen.add(m.id);
+      additions.push({
+        id: m.id,
+        label: m.displayName || m.email || m.id,
+        sublabel: m.email,
+        avatar: m.photoURL,
+        color: m.photoURL ? undefined : this.generateAvatarColor(m.email || m.id),
+      });
+    }
+    if (additions.length) {
+      this.selectedAssignees.set([...current, ...additions]);
+    }
   }
 
   async onSubmit() {

--- a/src/app/features/tasks/task-detail-modal.component.html
+++ b/src/app/features/tasks/task-detail-modal.component.html
@@ -38,6 +38,7 @@
         (assigneeSearch)="onAssigneeSearch($event)"
         (assigneeSelected)="onAssigneeSelected($event)"
         (assigneeRemoved)="removeAssignee($event)"
+        (applyGroup)="applyGroupToAssignees($event)"
         (notifyAssigneesChange)="notifyAssigneesSig.set($event); form.markAsDirty(); autoSave()"
         (customFieldUpdated)="updateCustomField($event.fieldId, $event.value)"
         (autoSave)="autoSave()"

--- a/src/app/features/tasks/task-detail-modal.component.ts
+++ b/src/app/features/tasks/task-detail-modal.component.ts
@@ -19,6 +19,7 @@ import { Contact } from '../../core/models/contact.model';
 import { CustomFieldService } from '../../core/services/custom-field.service';
 import { TaskDependencyService } from '../../core/services/task-dependency.service';
 import { Task, Project, CustomFieldDefinition } from '../../core/models/domain.model';
+import { UserGroupMember } from '../../core/models/user-group.model';
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 import { switchMap, of, map, BehaviorSubject, debounceTime, firstValueFrom } from 'rxjs';
 import {
@@ -352,6 +353,33 @@ export class TaskDetailModalComponent {
     this.selectedAssignees.update((list) => list.filter((a) => a.id !== id));
     this.form.markAsDirty();
     this.autoSave();
+  }
+
+  /**
+   * Apply every member of a user group to the assignee list, then auto-save.
+   * Skips anyone already assigned so re-applying a group is idempotent.
+   */
+  applyGroupToAssignees(members: UserGroupMember[]): void {
+    if (!members?.length) return;
+    const current = this.selectedAssignees();
+    const seen = new Set(current.map((a) => a.id));
+    const additions: AutocompleteOption[] = [];
+    for (const m of members) {
+      if (!m?.id || seen.has(m.id)) continue;
+      seen.add(m.id);
+      additions.push({
+        id: m.id,
+        label: m.displayName || m.email || m.id,
+        sublabel: m.email,
+        avatar: m.photoURL,
+        color: m.photoURL ? undefined : this.generateAvatarColor(m.email || m.id),
+      });
+    }
+    if (additions.length) {
+      this.selectedAssignees.set([...current, ...additions]);
+      this.form.markAsDirty();
+      this.autoSave();
+    }
   }
 
   /**

--- a/src/app/features/user-groups/user-group-manager.component.html
+++ b/src/app/features/user-groups/user-group-manager.component.html
@@ -1,0 +1,357 @@
+<div class="space-y-5">
+  <!-- Header row -->
+  <div class="flex items-center justify-between gap-3 flex-wrap">
+    <div>
+      <h2 class="text-lg font-semibold text-white">User groups</h2>
+      <p class="text-xs text-slate-400 mt-1">
+        Bundle people together once, then assign the whole group anywhere you would assign a
+        single user — projects, tasks, and permissions.
+      </p>
+    </div>
+    @if (!showCreate()) {
+      <button
+        (click)="openCreate()"
+        class="omni-glitch-btn px-3 py-1.5 rounded-lg bg-cyan-500 hover:bg-cyan-400 text-white text-xs font-semibold transition-all"
+      >
+        + New group
+      </button>
+    }
+  </div>
+
+  <!-- Create form -->
+  @if (showCreate()) {
+    <div class="bg-black/40 border border-cyan-500/30 rounded-xl p-4 space-y-4">
+      <div class="flex items-center gap-3">
+        <div
+          class="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold text-lg"
+          [style.background-color]="newColor()"
+        >
+          {{ newName().charAt(0).toUpperCase() || 'G' }}
+        </div>
+        <div class="flex-1">
+          <input
+            type="text"
+            [ngModel]="newName()"
+            (ngModelChange)="newName.set($event)"
+            placeholder="Group name (e.g. 'Design Leads')"
+            class="w-full bg-black/60 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-cyan-500/60"
+          />
+        </div>
+      </div>
+
+      <textarea
+        [ngModel]="newDescription()"
+        (ngModelChange)="newDescription.set($event)"
+        rows="2"
+        placeholder="What is this group for? (optional)"
+        class="w-full bg-black/60 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/60 resize-none"
+      ></textarea>
+
+      <div class="flex flex-wrap gap-2 items-center">
+        <span class="text-[10px] uppercase tracking-wider text-slate-400 mr-1">Color</span>
+        @for (c of palette; track c) {
+          <button
+            type="button"
+            class="w-6 h-6 rounded-full border-2 transition-transform"
+            [class.border-white]="newColor() === c"
+            [class.border-transparent]="newColor() !== c"
+            [class.scale-110]="newColor() === c"
+            [style.background-color]="c"
+            (click)="newColor.set(c)"
+          ></button>
+        }
+      </div>
+
+      <label class="flex items-center gap-2 text-xs text-slate-300 select-none">
+        <input
+          type="checkbox"
+          [checked]="newShared()"
+          (change)="newShared.set($any($event.target).checked)"
+          class="accent-cyan-400"
+        />
+        Share with everyone (otherwise only you can apply this group)
+      </label>
+
+      <!-- Member picker -->
+      <div>
+        <div class="text-xs uppercase tracking-wider text-slate-400 mb-2">Members</div>
+        @if (newMembers().length) {
+          <div class="flex flex-wrap gap-2 mb-3">
+            @for (m of newMembers(); track trackMember($index, m)) {
+              <div
+                class="flex items-center gap-2 pl-1 pr-2 py-1 rounded-full border border-white/10 bg-white/5"
+              >
+                @if (m.photoURL) {
+                  <img [src]="m.photoURL" class="w-6 h-6 rounded-full object-cover" alt="" />
+                } @else {
+                  <div
+                    class="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white"
+                    [style.background-color]="avatarColor(m.email || m.id)"
+                  >
+                    {{ getInitials(m.displayName, m.email) }}
+                  </div>
+                }
+                <span class="text-xs text-white">{{ m.displayName }}</span>
+                <button
+                  type="button"
+                  class="text-slate-400 hover:text-rose-400 text-xs leading-none"
+                  (click)="removeMemberFromNew(m.id)"
+                  aria-label="Remove member"
+                >
+                  ×
+                </button>
+              </div>
+            }
+          </div>
+        } @else {
+          <p class="text-xs text-slate-500 italic mb-3">No members yet.</p>
+        }
+
+        <div class="relative">
+          <input
+            type="text"
+            [formControl]="searchControl"
+            placeholder="Search users to add…"
+            class="w-full bg-black/60 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/60"
+            (focus)="showSearchResults.set(true)"
+            (blur)="showSearchResults.set(false)"
+          />
+          @if (showSearchResults() && searchResults().length) {
+            <div
+              class="absolute top-full left-0 right-0 mt-1 bg-[#0f172a] border border-white/10 rounded-lg shadow-xl z-40 max-h-60 overflow-y-auto"
+            >
+              @for (c of searchResults(); track c.id) {
+                <button
+                  type="button"
+                  class="w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-white/5 transition-colors"
+                  (mousedown)="addMemberToNew(c)"
+                >
+                  <div
+                    class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white"
+                    [style.background-color]="avatarColor(c.email || c.id)"
+                  >
+                    {{ getInitials(c.displayName, c.email) }}
+                  </div>
+                  <div class="flex flex-col">
+                    <span class="text-sm text-white">{{ c.displayName }}</span>
+                    <span class="text-[11px] text-slate-400">{{ c.email }}</span>
+                  </div>
+                </button>
+              }
+            </div>
+          }
+        </div>
+      </div>
+
+      <div class="flex justify-end gap-2 pt-2">
+        <button
+          type="button"
+          (click)="cancelCreate()"
+          class="px-3 py-1.5 rounded-lg border border-white/10 text-slate-300 hover:bg-white/5 text-xs font-semibold"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          (click)="saveNewGroup()"
+          [disabled]="saving() || !newName().trim()"
+          class="px-4 py-1.5 rounded-lg bg-cyan-500 hover:bg-cyan-400 text-white text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed shadow-[0_0_14px_rgba(0,210,255,0.4)]"
+        >
+          {{ saving() ? 'Saving…' : 'Save group' }}
+        </button>
+      </div>
+    </div>
+  }
+
+  <!-- Groups list -->
+  @if (groups().length === 0) {
+    <div class="text-center py-10 border border-dashed border-white/10 rounded-xl">
+      <p class="text-sm text-slate-500">
+        No groups yet. Create one to apply a set of users with a single click.
+      </p>
+    </div>
+  } @else {
+    <div class="space-y-3">
+      @for (g of groups(); track trackById($index, g)) {
+        <div
+          class="bg-black/30 border border-white/10 rounded-xl p-4 hover:border-white/20 transition-colors"
+        >
+          <div class="flex items-start justify-between gap-3 flex-wrap">
+            <div class="flex items-start gap-3 min-w-0">
+              <div
+                class="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold shrink-0"
+                [style.background-color]="g.color || '#8b5cf6'"
+              >
+                {{ g.name.charAt(0).toUpperCase() }}
+              </div>
+              <div class="min-w-0">
+                @if (editingId() === g.id) {
+                  <input
+                    type="text"
+                    [value]="g.name"
+                    (change)="renameGroup(g, $any($event.target).value)"
+                    class="bg-black/60 border border-white/10 rounded-lg px-2 py-1 text-sm text-white focus:outline-none focus:border-cyan-500/60 w-full"
+                  />
+                } @else {
+                  <h3 class="text-base font-semibold text-white truncate">{{ g.name }}</h3>
+                }
+                <p class="text-xs text-slate-400 mt-0.5">
+                  {{ g.memberIds.length }} member{{ g.memberIds.length === 1 ? '' : 's' }}
+                  @if (g.shared) {
+                    <span class="ml-2 text-[10px] uppercase tracking-wider text-emerald-400"
+                      >Shared</span
+                    >
+                  } @else {
+                    <span class="ml-2 text-[10px] uppercase tracking-wider text-slate-500"
+                      >Private</span
+                    >
+                  }
+                </p>
+                @if (editingId() === g.id) {
+                  <textarea
+                    rows="2"
+                    [value]="g.description || ''"
+                    (change)="updateGroupDescription(g, $any($event.target).value)"
+                    placeholder="Description"
+                    class="mt-2 w-full bg-black/60 border border-white/10 rounded-lg px-2 py-1 text-xs text-slate-200 focus:outline-none focus:border-cyan-500/60 resize-none"
+                  ></textarea>
+                } @else if (g.description) {
+                  <p class="text-xs text-slate-500 mt-1 line-clamp-2">{{ g.description }}</p>
+                }
+              </div>
+            </div>
+
+            @if (canEdit(g)) {
+              <div class="flex items-center gap-1 shrink-0">
+                @if (editingId() === g.id) {
+                  <button
+                    type="button"
+                    (click)="cancelEdit()"
+                    class="px-2 py-1 rounded-lg text-xs text-slate-300 hover:bg-white/5"
+                  >
+                    Done
+                  </button>
+                } @else {
+                  <button
+                    type="button"
+                    (click)="startEdit(g)"
+                    class="px-2 py-1 rounded-lg text-xs text-cyan-400 hover:bg-cyan-500/10"
+                  >
+                    Edit
+                  </button>
+                }
+                <button
+                  type="button"
+                  (click)="deleteGroup(g)"
+                  class="px-2 py-1 rounded-lg text-xs text-rose-400 hover:bg-rose-500/10"
+                >
+                  Delete
+                </button>
+              </div>
+            }
+          </div>
+
+          <!-- Member chips -->
+          @if (g.members.length) {
+            <div class="flex flex-wrap gap-2 mt-4">
+              @for (m of g.members; track trackMember($index, m)) {
+                <div
+                  class="flex items-center gap-2 pl-1 pr-2 py-1 rounded-full border border-white/10 bg-white/5"
+                  [title]="m.email"
+                >
+                  @if (m.photoURL) {
+                    <img [src]="m.photoURL" class="w-6 h-6 rounded-full object-cover" alt="" />
+                  } @else {
+                    <div
+                      class="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white"
+                      [style.background-color]="avatarColor(m.email || m.id)"
+                    >
+                      {{ getInitials(m.displayName, m.email) }}
+                    </div>
+                  }
+                  <span class="text-xs text-white">{{ m.displayName }}</span>
+                  @if (canEdit(g) && editingId() === g.id) {
+                    <button
+                      type="button"
+                      class="text-slate-400 hover:text-rose-400 text-xs leading-none"
+                      (click)="removeMemberFromGroup(g, m.id)"
+                      aria-label="Remove member"
+                    >
+                      ×
+                    </button>
+                  }
+                </div>
+              }
+            </div>
+          } @else {
+            <p class="text-xs text-slate-500 italic mt-3">No members yet.</p>
+          }
+
+          <!-- Member picker (shown while editing) -->
+          @if (canEdit(g) && editingId() === g.id) {
+            <div class="relative mt-4">
+              <input
+                type="text"
+                [formControl]="searchControl"
+                placeholder="Search users to add to this group…"
+                class="w-full bg-black/60 border border-white/10 rounded-lg px-3 py-2 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/60"
+                (focus)="showSearchResults.set(true)"
+                (blur)="showSearchResults.set(false)"
+              />
+              @if (showSearchResults() && searchResults().length) {
+                <div
+                  class="absolute top-full left-0 right-0 mt-1 bg-[#0f172a] border border-white/10 rounded-lg shadow-xl z-40 max-h-60 overflow-y-auto"
+                >
+                  @for (c of searchResults(); track c.id) {
+                    <button
+                      type="button"
+                      class="w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-white/5 transition-colors"
+                      (mousedown)="addMemberToGroup(g, c)"
+                    >
+                      <div
+                        class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white"
+                        [style.background-color]="avatarColor(c.email || c.id)"
+                      >
+                        {{ getInitials(c.displayName, c.email) }}
+                      </div>
+                      <div class="flex flex-col">
+                        <span class="text-sm text-white">{{ c.displayName }}</span>
+                        <span class="text-[11px] text-slate-400">{{ c.email }}</span>
+                      </div>
+                    </button>
+                  }
+                </div>
+              }
+            </div>
+
+            <div class="flex items-center justify-between gap-2 mt-3 flex-wrap">
+              <label class="flex items-center gap-2 text-xs text-slate-300 select-none">
+                <input
+                  type="checkbox"
+                  [checked]="g.shared"
+                  (change)="toggleShared(g)"
+                  class="accent-cyan-400"
+                />
+                Shared with everyone
+              </label>
+              <div class="flex gap-1 items-center">
+                <span class="text-[10px] uppercase tracking-wider text-slate-400 mr-1">Color</span>
+                @for (c of palette; track c) {
+                  <button
+                    type="button"
+                    class="w-5 h-5 rounded-full border-2 transition-transform"
+                    [class.border-white]="g.color === c"
+                    [class.border-transparent]="g.color !== c"
+                    [class.scale-110]="g.color === c"
+                    [style.background-color]="c"
+                    (click)="updateGroupColor(g, c)"
+                  ></button>
+                }
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/src/app/features/user-groups/user-group-manager.component.ts
+++ b/src/app/features/user-groups/user-group-manager.component.ts
@@ -1,0 +1,255 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { BehaviorSubject, debounceTime, switchMap } from 'rxjs';
+
+import { AuthService } from '../../core/auth/auth.service';
+import { ContactsService } from '../../core/services/contacts.service';
+import { DialogService } from '../../core/services/dialog.service';
+import { UserGroupService } from '../../core/services/user-group.service';
+import { Contact } from '../../core/models/contact.model';
+import { UserGroup, UserGroupMember } from '../../core/models/user-group.model';
+
+const PALETTE = [
+  '#8b5cf6',
+  '#3b82f6',
+  '#06b6d4',
+  '#10b981',
+  '#f59e0b',
+  '#ef4444',
+  '#ec4899',
+  '#6366f1',
+  '#14b8a6',
+  '#f97316',
+];
+
+/**
+ * CRUD UI for {@link UserGroup} documents. Drops into any container — used
+ * by Settings (for personal groups) and the admin dashboard (for shared org
+ * groups). Members are picked from the ContactsService so the same pool of
+ * users is available as elsewhere in the app.
+ */
+@Component({
+  selector: 'app-user-group-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  templateUrl: './user-group-manager.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserGroupManagerComponent {
+  private readonly groupService = inject(UserGroupService);
+  private readonly contactsService = inject(ContactsService);
+  private readonly dialogService = inject(DialogService);
+  private readonly auth = inject(AuthService);
+
+  palette = PALETTE;
+
+  groups = toSignal(this.groupService.getMyGroups(), { initialValue: [] });
+
+  editingId = signal<string | null>(null);
+  showCreate = signal(false);
+
+  // Create form state
+  newName = signal('');
+  newDescription = signal('');
+  newColor = signal(PALETTE[0]);
+  newShared = signal(true);
+  newMembers = signal<UserGroupMember[]>([]);
+  saving = signal(false);
+
+  // Search for member picker (shared between create & edit)
+  searchControl = new FormControl('');
+  private searchSubject = new BehaviorSubject<string>('');
+  showSearchResults = signal(false);
+
+  searchResults = toSignal(
+    this.searchSubject.pipe(
+      debounceTime(200),
+      switchMap((q) => this.contactsService.searchContacts(q || '')),
+    ),
+    { initialValue: [] as Contact[] },
+  );
+
+  constructor() {
+    this.searchControl.valueChanges.subscribe((v) => this.searchSubject.next(v || ''));
+  }
+
+  currentUid = computed(() => this.auth.currentUserSig()?.uid || '');
+
+  canEdit(group: UserGroup): boolean {
+    const uid = this.currentUid();
+    if (!uid) return false;
+    if (group.ownerId === uid) return true;
+    const perms = this.auth.currentUserSig()?.permissions;
+    return !!perms?.isSuperAdmin;
+  }
+
+  // ---- Create flow ----
+
+  openCreate(): void {
+    this.newName.set('');
+    this.newDescription.set('');
+    this.newColor.set(this.randomColor());
+    this.newShared.set(true);
+    this.newMembers.set([]);
+    this.editingId.set(null);
+    this.showCreate.set(true);
+  }
+
+  cancelCreate(): void {
+    this.showCreate.set(false);
+    this.searchControl.setValue('');
+  }
+
+  async saveNewGroup(): Promise<void> {
+    const name = this.newName().trim();
+    if (!name) {
+      await this.dialogService.alert('Group name is required.', 'Missing name');
+      return;
+    }
+    this.saving.set(true);
+    try {
+      await this.groupService.createGroup(name, this.newMembers(), {
+        description: this.newDescription(),
+        color: this.newColor(),
+        shared: this.newShared(),
+      });
+      this.showCreate.set(false);
+    } catch (err) {
+      console.error('Failed to create group', err);
+      await this.dialogService.alert(
+        err instanceof Error ? err.message : 'Failed to create group.',
+        'Error',
+      );
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  addMemberToNew(contact: Contact): void {
+    const member = this.contactToMember(contact);
+    const current = this.newMembers();
+    if (current.some((m) => m.id === member.id)) return;
+    this.newMembers.set([...current, member]);
+    this.searchControl.setValue('');
+  }
+
+  removeMemberFromNew(id: string): void {
+    this.newMembers.update((list) => list.filter((m) => m.id !== id));
+  }
+
+  // ---- Edit flow (inline per-group) ----
+
+  startEdit(group: UserGroup): void {
+    if (!this.canEdit(group)) return;
+    this.editingId.set(group.id);
+    this.showCreate.set(false);
+    this.searchControl.setValue('');
+  }
+
+  cancelEdit(): void {
+    this.editingId.set(null);
+    this.searchControl.setValue('');
+  }
+
+  async addMemberToGroup(group: UserGroup, contact: Contact): Promise<void> {
+    if (!this.canEdit(group)) return;
+    const member = this.contactToMember(contact);
+    try {
+      await this.groupService.addMember(group.id, member);
+      this.searchControl.setValue('');
+    } catch (err) {
+      console.error('Failed to add member to group', err);
+    }
+  }
+
+  async removeMemberFromGroup(group: UserGroup, memberId: string): Promise<void> {
+    if (!this.canEdit(group)) return;
+    try {
+      await this.groupService.removeMember(group.id, memberId);
+    } catch (err) {
+      console.error('Failed to remove member from group', err);
+    }
+  }
+
+  async renameGroup(group: UserGroup, name: string): Promise<void> {
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === group.name) return;
+    await this.groupService.updateGroup(group.id, { name: trimmed });
+  }
+
+  async updateGroupDescription(group: UserGroup, description: string): Promise<void> {
+    if ((description || '') === (group.description || '')) return;
+    await this.groupService.updateGroup(group.id, { description });
+  }
+
+  async updateGroupColor(group: UserGroup, color: string): Promise<void> {
+    if (color === group.color) return;
+    await this.groupService.updateGroup(group.id, { color });
+  }
+
+  async toggleShared(group: UserGroup): Promise<void> {
+    await this.groupService.updateGroup(group.id, { shared: !group.shared });
+  }
+
+  async deleteGroup(group: UserGroup): Promise<void> {
+    if (!this.canEdit(group)) return;
+    const ok = await this.dialogService.confirm(
+      `Delete group "${group.name}"? This cannot be undone.`,
+      'Delete group',
+    );
+    if (!ok) return;
+    try {
+      await this.groupService.deleteGroup(group.id);
+      if (this.editingId() === group.id) this.editingId.set(null);
+    } catch (err) {
+      console.error('Failed to delete group', err);
+    }
+  }
+
+  // ---- Helpers ----
+
+  private contactToMember(contact: Contact): UserGroupMember {
+    return {
+      id: contact.id,
+      email: contact.email,
+      displayName: contact.displayName || contact.email,
+      photoURL: contact.photoURL,
+    };
+  }
+
+  private randomColor(): string {
+    return PALETTE[Math.floor(Math.random() * PALETTE.length)];
+  }
+
+  getInitials(name: string, email = ''): string {
+    const base = name || email || '?';
+    return base
+      .split(/\s+|@/)
+      .map((part) => part.charAt(0).toUpperCase())
+      .filter(Boolean)
+      .slice(0, 2)
+      .join('');
+  }
+
+  avatarColor(seed: string): string {
+    const key = seed || '';
+    const hash = key.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+    return PALETTE[hash % PALETTE.length];
+  }
+
+  trackById(_i: number, g: UserGroup) {
+    return g.id;
+  }
+
+  trackMember(_i: number, m: UserGroupMember) {
+    return m.id;
+  }
+}

--- a/src/app/features/user-groups/user-group-manager.component.ts
+++ b/src/app/features/user-groups/user-group-manager.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, FormControl, ReactiveFormsModule } from '@angular/forms';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toSignal, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, debounceTime, switchMap } from 'rxjs';
 
 import { AuthService } from '../../core/auth/auth.service';
@@ -78,7 +78,9 @@ export class UserGroupManagerComponent {
   );
 
   constructor() {
-    this.searchControl.valueChanges.subscribe((v) => this.searchSubject.next(v || ''));
+    this.searchControl.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((v) => this.searchSubject.next(v || ''));
   }
 
   currentUid = computed(() => this.auth.currentUserSig()?.uid || '');
@@ -125,7 +127,7 @@ export class UserGroupManagerComponent {
     } catch (err) {
       console.error('Failed to create group', err);
       await this.dialogService.alert(
-        err instanceof Error ? err.message : 'Failed to create group.',
+        'Failed to create group. Please try again.',
         'Error',
       );
     } finally {

--- a/src/app/features/user-groups/user-group-manager.component.ts
+++ b/src/app/features/user-groups/user-group-manager.component.ts
@@ -86,11 +86,12 @@ export class UserGroupManagerComponent {
   currentUid = computed(() => this.auth.currentUserSig()?.uid || '');
 
   canEdit(group: UserGroup): boolean {
-    const uid = this.currentUid();
-    if (!uid) return false;
-    if (group.ownerId === uid) return true;
-    const perms = this.auth.currentUserSig()?.permissions;
-    return !!perms?.isSuperAdmin;
+    const user = this.auth.currentUserSig();
+    if (!user) return false;
+    if (group.ownerId === user.uid) return true;
+    // Admins and super-admins can mutate any group (matches Firestore rules).
+    if (user.role === 'admin') return true;
+    return !!user.permissions?.isSuperAdmin;
   }
 
   // ---- Create flow ----
@@ -169,6 +170,10 @@ export class UserGroupManagerComponent {
       this.searchControl.setValue('');
     } catch (err) {
       console.error('Failed to add member to group', err);
+      await this.dialogService.alert(
+        'Failed to add member to the group. Please try again.',
+        'Error',
+      );
     }
   }
 
@@ -178,27 +183,63 @@ export class UserGroupManagerComponent {
       await this.groupService.removeMember(group.id, memberId);
     } catch (err) {
       console.error('Failed to remove member from group', err);
+      await this.dialogService.alert(
+        'Failed to remove member from the group. Please try again.',
+        'Error',
+      );
     }
   }
 
   async renameGroup(group: UserGroup, name: string): Promise<void> {
     const trimmed = name.trim();
     if (!trimmed || trimmed === group.name) return;
-    await this.groupService.updateGroup(group.id, { name: trimmed });
+    try {
+      await this.groupService.updateGroup(group.id, { name: trimmed });
+    } catch (err) {
+      console.error('Failed to rename group', err);
+      await this.dialogService.alert(
+        'Failed to rename the group. Please try again.',
+        'Error',
+      );
+    }
   }
 
   async updateGroupDescription(group: UserGroup, description: string): Promise<void> {
     if ((description || '') === (group.description || '')) return;
-    await this.groupService.updateGroup(group.id, { description });
+    try {
+      await this.groupService.updateGroup(group.id, { description });
+    } catch (err) {
+      console.error('Failed to update group description', err);
+      await this.dialogService.alert(
+        'Failed to update the group description. Please try again.',
+        'Error',
+      );
+    }
   }
 
   async updateGroupColor(group: UserGroup, color: string): Promise<void> {
     if (color === group.color) return;
-    await this.groupService.updateGroup(group.id, { color });
+    try {
+      await this.groupService.updateGroup(group.id, { color });
+    } catch (err) {
+      console.error('Failed to update group color', err);
+      await this.dialogService.alert(
+        'Failed to update the group color. Please try again.',
+        'Error',
+      );
+    }
   }
 
   async toggleShared(group: UserGroup): Promise<void> {
-    await this.groupService.updateGroup(group.id, { shared: !group.shared });
+    try {
+      await this.groupService.updateGroup(group.id, { shared: !group.shared });
+    } catch (err) {
+      console.error('Failed to toggle group sharing', err);
+      await this.dialogService.alert(
+        'Failed to update sharing for the group. Please try again.',
+        'Error',
+      );
+    }
   }
 
   async deleteGroup(group: UserGroup): Promise<void> {
@@ -213,6 +254,10 @@ export class UserGroupManagerComponent {
       if (this.editingId() === group.id) this.editingId.set(null);
     } catch (err) {
       console.error('Failed to delete group', err);
+      await this.dialogService.alert(
+        'Failed to delete the group. Please try again.',
+        'Error',
+      );
     }
   }
 

--- a/src/app/shared/components/group-picker/group-picker.component.html
+++ b/src/app/shared/components/group-picker/group-picker.component.html
@@ -1,0 +1,77 @@
+<div class="relative inline-block">
+  <button
+    type="button"
+    (click)="toggle()"
+    [class.px-2]="compact()"
+    [class.py-1]="compact()"
+    [class.text-xs]="compact()"
+    [class.px-3]="!compact()"
+    [class.py-1.5]="!compact()"
+    [class.text-sm]="!compact()"
+    class="inline-flex items-center gap-1.5 rounded-lg border border-violet-500/40 bg-violet-500/10 text-violet-200 font-semibold hover:bg-violet-500/20 hover:border-violet-500/60 transition-colors"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-3.5 w-3.5"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="2"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-5a4 4 0 11-8 0 4 4 0 018 0zm6 0a4 4 0 11-8 0 4 4 0 018 0z"
+      />
+    </svg>
+    <span>{{ label() }}</span>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-3 w-3"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      stroke-width="3"
+    >
+      <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  </button>
+
+  @if (open()) {
+    <div
+      class="absolute right-0 top-full mt-1 w-64 bg-[#0f172a] border border-white/10 rounded-lg shadow-xl z-50 overflow-hidden"
+    >
+      @if (groups().length === 0) {
+        <div class="px-4 py-5 text-center text-xs text-slate-500">
+          No groups yet. Create one from Settings → User Groups.
+        </div>
+      } @else {
+        <div class="max-h-72 overflow-y-auto">
+          @for (g of groups(); track trackById($index, g)) {
+            <button
+              type="button"
+              class="w-full text-left px-3 py-2 flex items-center gap-3 hover:bg-white/5 transition-colors border-b border-white/5 last:border-0"
+              (click)="pick(g)"
+            >
+              <div
+                class="w-7 h-7 rounded-lg flex items-center justify-center text-white font-bold text-xs shrink-0"
+                [style.background-color]="g.color || '#8b5cf6'"
+              >
+                {{ g.name.charAt(0).toUpperCase() }}
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="text-sm text-white truncate">{{ g.name }}</div>
+                <div class="text-[11px] text-slate-400">
+                  {{ g.memberIds.length }} member{{ g.memberIds.length === 1 ? '' : 's' }}
+                  @if (!g.shared) {
+                    <span class="ml-1 text-slate-500">· private</span>
+                  }
+                </div>
+              </div>
+            </button>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/src/app/shared/components/group-picker/group-picker.component.ts
+++ b/src/app/shared/components/group-picker/group-picker.component.ts
@@ -1,0 +1,63 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+import { UserGroupService } from '../../../core/services/user-group.service';
+import { UserGroup, UserGroupMember } from '../../../core/models/user-group.model';
+
+/**
+ * Button + dropdown for applying a saved {@link UserGroup} to the current
+ * context. Consumers receive a flat list of {@link UserGroupMember} via the
+ * {@link applyGroup} output — it's up to the parent to decide how to merge
+ * those members into their own state (project.memberIds, task.assigneeIds,
+ * permission bundles, etc.).
+ */
+@Component({
+  selector: 'app-group-picker',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './group-picker.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GroupPickerComponent {
+  private readonly groupService = inject(UserGroupService);
+  private readonly host = inject(ElementRef<HTMLElement>);
+
+  label = input<string>('Apply group');
+  compact = input<boolean>(false);
+
+  applyGroup = output<UserGroupMember[]>();
+
+  groups = toSignal(this.groupService.getMyGroups(), { initialValue: [] });
+
+  open = signal(false);
+
+  toggle(): void {
+    this.open.update((v) => !v);
+  }
+
+  pick(group: UserGroup): void {
+    this.open.set(false);
+    this.applyGroup.emit([...(group.members || [])]);
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocClick(event: MouseEvent): void {
+    if (!this.host.nativeElement.contains(event.target as Node)) {
+      this.open.set(false);
+    }
+  }
+
+  trackById(_i: number, g: UserGroup) {
+    return g.id;
+  }
+}


### PR DESCRIPTION
## Summary
Introduces a new user groups feature that allows users to create named collections of team members and apply them in bulk to projects, tasks, and other assignment contexts. Groups are lightweight references that expand into member IDs at assignment time, preserving the existing shape of project and task data structures.

## Key Changes

### New Components & Services
- **UserGroupManagerComponent**: Full CRUD UI for managing user groups with inline editing, member picker, color customization, and sharing controls
- **GroupPickerComponent**: Reusable dropdown button for applying saved groups to any assignment context
- **UserGroupService**: Firestore-backed service for group persistence, member management, and querying (with support for shared vs. private groups)
- **UserGroup & UserGroupMember models**: Type definitions for group documents and cached member details

### Integration Points
- **Task creation/detail modals**: Added group picker to assignee fields with `applyGroupToAssignees()` method to merge group members into current assignee list
- **Project member manager**: Integrated group picker for bulk team member assignment
- **Settings page**: Added user groups management section for personal group creation
- **Admin dashboard**: New "Groups" tab for managing organization-wide shared groups
- **Firestore rules**: Added security rules for group CRUD with owner/admin-only mutation and shared/private visibility controls

### Implementation Details
- Groups are stored in a `userGroups` Firestore collection with `ownerId`, `shared` flag, and cached member details
- Member picker uses `ContactsService` to search available users (both app users and directory contacts)
- Groups support custom colors from a predefined palette, descriptions, and optional sharing with all authenticated users
- Deduplication logic prevents duplicate members and maintains alphabetical sort order
- Group application is idempotent—re-applying a group skips members already assigned
- Firestore rules allow authenticated users to read shared groups or groups they own; only owners and admins can mutate

https://claude.ai/code/session_01L2Zv9MP9p6mrPhCLN7vLmM