### PR TITLE
chore(antigravity): bootstrap Antigravity + Claude Code workspace

### DIFF
--- a/+Workspace/draft-pr.md
+++ b/+Workspace/draft-pr.md
@@ -1,0 +1,117 @@
+# draft-pr
+
+Slash-command workflow that generates a clean PR description from current git state. Trigger with `/draft-pr` in Antigravity.
+
+## Goal
+
+Produce a paste-ready PR description summarizing local changes against the target branch (default: `main`), formatted for OmniFlex's GitHub PR template.
+
+## Steps
+
+1. **Determine target branch**
+   - If the current branch has an upstream tracking branch, use the merge base of HEAD and the upstream
+   - Otherwise default to `main`
+   - If `main` does not exist, fall back to `master`
+   - Surface the chosen target branch to the user before proceeding
+
+2. **Gather diff**
+   - Run `git diff {target_branch}...HEAD --stat` to get the file-level summary
+   - Run `git log {target_branch}..HEAD --oneline` to get commit history on this branch
+   - Run `git diff {target_branch}...HEAD` to get full diff (token-budget permitting)
+   - If the diff exceeds 50 files, summarize from the stat output and commit messages rather than reading every file
+
+3. **Categorize changes**
+   - Identify which features/areas are touched based on file paths under `lib/features/` or `functions/`
+   - Identify whether changes include: new files, deletions, renames, breaking API changes
+   - Identify whether tests, docs, or both are updated
+
+4. **Compose PR description**
+
+   Use the OmniFlex PR template:
+
+   ```markdown
+   ## Summary
+
+   [1-2 sentence description of what this PR does, in OmniFlex Voice — direct, no hype]
+
+   ## Changes
+
+   ### What
+   - [Bulleted list of technical changes, grouped by feature/area]
+   - [Each bullet specific enough to understand without reading the diff]
+
+   ### Why
+   - [Reasoning behind each non-obvious change, inferred from commits and code comments]
+   - [Link any related Obsidian notes or GitHub issues if found in commit messages]
+
+   ## Testing
+
+   - [How these changes were verified]
+   - [What new tests were added]
+   - [What manual testing the reviewer should do, if any]
+
+   ## Notes
+
+   - [Any caveats, follow-ups, or known limitations]
+   - [Anything the reviewer should pay extra attention to]
+   - [Brand/UX/security implications worth flagging]
+
+   ## Checklist
+
+   - [ ] `flutter analyze` passes
+   - [ ] `flutter test` passes
+   - [ ] No new packages in `pubspec.yaml` without justification
+   - [ ] Brand tokens used (no hardcoded colors/typography)
+   - [ ] Firestore rules updated if the diff touches new collections
+   - [ ] Documentation updated if public API changed
+   ```
+
+5. **Output**
+   - Place the rendered description in a single Markdown code block
+   - The user copies it into the PR body on GitHub
+   - Do not push the PR for the user; they create the PR themselves
+
+## Constraints
+
+- Plain ASCII; no smart quotes or em dashes
+- "What" is technical; "Why" is reasoning; "Testing" is how to verify; "Notes" is context
+- No marketing language, no hype words
+- If a change has unclear motivation from commits/code, surface that as a "needs author input" note rather than fabricating a reason
+- If the branch has no commits diverging from target, output a single message: "No changes detected against {target_branch}. Are you on the right branch?"
+
+## Example Output
+
+```markdown
+## Summary
+
+Adds the rest timer widget for the workout logger and wires it into the active workout view.
+
+## Changes
+
+### What
+- New widget at `lib/features/workout/presentation/widgets/rest_timer.dart` with countdown, pause, and skip actions
+- Riverpod provider `restTimerProvider` for timer state
+- Integration into `WorkoutScreen` between exercise sets
+- Widget test at `test/features/workout/widgets/rest_timer_test.dart`
+
+### Why
+- Rest timing was a top-3 user request from the closed beta survey (see `C:/OmniFlex Vault/Research/nexus-beta-feedback.md`)
+- Implementing as a self-contained widget keeps it reusable for future supersets feature
+
+## Testing
+
+- `flutter analyze` and `flutter test` pass
+- Manually tested: countdown completes, pause/resume works, skip advances workout state, app backgrounding preserves remaining time
+- Reviewer: please verify haptic feedback fires on countdown completion (only testable on physical device)
+
+## Notes
+
+- Did not add iOS-specific haptic patterns; uses Flutter's default. Can revisit if iOS feels weak
+- Timer accuracy: ~50ms drift over 5 minutes. Acceptable for the use case but flagged for future
+```
+
+## Failure Modes
+
+- **No commits to summarize**: surface the message and stop
+- **Diff too large to read fully**: summarize from stats and commits; flag at the top of the output
+- **Conflicting commit messages**: when multiple commits touch the same area with different stated reasons, list both and let the user reconcile

