### PR TITLE
Reorient nav: My Tasks as home, Workspace for project view, sheet sync

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,6 +19,11 @@ export const routes: Routes = [
       {
         path: '',
         loadComponent: () =>
+          import('./features/my-tasks/my-tasks.component').then((m) => m.MyTasksComponent),
+      },
+      {
+        path: 'workspace',
+        loadComponent: () =>
           import('./features/dashboard/dashboard.component').then((m) => m.DashboardComponent),
       },
       {
@@ -34,11 +39,6 @@ export const routes: Routes = [
           import('./features/projects/project-detail.component').then(
             (m) => m.ProjectDetailComponent,
           ),
-      },
-      {
-        path: 'tasks',
-        loadComponent: () =>
-          import('./features/my-tasks/my-tasks.component').then((m) => m.MyTasksComponent),
       },
       {
         path: 'schedule',

--- a/src/app/core/layout/navbar.component.html
+++ b/src/app/core/layout/navbar.component.html
@@ -116,33 +116,35 @@
               </a>
 
               <a
-                routerLink="/tasks"
+                routerLink="/workspace"
                 routerLinkActive
-                #rlaTasks="routerLinkActive"
+                #rlaWorkspace="routerLinkActive"
                 class="omni-glitch-btn relative px-3 py-1.5 text-sm font-medium transition-all group"
-                [class.text-cyan-400]="rlaTasks.isActive"
-                [class.text-slate-400]="!rlaTasks.isActive"
-                [class.hover:text-violet-400]="!rlaTasks.isActive"
+                [class.text-cyan-400]="rlaWorkspace.isActive"
+                [class.text-slate-400]="!rlaWorkspace.isActive"
+                [class.hover:text-violet-400]="!rlaWorkspace.isActive"
               >
                 <!-- Active/Hover Background -->
                 <span
                   class="absolute inset-0 rounded-lg transition-all duration-300"
-                  [class.bg-cyan-500/10]="rlaTasks.isActive"
-                  [class.bg-violet-500/0]="!rlaTasks.isActive"
-                  [class.group-hover:bg-violet-500/10]="!rlaTasks.isActive"
+                  [class.bg-cyan-500/10]="rlaWorkspace.isActive"
+                  [class.bg-violet-500/0]="!rlaWorkspace.isActive"
+                  [class.group-hover:bg-violet-500/10]="!rlaWorkspace.isActive"
                 ></span>
                 <!-- Underline -->
                 <span
                   class="absolute bottom-0 left-1/2 -translate-x-1/2 h-0.5 rounded-full transition-all duration-300"
-                  [class.bg-cyan-500]="rlaTasks.isActive"
-                  [class.shadow-[0_0_10px_rgba(6,182,212,0.9)]]="rlaTasks.isActive"
-                  [class.w-2/3]="rlaTasks.isActive"
-                  [class.w-0]="!rlaTasks.isActive"
-                  [class.group-hover:w-2/3]="!rlaTasks.isActive"
-                  [class.group-hover:bg-violet-500]="!rlaTasks.isActive"
-                  [class.group-hover:shadow-[0_0_10px_rgba(139,92,246,0.9)]]="!rlaTasks.isActive"
+                  [class.bg-cyan-500]="rlaWorkspace.isActive"
+                  [class.shadow-[0_0_10px_rgba(6,182,212,0.9)]]="rlaWorkspace.isActive"
+                  [class.w-2/3]="rlaWorkspace.isActive"
+                  [class.w-0]="!rlaWorkspace.isActive"
+                  [class.group-hover:w-2/3]="!rlaWorkspace.isActive"
+                  [class.group-hover:bg-violet-500]="!rlaWorkspace.isActive"
+                  [class.group-hover:shadow-[0_0_10px_rgba(139,92,246,0.9)]]="
+                    !rlaWorkspace.isActive
+                  "
                 ></span>
-                <span class="relative">My Tasks</span>
+                <span class="relative">Workspace</span>
               </a>
 
               <a

--- a/src/app/features/dashboard/components/dashboard-header.html
+++ b/src/app/features/dashboard/components/dashboard-header.html
@@ -176,8 +176,8 @@
         Add Task
       </button>
 
-      <!-- Google Tasks Sync Button -->
-      @if (currentProject()?.syncEnabled && currentProject()?.googleTaskListId) {
+      <!-- Google Sheets Sync Button -->
+      @if (currentProject()?.googleSheetId) {
         <button
           class="omni-glitch-btn relative p-2 rounded-lg border transition-all duration-200 group"
           [class.border-emerald-500/30]="!syncing()"
@@ -188,8 +188,8 @@
           [class.bg-amber-500/10]="syncing()"
           [class.text-amber-400]="syncing()"
           [disabled]="syncing()"
-          (click)="syncGoogleTasks.emit()"
-          title="Sync with Google Tasks"
+          (click)="syncGoogleSheet.emit()"
+          title="Sync with Google Sheets"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/app/features/dashboard/components/dashboard-header.ts
+++ b/src/app/features/dashboard/components/dashboard-header.ts
@@ -26,7 +26,7 @@ export class DashboardHeaderComponent {
   editProjectModal = output<Project>();
   viewModeChange = output<TaskViewMode>();
   openCreateTaskModal = output<void>();
-  syncGoogleTasks = output<void>();
+  syncGoogleSheet = output<void>();
   toggleSidebar = output<void>();
 
   getColorWithOpacity(color: string | undefined, alpha: number): string {

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -41,7 +41,7 @@
           (editProjectModal)="editProjectModal.set($event)"
           (viewModeChange)="viewMode.set($event)"
           (openCreateTaskModal)="openCreateTaskModal()"
-          (syncGoogleTasks)="syncGoogleTasks()"
+          (syncGoogleSheet)="syncGoogleSheet()"
           (toggleSidebar)="mobileSidebarOpen.set(!mobileSidebarOpen())"
         ></app-dashboard-header>
         <!-- View Content -->

--- a/src/app/features/dashboard/dashboard.component.spec.ts
+++ b/src/app/features/dashboard/dashboard.component.spec.ts
@@ -6,8 +6,8 @@ import { TaskService } from '../../core/services/task.service';
 import { SeedDataService } from '../../core/services/seed-data.service';
 import { DialogService } from '../../core/services/dialog.service';
 import { Router } from '@angular/router';
-import { GoogleTasksSyncService } from '../../core/services/google-tasks-sync.service';
-import { GoogleTasksService } from '../../core/services/google-tasks.service';
+import { GoogleSheetsSyncService } from '../../core/services/google-sheets-sync.service';
+import { GoogleSheetsService } from '../../core/services/google-sheets.service';
 import { BehaviorSubject, of } from 'rxjs';
 import { signal } from '@angular/core';
 import { Project, Task } from '../../core/models/domain.model';
@@ -23,8 +23,8 @@ describe('DashboardComponent', () => {
   let mockSeedDataService: jasmine.SpyObj<SeedDataService>;
   let mockDialogService: jasmine.SpyObj<DialogService>;
   let mockRouter: jasmine.SpyObj<Router>;
-  let mockGTSyncService: jasmine.SpyObj<GoogleTasksSyncService>;
-  let mockGTService: jasmine.SpyObj<GoogleTasksService>;
+  let mockSheetsSyncService: jasmine.SpyObj<GoogleSheetsSyncService>;
+  let mockSheetsService: jasmine.SpyObj<GoogleSheetsService>;
 
   beforeEach(async () => {
     mockAuthService = jasmine.createSpyObj('AuthService', ['logout']);
@@ -48,8 +48,10 @@ describe('DashboardComponent', () => {
     mockDialogService = jasmine.createSpyObj('DialogService', ['confirm', 'alert']);
     mockRouter = jasmine.createSpyObj('Router', ['navigate']);
 
-    mockGTSyncService = jasmine.createSpyObj('GoogleTasksSyncService', ['pullFromGoogleTasks']);
-    mockGTService = jasmine.createSpyObj('GoogleTasksService', ['isAuthenticated']);
+    mockSheetsSyncService = jasmine.createSpyObj('GoogleSheetsSyncService', [
+      'syncProjectWithSheet',
+    ]);
+    mockSheetsService = jasmine.createSpyObj('GoogleSheetsService', ['isAuthenticated']);
 
     await TestBed.configureTestingModule({
       imports: [DashboardComponent],
@@ -60,8 +62,8 @@ describe('DashboardComponent', () => {
         { provide: SeedDataService, useValue: mockSeedDataService },
         { provide: DialogService, useValue: mockDialogService },
         { provide: Router, useValue: mockRouter },
-        { provide: GoogleTasksSyncService, useValue: mockGTSyncService },
-        { provide: GoogleTasksService, useValue: mockGTService },
+        { provide: GoogleSheetsSyncService, useValue: mockSheetsSyncService },
+        { provide: GoogleSheetsService, useValue: mockSheetsService },
       ],
     })
       // For standalone components with lots of deep dependencies, sometimes it's easier to just override the template,

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -16,8 +16,11 @@ import { ProjectService } from '../../core/services/project.service';
 import { AuthService } from '../../core/auth/auth.service';
 import { DialogService } from '../../core/services/dialog.service';
 import { SeedDataService } from '../../core/services/seed-data.service';
-import { GoogleTasksSyncService } from '../../core/services/google-tasks-sync.service';
-import { GoogleTasksService } from '../../core/services/google-tasks.service';
+import {
+  GoogleSheetsSyncService,
+  DEFAULT_SHEET_TAB_NAME,
+} from '../../core/services/google-sheets-sync.service';
+import { GoogleSheetsService } from '../../core/services/google-sheets.service';
 import { Project, Task, TaskViewMode } from '../../core/models/domain.model';
 
 import { ProjectSidebarComponent } from '../projects/project-sidebar.component';
@@ -59,8 +62,8 @@ export class DashboardComponent {
   seedService = inject(SeedDataService);
   dialogService = inject(DialogService);
   router = inject(Router);
-  googleTasksSyncService = inject(GoogleTasksSyncService);
-  googleTasksService = inject(GoogleTasksService);
+  googleSheetsSyncService = inject(GoogleSheetsSyncService);
+  googleSheetsService = inject(GoogleSheetsService);
 
   // State
   selectedProjectId = this.projectService.selectedProjectId;
@@ -182,21 +185,20 @@ export class DashboardComponent {
     }
   }
 
-  async syncGoogleTasks() {
+  async syncGoogleSheet() {
     const project = this.currentProject();
-    if (!project?.googleTaskListId) {
+    if (!project?.googleSheetId) {
       await this.dialogService.alert(
-        'Please configure Google Tasks sync in project settings first.',
+        'Please link a Google Sheet in project settings first.',
         'Sync Not Configured',
       );
       return;
     }
 
-    // Check if Google Tasks is authenticated
-    if (!this.googleTasksService.isAuthenticated()) {
+    if (!this.googleSheetsService.isAuthenticated()) {
       const shouldReauth = await this.dialogService.confirm(
-        'Google Tasks is not connected. You need to sign out and sign in again to grant permission to access Google Tasks.\n\nWould you like to sign out now?',
-        'Google Tasks Not Connected',
+        'Google Sheets is not connected. You need to sign out and sign in again to grant permission to access Google Sheets.\n\nWould you like to sign out now?',
+        'Google Sheets Not Connected',
       );
       if (shouldReauth) {
         await this.auth.logout();
@@ -206,46 +208,36 @@ export class DashboardComponent {
 
     this.syncing.set(true);
     try {
-      // Update sync status to pending
-      await this.projectService.updateProject(project.id, { syncStatus: 'pending' });
+      await this.projectService.updateProject(project.id, { sheetSyncStatus: 'pending' });
 
-      // Get the last sync timestamp
-      const lastSyncAt = project.lastSyncAt;
-      const lastSyncDate = lastSyncAt
-        ? lastSyncAt instanceof Date
-          ? lastSyncAt
-          : (lastSyncAt as any).toDate?.() || undefined
-        : undefined;
-
-      // Pull tasks from Google Tasks
-      const result = await this.googleTasksSyncService.pullFromGoogleTasks(
+      const tabName = project.googleSheetTabName || DEFAULT_SHEET_TAB_NAME;
+      const result = await this.googleSheetsSyncService.syncProjectWithSheet(
         project.id,
-        project.googleTaskListId,
-        lastSyncDate,
+        project.googleSheetId,
+        tabName,
       );
 
-      console.log(`Sync complete: ${result.added} added, ${result.updated} updated`);
+      console.log(
+        `Sheet sync complete: ${result.added} added, ${result.updated} updated, ${result.pushed} pushed`,
+      );
 
-      // Show success message
       await this.dialogService.alert(
-        `Sync complete!\n\n${result.added} tasks added, ${result.updated} tasks updated.`,
+        `Sync complete!\n\n${result.added} added, ${result.updated} updated, ${result.pushed} pushed to the sheet.`,
         'Sync Successful',
       );
 
-      // Mark as synced
       await this.projectService.updateProject(project.id, {
-        syncStatus: 'synced',
-        lastSyncAt: new Date(),
+        sheetSyncStatus: 'synced',
+        lastSheetSyncAt: new Date(),
       });
     } catch (error: unknown) {
-      console.error('Sync failed:', error);
-      await this.projectService.updateProject(project.id, { syncStatus: 'error' });
+      console.error('Sheet sync failed:', error);
+      await this.projectService.updateProject(project.id, { sheetSyncStatus: 'error' });
 
-      // Provide specific error message
       let errorMessage = 'Sync failed. Please try again.';
       const err = error as { message?: string; status?: number };
       if (err?.message?.includes('not authenticated')) {
-        errorMessage = 'Google Tasks authentication expired. Please sign out and sign in again.';
+        errorMessage = 'Google Sheets authentication expired. Please sign out and sign in again.';
       } else if (err?.status === 401 || err?.status === 403) {
         errorMessage = 'Access denied. Please sign out and sign in again to refresh permissions.';
       }

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -62,8 +62,8 @@ export class DashboardComponent {
   seedService = inject(SeedDataService);
   dialogService = inject(DialogService);
   router = inject(Router);
-  googleSheetsSyncService = inject(GoogleSheetsSyncService);
-  googleSheetsService = inject(GoogleSheetsService);
+  readonly googleSheetsSyncService = inject(GoogleSheetsSyncService);
+  readonly googleSheetsService = inject(GoogleSheetsService);
 
   // State
   selectedProjectId = this.projectService.selectedProjectId;
@@ -185,7 +185,7 @@ export class DashboardComponent {
     }
   }
 
-  async syncGoogleSheet() {
+  async syncGoogleSheet(): Promise<void> {
     const project = this.currentProject();
     if (!project?.googleSheetId) {
       await this.dialogService.alert(
@@ -217,19 +217,15 @@ export class DashboardComponent {
         tabName,
       );
 
-      console.log(
-        `Sheet sync complete: ${result.added} added, ${result.updated} updated, ${result.pushed} pushed`,
-      );
+      await this.projectService.updateProject(project.id, {
+        sheetSyncStatus: 'synced',
+        lastSheetSyncAt: new Date(),
+      });
 
       await this.dialogService.alert(
         `Sync complete!\n\n${result.added} added, ${result.updated} updated, ${result.pushed} pushed to the sheet.`,
         'Sync Successful',
       );
-
-      await this.projectService.updateProject(project.id, {
-        sheetSyncStatus: 'synced',
-        lastSheetSyncAt: new Date(),
-      });
     } catch (error: unknown) {
       console.error('Sheet sync failed:', error);
       await this.projectService.updateProject(project.id, { sheetSyncStatus: 'error' });


### PR DESCRIPTION
## Summary
- Make the user-centric **My Tasks** dashboard the landing page after login, surfaced through the renamed **Dashboard** nav link (`/`).
- Rename the previous "My Tasks" nav item to **Workspace** (`/workspace`); it still loads the project-centric dashboard (sidebar + selected project's tasks).
- Repoint the workspace sync button to sync the project's linked **Google Sheet** instead of Google Tasks. The button now appears whenever `googleSheetId` is set, uses `GoogleSheetsSyncService.syncProjectWithSheet`, and updates `sheetSyncStatus` / `lastSheetSyncAt` on the project.

## Changes
- `src/app/app.routes.ts`: `'' → MyTasksComponent`, new `'workspace' → DashboardComponent`, drop the `/tasks` route.
- `src/app/core/layout/navbar.component.html`: rename "My Tasks" pill to "Workspace" and route it to `/workspace`.
- `src/app/features/dashboard/dashboard.component.ts` (+ `.html`, spec): swap `GoogleTasksService` / `GoogleTasksSyncService` for `GoogleSheetsService` / `GoogleSheetsSyncService`; replace `syncGoogleTasks()` with `syncGoogleSheet()` driven by the project's `googleSheetId` / `googleSheetTabName`.
- `src/app/features/dashboard/components/dashboard-header.{ts,html}`: rename the output to `syncGoogleSheet`, update gating to `currentProject()?.googleSheetId`, and re-label the button title to "Sync with Google Sheets".

## Test plan
- [ ] Log in as a fresh user — first page after auth is the user's My Tasks dashboard.
- [ ] Click "Dashboard" in the nav from any other route — lands on My Tasks.
- [ ] Click "Workspace" — lands on the project-centric dashboard with the project sidebar and view switcher.
- [ ] Open a project that has a linked Google Sheet — the sync button is visible and titled "Sync with Google Sheets".
- [ ] Click the sync button — pulls/pushes via Google Sheets, updates `sheetSyncStatus` to `synced` and `lastSheetSyncAt` on success.
- [ ] Open a project with no linked sheet — sync button is hidden.
- [ ] Sign out from a session without Sheets auth — clicking sync prompts re-auth instead of erroring.

https://claude.ai/code/session_01RjE81xDMkXw7LCmSB2B1uU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjE81xDMkXw7LCmSB2B1uU)_