--- a/.antigravity/skills/omniflex-code-review/SKILL.md
+++ b/.antigravity/skills/omniflex-code-review/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: omniflex-code-review
+description: Use when reviewing a Flutter or Firebase code change before commit, before merge to main, or as a pre-deployment audit. Activates on prompts asking to review a diff, check a PR, audit a feature, or verify code is ready to ship. Runs the OmniFlex code review checklist covering null safety, Firebase error handling, brand consistency, accessibility, performance, and OmniFlex-specific footguns. Always finishes the full checklist even if early findings look severe.
+---
+
+# OmniFlex Code Review
+
+A consistent review pass that catches OmniFlex-specific footguns and enforces conventions from `AGENTS.md`.
+
+## Activation Triggers
+
+Activate when a prompt mentions:
+- Reviewing a diff, PR, or commit
+- Auditing code before deployment
+- Checking if a feature is ready to ship
+- Verifying changes against OmniFlex standards
+- "Looks good?" or "ship it?" — run the checklist anyway
+
+## Hard Rule
+
+**Always complete the full checklist.** Do not short-circuit on the first finding. Do not skip categories that "obviously look fine." The point of the checklist is to catch what looks fine but isn't.
+
+## Checklist
+
+See `checklist.md` for the full list. Categories:
+
+1. **Null safety**
+2. **Firebase error handling**
+3. **Brand consistency**
+4. **Accessibility**
+5. **Performance**
+6. **Security rule alignment**
+7. **Test coverage**
+8. **OmniFlex-specific footguns**
+
+## Output Format
+
+Report findings in a single structured response:
+
+```
+# Review: {feature/commit/PR title}
+
+## Overall: [SHIP / FIX FIRST / NEEDS DISCUSSION]
+
+## Findings
+
+### Null safety
+- [Finding 1 with file:line reference]
+- (or: "Pass — no issues found")
+
+### Firebase error handling
+- ...
+
+[continue for all 8 categories]
+
+## Recommendations (in priority order)
+1. [Highest-priority fix]
+2. [Next fix]
+3. [Optional improvements]
+
+## Test additions suggested
+- [Specific test cases to add before merge]
+```
+
+Findings include file paths and line numbers when applicable. "Looks fine" is not a finding; either the category passes (state that explicitly) or there's a specific issue with a location.
+
+## Verdict Rubric
+
+- **SHIP**: no findings in any category, or only minor optional improvements suggested
+- **FIX FIRST**: any finding in null safety, Firebase error handling, security rules, or OmniFlex footguns; any test gaps for new features
+- **NEEDS DISCUSSION**: findings that involve architectural choices, third-party package additions, or anything outside the reviewer's scope to decide alone
+
+Never report SHIP unless the full checklist has been run. If the user pushes for a faster verdict, complete the checklist anyway and surface findings.
+
+## What This Review Does Not Cover
+
+- Whether the feature itself is a good idea (that's product decision, not code review)
+- Whether the implementation matches a Figma design pixel-perfect (visual review is separate; have the user verify in Antigravity's integrated browser)
+- Whether business logic is correct beyond what's documented in the spec (you can flag suspicious logic but cannot validate against unstated requirements)

--- a/.antigravity/skills/omniflex-code-review/checklist.md
+++ b/.antigravity/skills/omniflex-code-review/checklist.md
@@ -1,0 +1,86 @@
+# OmniFlex Code Review Checklist
+
+Run every category. Report findings or pass for each.
+
+---
+
+## 1. Null Safety
+
+- [ ] No `!` operators without an inline comment justifying the assertion
+- [ ] No `dynamic` types except where interfacing with untyped JSON (and then with explicit casts soon after)
+- [ ] No `late` variables that could be initialized in `initState` instead
+- [ ] All `AsyncValue` consumers handle `data`, `loading`, AND `error` states (no `value!` calls)
+- [ ] Function return types and parameters are non-nullable wherever possible; nullability is intentional, not lazy
+- [ ] No `String?` where empty string would suffice and simplify downstream code
+
+## 2. Firebase Error Handling
+
+- [ ] Every Firestore call (`get`, `set`, `update`, `delete`, `add`) has a try/catch with explicit handling
+- [ ] FirebaseException catches are typed: `on FirebaseException catch (e, stack)` not bare `catch (e)`
+- [ ] Errors are logged with context (which document, which user, what operation)
+- [ ] Errors are surfaced to the user via the standard error UI, not swallowed silently
+- [ ] Cloud Function calls have timeouts configured; defaults are too long for mobile UX
+- [ ] Storage uploads handle interruption (network drop, app backgrounding)
+- [ ] Auth state changes invalidate cached data appropriately
+
+## 3. Brand Consistency
+
+- [ ] No hardcoded color values (`Color(0xFF...)`, `Colors.blue`, hex strings) — must use `OmniFlexColors`
+- [ ] No hardcoded text styles — must use `OmniFlexTypography`
+- [ ] No hardcoded spacing values — must use `OmniFlexSpacing` (8pt grid)
+- [ ] Glow effects use `OmniFlexEffects.neonGlow` not custom `BoxShadow` recreations
+- [ ] No corporate-feeling language in user-facing strings ("welcome to your fitness journey" — flag and rewrite)
+- [ ] Empty states feel intentional, not default Material placeholder
+- [ ] Loading states use OmniFlex's pulsing-glow loader, not default `CircularProgressIndicator`
+
+## 4. Accessibility
+
+- [ ] Interactive widgets have `Semantics` labels or use widgets that provide them by default
+- [ ] Touch targets minimum 48×48 logical pixels (custom buttons explicitly enforce; default Material widgets already do)
+- [ ] Text contrast against the dark cyberpunk background meets WCAG AA — check against `OmniFlexColors.deepBackground`
+- [ ] No information conveyed by color alone (state changes paired with icon or text)
+- [ ] Glow intensity is decorative; never carries information
+- [ ] Form fields have visible labels (not just placeholder text)
+- [ ] Error states announced to screen readers via `Semantics(liveRegion: true)`
+
+## 5. Performance
+
+- [ ] `const` constructors used wherever possible
+- [ ] `ListView.builder` (or equivalent lazy builder) for any list with more than ~20 items
+- [ ] No expensive work in `build()` (network calls, file I/O, heavy computation)
+- [ ] Animations use `AnimatedBuilder` / `AnimationController` rather than rebuilding parent widgets
+- [ ] Image assets sized appropriately; no 4096px hero images on mobile
+- [ ] `flutter analyze` passes with zero warnings (not just zero errors)
+- [ ] No `setState` calls outside the widget that owns the state
+
+## 6. Security Rule Alignment
+
+- [ ] If the change touches Firestore reads/writes, the relevant collection is covered by rules in `firestore.rules`
+- [ ] New fields written by the client are present in the rule's `fieldsAreSubsetOf` allow-list
+- [ ] If the change adds a new collection, rules exist before merge — never deploy app code that writes to an unprotected collection
+- [ ] `allow list` is set explicitly for collections the client queries (not just `allow read`)
+- [ ] Test cases (positive and negative) exist in the rules test file or emulator-tested by hand
+
+## 7. Test Coverage
+
+- [ ] Every new public widget has at least one widget test
+- [ ] Every new feature has at least one happy-path integration test
+- [ ] State management providers have unit tests where logic is non-trivial
+- [ ] Tests pass: `flutter test` runs clean
+- [ ] Test names are descriptive: `test('rest timer counts down from configured duration')`, not `test('test rest timer')`
+- [ ] No commented-out tests; either fix them or delete them with a note
+
+## 8. OmniFlex-Specific Footguns
+
+- [ ] **`pubspec.yaml` unchanged** unless the change explicitly justifies a new package
+- [ ] **`firebase.json`, `firestore.rules`, `storage.rules` diffs reviewed manually** — these touch security, treat with care
+- [ ] **`analysis_options.yaml` unchanged** unless lint config change is the explicit purpose of the PR
+- [ ] **No new top-level routes** outside the established `go_router` config
+- [ ] **No deletion of tests** to make CI pass
+- [ ] **No `// ignore:` comments** without justification naming the lint rule and reason
+- [ ] **No `print()` statements** — use the logger
+- [ ] **No `debugPrint()` left in production code paths** (review-only callouts are fine)
+- [ ] **No commented-out code** unless paired with a TODO and ticket reference
+- [ ] **No App Check bypass code** committed (debug tokens are fine; bypass code is not)
+- [ ] **No personally identifiable info in logs** — Firebase log streams are not GDPR-clean by default
+- [ ] **No hardcoded API keys, secrets, or tokens** — environment variables or Firebase config only

--- a/.antigravity/skills/omniflex-content-brief/SKILL.md
+++ b/.antigravity/skills/omniflex-content-brief/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: omniflex-content-brief
+description: Use when generating educational or marketing content for OmniFlex social media, blog, email, or app copy. Activates on prompts about creating content for Supplement Sundays, Max Out Mondays, OmniFacts, Based or BS, Fitness Frauds, quote posts, or generic OmniFlex educational posts. Applies the OmniFlex Voice (plain ASCII, study-guide formatting, science-forward, direct, anti-hype, myth-busting) and outputs in copy-block format ready for Obsidian and multi-platform distribution.
+---
+
+# OmniFlex Content Brief Generation
+
+OmniFlex content has a specific voice and format. This skill encodes both so generated content is paste-ready for Obsidian, the Social Media Content Engine project, and direct platform distribution.
+
+## Activation Triggers
+
+Activate when a prompt mentions any of:
+- Generating content for OmniFlex social media
+- Specific content series: Supplement Sundays, Max Out Mondays, OmniFacts, Based or BS, Fitness Frauds, Quote Posts
+- Writing captions, blog posts, email newsletters, push notifications, app onboarding copy
+- Drafting educational content about supplements, training, nutrition, recovery, sports science
+- Creating myth-buster content or rebuttals to fitness misinformation
+
+## OmniFlex Voice — Hard Rules
+
+### Confident
+- Take a stance based on evidence
+- Do not hedge unnecessarily ("studies suggest" → "studies show" when the evidence is strong)
+- When evidence is genuinely mixed, say so explicitly: "the evidence is mixed" — do not pretend confidence
+
+### Science-forward
+- Cite sources where possible. Preferred: PubMed, NIH, peer-reviewed journals, ISSN, ACSM, NSCA position stands
+- Distinguish correlation from causation explicitly when relevant
+- Note study population (sex, training status, age) when generalizing
+- Cite mechanism *and* outcome when both exist; mechanism alone is weak
+
+### Direct
+- Short sentences over long
+- Active voice over passive
+- Lead with the conclusion, then evidence
+- Cut filler ("it's important to note that," "it's worth mentioning," "interestingly")
+
+### Anti-hype
+- Banned words: game-changing, revolutionary, cutting-edge, mind-blowing, insane, crazy, ultimate, secret, hack, unlock
+- Never describe a supplement, exercise, or method as "the best" without comparative evidence
+- Never imply a product is necessary; frame in terms of marginal benefit
+
+### Myth-busting
+- Frame educational content against the misconception when one exists
+- Name the myth directly; do not be vague about what's wrong
+- Show the evidence that contradicts it
+- Acknowledge nuance where the myth has a kernel of truth
+
+## Format Rules
+
+### Plain ASCII
+
+- No em dashes, fancy quotes, or special characters in copy meant for cross-platform distribution
+- Use straight quotes ("), straight apostrophes ('), regular hyphens (-)
+- This is a constraint inherited from cross-platform pasting (some platforms mangle Unicode)
+- Exception: when the platform supports it and the user explicitly asks for typographic polish
+
+### Study-guide structure for educational posts
+
+```
+HOOK (1-2 sentences)
+
+CLAIM / TAKEAWAY (1 sentence, bolded if platform allows)
+
+EVIDENCE (3-5 bullets)
+- Bullet 1
+- Bullet 2
+- Bullet 3
+
+NUANCE / WHO IT APPLIES TO (1-2 sentences)
+
+CALL TO ACTION (1 sentence)
+```
+
+### Copy-block format for distribution
+
+Every content output should be packaged as separate code blocks per platform. Example layout for a single educational post:
+
+````markdown
+## Caption — Instagram / Threads / Facebook
+
+```
+[Caption text here, with hashtags at end]
+```
+
+## Caption — Twitter/X (with thread breaks if needed)
+
+```
+1/ [First tweet, max 280 chars]
+
+2/ [Second tweet]
+
+3/ [Third tweet, ends with CTA]
+```
+
+## TikTok Hook (spoken, on-screen text)
+
+```
+HOOK (spoken): "[hook line]"
+ON-SCREEN: "[text overlay]"
+```
+
+## Sources Cited
+
+- [Author, Year. Title. Journal.](url)
+- [Author, Year. Title. Journal.](url)
+````
+
+The user copies blocks platform-by-platform without re-formatting.
+
+## Series-Specific Templates
+
+See `templates/post-formats.md` for ready-to-fill templates for each content series.
+
+## What NOT to Do
+
+- Do not generate health claims that exceed the evidence (e.g., "Creatine prevents Alzheimer's" — the evidence is preliminary)
+- Do not present mechanism-only evidence as outcome evidence
+- Do not cite single studies when meta-analyses exist
+- Do not generate content that could be construed as medical advice; reference medical consultation when symptoms are involved
+- Do not write content in voices other than OmniFlex Voice without explicit instruction (no "casual influencer" tone, no "stiff academic" tone)
+- Do not include affiliate links, brand partnerships, or product recommendations unless explicitly part of the brief
+
+## Output Format
+
+When generating an educational content brief:
+1. Confirm the series and topic
+2. Present the structure as code blocks per platform
+3. Include sources at the end
+4. Note any evidence gaps the user should be aware of before publishing
+5. Suggest visual treatment (cyberpunk overlay, HUD-style data display) only if the user mentions visual production

--- a/.antigravity/skills/omniflex-content-brief/templates/post-formats.md
+++ b/.antigravity/skills/omniflex-content-brief/templates/post-formats.md
@@ -1,0 +1,204 @@
+# OmniFlex Content Series Templates
+
+Ready-to-fill templates for each content series. Substitute bracketed values; keep the structure.
+
+---
+
+## Supplement Sundays
+
+Educational deep-dives on supplements: efficacy, dosing, who benefits, who doesn't.
+
+```
+HOOK
+[1-2 sentences naming the supplement and a question or surprising fact]
+
+THE CLAIM
+[1 sentence: what most people think this supplement does]
+
+THE EVIDENCE
+- [Mechanism: how it actually works in the body]
+- [Outcome data: what RCTs and meta-analyses show]
+- [Effective dose range with citation]
+- [Time to effect]
+- [Who responds, who doesn't]
+
+NUANCE
+[1-2 sentences on edge cases, contraindications, or population differences]
+
+VERDICT
+[1 sentence: worth it / not worth it / depends on X]
+
+SOURCES
+- [Citation 1]
+- [Citation 2]
+```
+
+Length target: 150-200 words for caption, ~60 seconds spoken for TikTok.
+
+---
+
+## Max Out Mondays
+
+Training-focused posts: technique, programming, mindset for serious lifting.
+
+```
+HOOK
+[Question or contrarian take on a training topic]
+
+THE PROBLEM
+[1-2 sentences naming the common mistake or sticking point]
+
+THE FIX
+- [Step 1 with cue or principle]
+- [Step 2]
+- [Step 3]
+
+WHY IT WORKS
+[1-2 sentences on the mechanism: leverage, neural drive, recovery, etc.]
+
+WHO THIS APPLIES TO
+[1 sentence: e.g., "Intermediate lifters with a sub-1.5x BW deadlift" or "Anyone whose squat depth is inconsistent"]
+
+ACTION
+[1 sentence: what to try in your next session]
+```
+
+Length target: 150-200 words for caption, demo video for TikTok showing fix in action.
+
+---
+
+## OmniFacts
+
+Single-fact posts. One science fact, one source, no fluff.
+
+```
+THE FACT
+[1 sentence stating the fact precisely]
+
+THE EVIDENCE
+[1-2 sentences with study or meta-analysis, including effect size when meaningful]
+
+WHY IT MATTERS
+[1 sentence on practical implication]
+
+SOURCE
+[1 citation]
+```
+
+Length target: 75-100 words. Designed for quote-card visual treatment.
+
+---
+
+## Based or BS
+
+Myth-busters. Take a common fitness claim, evaluate it, render verdict.
+
+```
+THE CLAIM
+"[Direct quote of the claim, in quotes]"
+
+VERDICT: [BASED / BS / PARTIALLY BASED]
+
+WHY
+- [Evidence point 1]
+- [Evidence point 2]
+- [Evidence point 3]
+
+THE NUANCE
+[1-2 sentences: what's true about the claim if anything, what's wrong]
+
+SOURCES
+- [Citation 1]
+- [Citation 2]
+```
+
+Length target: 125-175 words. Designed for split-screen visual: claim vs. verdict.
+
+---
+
+## Fitness Frauds
+
+Calling out misinformation, pseudoscience, or predatory marketing.
+
+```
+THE TAKE
+[1 sentence: the fraudulent claim, idea, or product being called out]
+
+WHO IS PUSHING IT
+[1 sentence: the influencer, brand, or community spreading it]
+
+WHY IT IS WRONG
+- [Evidence point 1]
+- [Evidence point 2]
+- [Evidence point 3]
+
+WHAT THEY GAIN
+[1 sentence: the financial or social incentive driving the misinformation]
+
+WHAT TO DO INSTEAD
+[1 sentence: the evidence-based alternative]
+
+SOURCES
+- [Citation 1]
+- [Citation 2]
+```
+
+Length target: 175-225 words. Tone is direct and unflinching but never personal-attack; criticize the claim, not the person's character.
+
+**Legal note for the agent**: do not generate Fitness Frauds content that names individual people unless the user has explicitly named them in the prompt. When in doubt, frame against the practice or claim rather than the person.
+
+---
+
+## Quote Posts
+
+Pulled quotes from research, athletes, or thinkers. No commentary.
+
+```
+[Quote, in quotes]
+
+— [Attribution]
+
+[Optional: 1 sentence of context if the quote is from a paper or book]
+
+SOURCE
+[Citation if from research, or work title if from a book/interview]
+```
+
+Length target: under 50 words total. Visual is the entire deliverable.
+
+---
+
+## Push Notification Templates
+
+For OmniFlex Nexus app push notifications:
+
+```
+TITLE (under 40 chars, no period at end)
+BODY (under 100 chars, action-oriented)
+DEEP LINK (path within app)
+```
+
+Examples:
+
+```
+TITLE: Workout streak: 7 days
+BODY: Day 8 starts now. Your last bench was 185x5.
+DEEP LINK: /workout/start
+```
+
+```
+TITLE: New OmniFact dropped
+BODY: Caffeine timing matters more than dose. Open to read.
+DEEP LINK: /content/omnifacts/caffeine-timing
+```
+
+---
+
+## Onboarding Copy
+
+For OmniFlex Nexus and FitMatch onboarding flows:
+
+- Each screen: 1 headline (under 8 words) + 1 sub-headline (under 25 words)
+- No corporate language ("Welcome to your fitness journey" → "Track lifts. See progress. That's it.")
+- Skip option always visible; never force-walk through onboarding
+- Final screen ends with a single primary CTA, not a wall of options

--- a/.antigravity/skills/omniflex-firestore-rules/SKILL.md
+++ b/.antigravity/skills/omniflex-firestore-rules/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: omniflex-firestore-rules
+description: Use when writing, modifying, or reviewing Firestore security rules for any OmniFlex project (Nexus, FitMatch, Zenith microsite, etc.). Also activates on Storage rule prompts since the patterns are similar. Ensures rules follow OmniFlex's defense-in-depth posture and match the standard collection structure used across OmniFlex Firebase projects.
+---
+
+# OmniFlex Firestore & Storage Security Rules
+
+OmniFlex Firebase projects share a common security posture. This skill encodes that posture so rules stay consistent across projects.
+
+## Activation Triggers
+
+Activate this skill when a prompt mentions any of:
+- Firestore rules, security rules, `firestore.rules`
+- Storage rules, `storage.rules`
+- Permission denied errors during Firebase reads/writes
+- Adding a new collection that needs access control
+- Reviewing or auditing existing rules
+
+## OmniFlex Defense-in-Depth Posture
+
+1. **Default deny**: every collection is denied by default. Allow rules are explicit.
+2. **Authentication required**: no anonymous reads or writes outside of explicit public collections (e.g., published content like Supplement Sundays cards).
+3. **App Check enforcement**: production rules require valid App Check tokens. Debug tokens registered for development.
+4. **Owner-or-admin pattern**: documents typically have an `ownerUid` field; access is granted to the owner or an admin custom claim.
+5. **Field-level validation**: writes validate field types, required fields, and immutable fields (e.g., `createdAt`, `ownerUid` cannot be modified after initial write).
+6. **Rate limiting**: writes that could be spammed (social posts, FitMatch likes, comments) include a `request.time` cooldown check against the last document.
+
+## Standard Helper Functions
+
+Every OmniFlex `firestore.rules` file should define these helpers at the top of `match /databases/{database}/documents`:
+
+```
+function isAuthenticated() {
+  return request.auth != null;
+}
+
+function isAppCheckValid() {
+  return request.auth != null && request.app_check != null;
+}
+
+function isOwner(resource) {
+  return isAuthenticated() && resource.data.ownerUid == request.auth.uid;
+}
+
+function isAdmin() {
+  return isAuthenticated() && request.auth.token.admin == true;
+}
+
+function isOwnerOrAdmin(resource) {
+  return isOwner(resource) || isAdmin();
+}
+
+function fieldsAreValidOnCreate(required, optional) {
+  return request.resource.data.keys().hasAll(required)
+    && request.resource.data.keys().hasOnly(required.concat(optional));
+}
+
+function isImmutableFieldUnchanged(fieldName) {
+  return !(fieldName in request.resource.data)
+    || resource.data[fieldName] == request.resource.data[fieldName];
+}
+```
+
+## Common Patterns
+
+See `templates/base-rules.rules` for a complete starting point covering:
+
+- User profile collection (owner read/write, public read of subset via separate `publicProfiles` collection)
+- Workout logs (owner-only)
+- Social feed posts (authenticated read, owner write, rate limited to 1 post per 30 seconds)
+- Match queue (FitMatch — authenticated read of own queue, no client writes)
+- Public content (Supplement Sundays cards, OmniFacts) — public read, admin write only
+
+## Review Checklist for Existing Rules
+
+When asked to review existing rules, run through:
+
+1. Is there a top-level default-deny? `match /{document=**} { allow read, write: if false; }` should be the last rule.
+2. Are admin-only collections actually admin-only, or do they leak via wildcard rules?
+3. Do create/update operations validate required fields?
+4. Are immutable fields (`createdAt`, `ownerUid`) protected on update?
+5. Are list operations restricted appropriately? `allow list` is often forgotten and defaults to allowing unbounded queries.
+6. Is App Check enforced where it matters?
+7. Are there any rate-limit-able write paths without cooldown checks?
+
+## Common Mistakes to Catch
+
+- **`allow read` without scoping `get` vs `list`**: someone can list a whole collection when you only meant to allow single-doc gets
+- **Missing `request.resource.data` validation on `update`**: lets clients write arbitrary new fields
+- **Comparing `request.resource.data.x == resource.data.x` for mutable fields**: this prevents legitimate updates
+- **Calling `get()` inside rules without batching consideration**: rule evaluations cost reads and can blow up costs
+- **Forgetting that `update` rules need both old and new data validation**: both `resource` (existing) and `request.resource` (proposed) must be validated
+
+## Output Format
+
+When generating new rules:
+1. Show the helpers section first
+2. Group rules by feature/collection with section comments
+3. End with the explicit default-deny
+4. After the rules block, list test cases that should pass and fail (paste-ready into `firestore.rules.test.js` or the emulator UI)

--- a/.antigravity/skills/omniflex-firestore-rules/templates/base-rules.rules
+++ b/.antigravity/skills/omniflex-firestore-rules/templates/base-rules.rules
@@ -1,0 +1,131 @@
+// OmniFlex base Firestore security rules
+// Drop into firestore.rules and adapt collection names per project.
+// Assumes App Check is enforced in production via Firebase Console settings,
+// not via rules (rules treat App Check as advisory; enforcement is project-level).
+
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // ===== Helper functions =====
+
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+
+    function isOwner(resource) {
+      return isAuthenticated() && resource.data.ownerUid == request.auth.uid;
+    }
+
+    function isAdmin() {
+      return isAuthenticated() && request.auth.token.admin == true;
+    }
+
+    function isOwnerOrAdmin(resource) {
+      return isOwner(resource) || isAdmin();
+    }
+
+    function hasRequiredFields(required) {
+      return request.resource.data.keys().hasAll(required);
+    }
+
+    function fieldsAreSubsetOf(allowed) {
+      return request.resource.data.keys().hasOnly(allowed);
+    }
+
+    function isImmutable(fieldName) {
+      return !(fieldName in request.resource.data)
+        || resource.data[fieldName] == request.resource.data[fieldName];
+    }
+
+    function isRecentEnough(lastTimestampField, cooldownSeconds) {
+      return resource == null
+        || request.time > resource.data[lastTimestampField] + duration.value(cooldownSeconds, 's');
+    }
+
+    // ===== Users =====
+    // /users/{uid} — private profile data, owner-only access
+
+    match /users/{uid} {
+      allow read: if isAuthenticated() && (request.auth.uid == uid || isAdmin());
+      allow create: if isAuthenticated()
+        && request.auth.uid == uid
+        && hasRequiredFields(['email', 'displayName', 'createdAt'])
+        && fieldsAreSubsetOf([
+          'email', 'displayName', 'photoUrl', 'createdAt',
+          'updatedAt', 'preferences', 'role'
+        ]);
+      allow update: if isAuthenticated()
+        && request.auth.uid == uid
+        && isImmutable('createdAt')
+        && isImmutable('email')
+        && isImmutable('role');  // role changes require admin via Cloud Function
+      allow delete: if false;  // never client-deletable; use Cloud Function for GDPR
+    }
+
+    // ===== Public profiles =====
+    // /publicProfiles/{uid} — derived subset of /users/{uid} maintained by Cloud Function
+
+    match /publicProfiles/{uid} {
+      allow read: if true;  // public
+      allow write: if false;  // Cloud Function only
+    }
+
+    // ===== Workout logs =====
+    // /workoutLogs/{logId} — owner-only
+
+    match /workoutLogs/{logId} {
+      allow read: if isOwner(resource);
+      allow create: if isAuthenticated()
+        && request.resource.data.ownerUid == request.auth.uid
+        && hasRequiredFields(['ownerUid', 'startedAt', 'exercises']);
+      allow update: if isOwner(resource)
+        && isImmutable('ownerUid')
+        && isImmutable('createdAt');
+      allow delete: if isOwner(resource);
+      allow list: if isAuthenticated()
+        && request.query.limit <= 100
+        && resource == null;  // no resource on list; rely on query constraints
+    }
+
+    // ===== Social feed posts =====
+    // /posts/{postId} — authenticated read, owner write, rate-limited
+
+    match /posts/{postId} {
+      allow read: if isAuthenticated();
+      allow create: if isAuthenticated()
+        && request.resource.data.ownerUid == request.auth.uid
+        && hasRequiredFields(['ownerUid', 'body', 'createdAt'])
+        && request.resource.data.body is string
+        && request.resource.data.body.size() <= 2000;
+      allow update: if isOwner(resource)
+        && isImmutable('ownerUid')
+        && isImmutable('createdAt');
+      allow delete: if isOwnerOrAdmin(resource);
+      allow list: if isAuthenticated() && request.query.limit <= 50;
+    }
+
+    // ===== Match queue (FitMatch) =====
+    // /matchQueue/{uid}/candidates/{candidateId} — read own queue, server-managed writes
+
+    match /matchQueue/{uid}/candidates/{candidateId} {
+      allow read: if isAuthenticated() && request.auth.uid == uid;
+      allow write: if false;  // Cloud Function only
+    }
+
+    // ===== Public content =====
+    // /content/{contentId} — public read, admin write
+    // Used for Supplement Sundays cards, OmniFacts, Based or BS, Fitness Frauds entries
+
+    match /content/{contentId} {
+      allow read: if true;
+      allow write: if isAdmin();
+    }
+
+    // ===== Default deny =====
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ service-account*.json
 test-results.log
 *.txt
 *.log
+
+# OmniFlex Antigravity workspace artifacts
+.antigravity/cache/
+.antigravity/runtime/
+mcp_config.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,192 @@
+# omnitask — Standing Instructions for Antigravity Agents
+
+This file is read by every Antigravity agent operating in this workspace. It encodes OmniTask conventions so agents do not have to be reminded each session.
+
+> **Source of truth**: `GEMINI.md` is the canonical project map for stack, architecture, file structure, services registry, and data schema. This file (AGENTS.md) carries agent-behavior rules and OmniFlex-ecosystem context. When the two disagree on stack details, GEMINI.md wins. When they disagree on agent behavior, this file wins.
+
+> **Companion docs**: `CLAUDE.md` mirrors this file for Claude Code, with additional CLI workflow rules. `.github/copilot-instructions.md` covers GitHub Copilot. Keep all four roughly in sync when stack or convention changes land.
+
+---
+
+## Project Identity
+
+- **Name**: omnitask
+- **Description**: OmniTask — Angular 21 + Firebase task management application (Asana-like feature parity)
+- **Org**: OmniFlex LLC (DBA OmniFlex Fitness) — OmniTask is part of the OmniFlex brand ecosystem
+- **Founder/sole maintainer**: Bertin Kenol
+- **Production branch**: `live` (deploys to Cloud Run via GitHub Actions on push)
+- **Default working branch**: `dev`; feature branches off `live` per `/feature-branch` workflow
+
+---
+
+## Stack (summary — full detail in GEMINI.md)
+
+### Frontend
+- **Angular 21** with **standalone components**, **signals**, **`inject()`** dependency injection, **OnPush** change detection
+- **TypeScript 5.9** strict mode
+- **TailwindCSS 3** with custom dark theme; design system per GEMINI.md "Brand Colors"
+- **No NgModules** — standalone components exclusively
+- **Signal-first state management** — prefer `signal()` and `computed()` over RxJS BehaviorSubject
+
+### Backend
+- **Firebase**: Firestore (modular API only), Authentication (email/password + Google SSO), Cloud Functions (Node.js 20.x)
+- **Firebase project**: `omnitask-475422`
+- **Firestore security rules**: version 2; production rules active
+- **Functions**: TypeScript, deployed via `firebase deploy --only functions`
+
+### Deployment
+- **Production**: Google Cloud Run (Docker + Nginx) via GitHub Actions on push to `live`
+- **Static assets / Functions**: Firebase Hosting + Firebase Functions
+- **CI/CD**: GitHub Actions (build, test, deploy)
+
+### Tooling
+- **Version control**: Git, hosted on GitHub at `OmniFlexFitness/OmniTask`
+- **Package manager**: npm (lockfile NOT committed; see `.gitignore`)
+- **Local dev**: `npm install && ng serve` → `http://localhost:4200`
+- **Firebase emulators**: `firebase emulators:start` for offline Firestore/Functions testing
+
+---
+
+## Brand
+
+OmniTask sits inside the OmniFlex brand ecosystem but uses its own product-specific palette (cyberpunk-adjacent, glassmorphism-heavy, dark-mode-first). The OmniFlex Nexus / FitMatch neon palette does NOT apply here.
+
+### Visual Identity (per GEMINI.md "Brand Colors")
+- **Primary Purple**: `#8b5cf6` — primary actions, CTAs
+- **Secondary Blue**: `#3b82f6` — secondary actions, links, info states
+- **Accent Cyan**: `#06b6d4` — glows, highlights, hover accents
+- **Background**: `#0f0f0f` to `#1a1a1a` (dark)
+- **Surface**: `rgba(255,255,255,0.05)` (glassmorphism panels)
+
+### Voice (OmniFlex-wide)
+- **Confident**: take a stance based on evidence; do not hedge unnecessarily
+- **Direct**: short sentences over long ones; active voice over passive
+- **Anti-hype**: do not use "game-changing," "revolutionary," "cutting-edge," or similar empty boosters
+- **No-nonsense**: error messages lead with what happened, then what the user can do
+
+---
+
+## Code Conventions
+
+### Architecture (per GEMINI.md "Behavioral Rules")
+
+Enforced (do these):
+- **Standalone components**: every component must use `standalone: true`
+- **Signals over BehaviorSubject**: `signal()` and `computed()` are the default
+- **`inject()` for DI**: never constructor injection
+- **OnPush change detection**: default to `changeDetection: ChangeDetectionStrategy.OnPush`
+- **Service layer for Firestore**: components NEVER call Firestore directly; route through `core/services/`
+- **Error handling**: try/catch around all Firestore calls, log to console, surface user-friendly toast via `ToastService`
+
+Forbidden (do not do these):
+- **No `any` type** — use `unknown` if uncertain
+- **No constructor DI** — always `inject()`
+- **No silent failures** — every catch must at minimum log
+- **No raw error messages to users** — use `ToastService` with friendly text
+- **No NgModules**
+- **No legacy Firebase compat API** — modular API (`@angular/fire/firestore`) only
+
+### File Structure (per GEMINI.md)
+
+```
+src/app/
+├── core/
+│   ├── models/         # TypeScript interfaces (Project, Task, User, etc.)
+│   ├── services/       # AuthService, ProjectService, TaskService, ThemeService, ToastService
+│   └── guards/         # Route guards
+├── features/
+│   ├── dashboard/
+│   ├── projects/
+│   ├── tasks/
+│   ├── calendar/
+│   └── settings/
+└── shared/
+    └── components/     # Reusable buttons, modals, inputs
+```
+
+Match this layout exactly. New features go under `features/{name}/` with their own components, services-if-needed, and templates.
+
+### Commit Discipline
+- **Conventional commits**: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`, `ci:`
+- **Subject line**: imperative mood, ≤72 chars, no trailing period
+- **Body**: explain *why*, not *what*
+- **No commits to `live`** — feature branches only, merge via PR (CI/CD deploys on push to `live`, so direct commits ship straight to production)
+- **Branch naming**: `feature/`, `fix/`, `chore/`, `claude/`, `codex/` prefixes per existing repo convention
+
+---
+
+## Workflow Rules
+
+### Planning
+- For changes touching more than 3 files, generate a plan in `docs/plans/{feature_name}.md` before writing code
+- Plans must include: scope, files affected, implementation steps, test plan, rollback consideration
+- Use the `/feature-branch` workflow for properly named branches (per GEMINI.md "Available Workflows")
+
+### Testing
+- Run `ng test` before declaring any task done
+- Run `ng build --configuration production` to catch production-only build issues
+- Run `ng lint` if configured
+- Confirm all green before committing
+- Every new component/service should have at least a smoke test
+
+### Multi-Agent Coordination (Manager View)
+When running parallel agents in Antigravity:
+- **Agent A**: feature implementation in `src/app/features/{name}/`
+- **Agent B**: related tests
+- **Agent C**: documentation updates and Firestore rule changes
+- Agents do not share write access to overlapping files; coordinate via the plan artifact
+
+### Reviewing Agent Output
+Before approving a Manager View artifact:
+1. Confirm files changed match the plan
+2. Confirm no `any` types introduced
+3. Confirm Firestore calls live in services, not components
+4. Confirm components use `standalone: true`, OnPush, `inject()`, and signals where applicable
+5. Confirm error paths log AND surface user-friendly messages
+6. Confirm no new top-level npm packages without justification in the commit body
+
+---
+
+## Forbidden Without Explicit Approval
+
+These are footguns that have caused real OmniTask production issues. Do not perform them without asking first:
+
+- Modifying `package.json` to add or upgrade dependencies (always show the diff and the reason)
+- Modifying `firebase.json`, `firestore.rules`, `firestore.indexes.json`, or `storage.rules` without showing the diff first
+- Modifying `angular.json` or `tsconfig*.json`
+- Modifying CI workflows in `.github/workflows/`
+- Modifying `Dockerfile`, `nginx.conf`, or anything in the deploy chain
+- Force-pushing to ANY branch
+- Pushing or merging directly to `live` (production deploy is automatic on push to `live`)
+- Deleting tests "to make CI pass"
+- Committing files matching `*-key.json`, `service-account*.json`, `.env*`, `firebase-sa-key.json` — these are gitignored for a reason
+- Running migrations or schema changes against the production Firebase project (`omnitask-475422`) — use the emulators
+
+---
+
+## Useful Context Locations
+
+- **GEMINI.md** (this repo, root) — canonical project map; check first for stack/architecture/services questions
+- **`.github/copilot-instructions.md`** (this repo) — Copilot's view of the same conventions
+- **`.gemini/styleguide.md`** (this repo) — style nuances Gemini Code Assist reads
+- **Obsidian vault**: `C:/OmniFlex Vault/`
+  - `Tech/` — technical decision logs, ADRs, troubleshooting notes
+  - `Knowledge/` — cross-cutting reference material
+  - `Design/` — brand guidelines, design system specs
+- **Brand assets**: Adobe Creative Cloud Library "OmniFlex Brand"
+- **Figma**: design system source of truth for OmniTask components
+- **Drive**: `omniflexfitness.com` Workspace, organized by Brand/Content/Products/Internship/Research/Tech/Personal
+
+When agent tasks reference visual specs or business context, check these locations via the appropriate MCP server before guessing.
+
+---
+
+## Skills Available in This Workspace
+
+Located under `.antigravity/skills/`:
+
+- `omniflex-firestore-rules/` — Firestore security rule patterns and templates (universal across OmniFlex Firebase projects)
+- `omniflex-content-brief/` — Educational content drafting in OmniFlex Voice
+- `omniflex-code-review/` — Pre-commit code review checklist (review for Angular relevance; some items may be Flutter-flavored from the template)
+
+The original template included a `omniflex-flutter-widget/` skill; it was removed for this workspace because OmniTask is Angular, not Flutter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# omnitask — Claude Code Operating Notes
+
+This file is read by Claude Code when invoked in this workspace. It mirrors `AGENTS.md` for shared conventions plus adds Claude-Code-specific workflow rules.
+
+> **Hierarchy**: `GEMINI.md` (project map / source of truth) → `AGENTS.md` (agent-behavior + ecosystem context) → this file (Claude-Code-CLI-specific rules). When sections overlap, the more specific document wins for its narrow concern.
+
+For canonical stack, brand, code conventions, and forbidden actions, see `AGENTS.md` and `GEMINI.md`. The lists below cover only the *additional* rules that apply when Claude Code is the executor.
+
+---
+
+## When Claude Code Should Plan First
+
+Generate a plan in `docs/plans/{feature_name}.md` before implementing if any of these apply:
+
+- The change touches more than 3 files
+- The change adds a new feature directory under `src/app/features/`
+- The change modifies Firestore security rules (`firestore.rules`) or Cloud Functions
+- The change touches authentication, payment, role/permission, or other security-sensitive surfaces
+- The change modifies the deploy chain (Dockerfile, nginx config, GitHub Actions workflows)
+- The user's prompt is open-ended (e.g., "improve the dashboard") rather than scoped (e.g., "add empty-state illustration to dashboard")
+
+Plans must include scope, files affected, implementation steps, test plan, and rollback considerations.
+
+---
+
+## Pre-Done Checklist
+
+Before declaring any task complete, run and pass:
+
+```bash
+ng build --configuration production
+ng test --watch=false --browsers=ChromeHeadless
+ng lint    # if configured
+```
+
+If any step fails, fix and re-run before reporting completion. Do not paper over warnings with `// @ts-ignore` or `// eslint-disable-next-line` comments without justification in a code comment that names the specific rule and reason.
+
+For Firebase Functions changes, additionally run:
+
+```bash
+cd functions && npm run build && npm run lint
+```
+
+---
+
+## When to Reach for MCP Tools
+
+Use MCP tools rather than guessing when:
+
+- A prompt references a Figma component → use the Figma MCP to fetch the actual spec
+- A prompt references a doc in Drive → use the Drive MCP (or `filesystem-drive-mirror`) to read it
+- A prompt references a GitHub issue or PR → use the GitHub MCP to read the body and comments
+- A prompt references "the spec" without a path → search Drive's Tech and Design folders before asking the user where it lives
+- A prompt asks about Firestore data, deployed Functions, or Firebase project state → use the Firebase MCP rather than guessing or shelling out
+
+Do not chain more than 3 MCP calls without surfacing intermediate results to the user.
+
+---
+
+## Obsidian Vault Integration
+
+The Obsidian vault at `C:/OmniFlex Vault/` is canonical for cross-cutting OmniFlex knowledge.
+
+Read these locations when relevant context is missing:
+- `C:/OmniFlex Vault/Tech/` — technical decisions, ADRs, troubleshooting
+- `C:/OmniFlex Vault/Knowledge/` — reference material
+- `C:/OmniFlex Vault/Design/` — brand guidelines, design language
+- `C:/OmniFlex Vault/Tech/antigravity-template/` — the canonical template this workspace was bootstrapped from; check here when propagating template updates back to the source
+
+Write back to the vault only when explicitly instructed. Do not auto-update vault files based on session work.
+
+---
+
+## Output Format Rules
+
+When Claude Code generates content for Bertin to consume directly (not code in the repo):
+
+- **Copy-paste content** (commit messages, PR descriptions): always in code blocks
+- **Long-form deliverables** (docs, scripts, multi-section drafts): file artifacts in `docs/` or `scripts/`
+- **Decision support**: lead with the recommendation, then the reasoning. Do not list pros/cons without choosing
+- **Technical explanations**: study-guide format with headers and bullets when substantive; prose for short answers
+
+When generating content for end users of OmniTask (UI copy, push notifications, error messages, marketing strings):
+
+- Apply the OmniFlex Voice (see `AGENTS.md` → Brand → Voice)
+- Plain ASCII unless emoji or special characters are explicitly required
+- No trailing periods on UI button labels or push notification titles
+- Error messages: lead with what happened, then what the user can do
+- Surface errors via `ToastService`, never as raw exceptions
+
+---
+
+## Code Review Mode
+
+When prompted to review a diff or changeset, run the `omniflex-code-review` skill checklist before reporting findings. The checklist lives at `.antigravity/skills/omniflex-code-review/checklist.md`. Some items in that checklist were written for Flutter — apply the *spirit* (null-safety equivalents in TS, brand-token equivalents in Tailwind, etc.) and skip Flutter-specific items.
+
+If any item in the checklist refers to Flutter packages, Dart, or pubspec.yaml, treat it as: "verify the Angular/TypeScript equivalent — strict types, no `any`, signal usage, modular Firebase API, no NgModules, etc."
+
+Do not approve a change in review mode without explicitly running the checklist. If the user says "looks good, ship it" before checklist completion, complete the checklist anyway and surface anything found.
+
+---
+
+## Working Across Repos
+
+Commands that span multiple OmniFlex repos (e.g., propagating a template update from `C:/OmniFlex Vault/Tech/antigravity-template/`) should be invoked from the parent directory `C:/Antigravity/` or wherever OmniFlex repos live, not from inside any individual repo. Cross-repo commands modify state in unexpected places, so:
+
+- Confirm the list of repos affected before any write operation
+- Operate on one repo at a time; commit between repos
+- Surface any repo where the operation failed to apply cleanly
+
+---
+
+## Failure Modes to Anticipate
+
+- **Firebase emulators not running**: integration tests will hang or hit production. Detect via `firebase emulators:exec` health check; surface clearly to user rather than waiting forever or silently using production.
+- **Stale `node_modules`**: TypeScript "Cannot find module" errors that look like bad imports are often stale node_modules after a branch switch. Run `npm ci` (or `rm -rf node_modules && npm install`) before deeper investigation.
+- **`functions/node_modules` drift**: the `functions/` directory has its own `package.json` and `node_modules`. After pulling, you may need `cd functions && npm ci` separately from the root install.
+- **Angular cache poisoning**: weird template-not-found or schema errors after a major refactor often resolve with `rm -rf .angular/cache`.
+- **Firebase Auth token expiry in dev**: causes "permission denied" Firestore errors that look like rules bugs. Refresh the auth state (sign out and back in) before assuming security rules are wrong.
+- **Cloud Run deploy fails on push to `live`**: GitHub Actions deploy log is the source of truth. Don't push retry commits to `live` to "kick CI" — that ships untested code to production. Open a PR back to `live` instead.
+- **Service account project mismatch**: `OMNIFLEX_FIREBASE_SERVICE_ACCOUNT` env var must reference a JSON key for project `omnitask-475422` for the Firebase MCP to work in this workspace. If it points elsewhere, the MCP will return 403s that look like permission bugs.
+- **Antigravity MCP tool-name regex**: tool names with dots (`.`) fail Antigravity's `^[a-zA-Z0-9_-]` validation. If a server fails to register, scaffold a Node.js sanitizing proxy — don't disable the server.

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,0 +1,78 @@
+{
+  "_comment": "OmniFlex Antigravity workspace MCP server registrations. Renamed to mcp_config.json during bootstrap. Schema follows the standard MCP server registration format. Antigravity has a known footgun where tool names containing dots fail validation against ^[a-zA-Z0-9_-]; if a server uses dot-notation tool names, route it through a sanitizing proxy (see C:/OmniFlex Vault/Tech/mcp-proxy-pattern.md if it exists, or have Claude Code scaffold one).",
+  "mcpServers": {
+    "github": {
+      "_comment": "GitHub repo operations: read issues, PRs, file contents, run actions. Requires GITHUB_PERSONAL_ACCESS_TOKEN env var with appropriate scopes (repo, read:org).",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "filesystem-vault": {
+      "_comment": "Read access to the OmniFlex Obsidian vault for cross-cutting context. Restricted to read-only by configuring the server with --readonly. Path uses Windows-style with forward slashes for Git Bash compatibility.",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "--readonly",
+        "C:/OmniFlex Vault"
+      ]
+    },
+    "filesystem-drive-mirror": {
+      "_comment": "Optional: if you mirror Google Drive locally via Drive for Desktop, point this at the mirror folder. Faster than the Drive MCP for read-heavy workflows. Comment out if not using a mirror.",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "--readonly",
+        "G:/My Drive"
+      ]
+    },
+    "firebase": {
+      "_comment": "Firebase project management: emulator control, deploy, logs, Firestore inspection. Requires firebase-tools installed globally (npm i -g firebase-tools) and `firebase login` already completed.",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@gannonh/firebase-mcp"
+      ],
+      "env": {
+        "SERVICE_ACCOUNT_KEY_PATH": "${OMNIFLEX_FIREBASE_SERVICE_ACCOUNT}",
+        "FIREBASE_STORAGE_BUCKET": "omnitask-475422.firebasestorage.app"
+      }
+    },
+    "figma": {
+      "_comment": "Figma component and frame access. Requires FIGMA_ACCESS_TOKEN env var. Antigravity should rename any dot-notation tool names automatically; if you see 'invalid tool name' errors, route through the proxy pattern.",
+      "command": "npx",
+      "args": [
+        "-y",
+        "figma-developer-mcp"
+      ],
+      "env": {
+        "FIGMA_API_KEY": "${FIGMA_ACCESS_TOKEN}"
+      }
+    },
+    "_disabled_examples": {
+      "_comment": "Servers below are commented-out examples. Uncomment by moving them into the parent mcpServers object and removing the _disabled wrapper.",
+      "supabase": {
+        "_comment": "If a project uses Supabase instead of Firebase",
+        "command": "npx",
+        "args": [
+          "-y",
+          "@supabase/mcp-server-supabase"
+        ]
+      },
+      "vercel": {
+        "_comment": "Deployment management for landing pages and the Zenith microsite",
+        "command": "npx",
+        "args": [
+          "-y",
+          "@vercel/mcp-server"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Bootstraps OmniTask with the OmniFlex Antigravity + Claude Code template (v1.0) so every agent operating in this workspace gets consistent standing instructions, MCP server registrations, and reusable skills without per-session re-explanation.

- Adds `AGENTS.md` (every Antigravity agent reads this) and `CLAUDE.md` (Claude Code-specific overlay), both rewritten from the canonical Flutter template to match this codebase's Angular 21 + Firebase stack
- Adds `mcp_config.json` registering GitHub, filesystem-vault (Obsidian, read-only), filesystem-drive-mirror, Firebase (against `omnitask-475422`), and Figma MCP servers
- Adds `+Workspace/draft-pr.md` slash-command workflow for `/draft-pr`
- Adds three reusable skills under `.antigravity/skills/`: `omniflex-firestore-rules`, `omniflex-content-brief`, `omniflex-code-review`
- Appends three lines to `.gitignore` for Antigravity workspace artifacts (`.antigravity/cache/`, `.antigravity/runtime/`, `mcp_config.local.json`)

No code changes outside the new agent/MCP config layer. No `package.json`, `firebase.json`, `firestore.rules`, `angular.json`, `tsconfig*`, CI workflow, or deploy-chain modifications.

## Why

Per `C:/OmniFlex Vault/Tech/antigravity-template/` (the canonical OmniFlex Antigravity template), every OmniFlex repo gets the same agent guidance layer so:
- Antigravity agents start each session with the right stack/architecture/conventions in context
- Claude Code knows when to plan vs implement, what pre-done checklist to run (`ng build`, `ng test`, `ng lint`), and which MCP tools to reach for
- Per-machine secrets stay in env vars, never in the repo

## What I customized vs the template default

| Change | Why |
| --- | --- |
| `AGENTS.md` and `CLAUDE.md` rewritten Flutter → Angular 21 + Firebase | Template was written for OmniFlex Nexus (Flutter); this repo is Angular |
| Removed `omniflex-flutter-widget` skill | Irrelevant to an Angular workspace |
| `mcp_config.json` `FIREBASE_STORAGE_BUCKET` set to `omnitask-475422.firebasestorage.app` | Template substituted `omnitask.firebasestorage.app` from the project name; corrected to the real Firebase project ID |
| Both AGENTS.md and CLAUDE.md cross-reference `GEMINI.md` as source of truth for stack/architecture/services | Avoids drift; GEMINI.md is already the canonical project doc here |

## Coexists with existing agent guidance

This repo already has `GEMINI.md` (canonical), `.github/copilot-instructions.md`, `.gemini/` (Code Assist), and `.agent/`. The new `AGENTS.md`/`CLAUDE.md` reference `GEMINI.md` rather than duplicating its content, so all five files form a layered guidance system rather than conflicting sources.

## Required env vars (NOT in this repo)

These must be set in `~/.bashrc` (or per-shell) for the MCP servers to authenticate:

- `GITHUB_PERSONAL_ACCESS_TOKEN`
- `FIGMA_ACCESS_TOKEN`
- `OMNIFLEX_FIREBASE_SERVICE_ACCOUNT` — path to a service account JSON for Firebase project `omnitask-475422`, kept in `~/.omniflex-secrets/` (outside the repo and outside the Obsidian vault)

## Test plan

- [ ] Open the workspace in Antigravity (`agy .` or `antigravity .`) and confirm:
  - [ ] AGENTS.md is detected and surfaced to the agent
  - [ ] All five MCP servers register without "invalid tool name" errors (regex `^[a-zA-Z0-9_-]` is strict; if any fail, scaffold a sanitizing proxy per `CLAUDE.md` failure-modes section)
  - [ ] The three skills appear in agent context when their trigger keywords are mentioned
  - [ ] `/draft-pr` slash command resolves
- [ ] In Antigravity's integrated terminal, run `claude --version` to confirm Claude Code is callable from the workspace shell
- [ ] Verify the Firebase MCP can list collections in `omnitask-475422` (proves service account auth works end-to-end)
- [ ] Verify no secrets leaked into the diff (`git diff --cached | grep -E 'ghp_|github_pat_|figd_|BEGIN PRIVATE KEY'` should return nothing)

## Rollback

This change is purely additive at the config layer (one `.gitignore` modification). To revert: revert this PR, delete the new files, undo the `.gitignore` append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)