### PR TITLE
Fix glow clipping on My Tasks status donut

### DIFF
--- a/src/app/features/my-tasks/components/my-tasks-overview.component.css
+++ b/src/app/features/my-tasks/components/my-tasks-overview.component.css
@@ -63,3 +63,8 @@
 .mt-mini-stat {
   @apply rounded-md py-1.5 bg-slate-900/40 border border-white/5;
 }
+
+/* Status donut: let drop-shadow glow extend past the SVG viewport. */
+.donut {
+  overflow: visible;
+}

--- a/src/app/features/my-tasks/components/my-tasks-overview.component.html
+++ b/src/app/features/my-tasks/components/my-tasks-overview.component.html
@@ -123,7 +123,7 @@
       } @else {
         @let donut = statusBreakdown();
         <div class="flex items-center gap-5">
-          <svg viewBox="0 0 100 100" class="w-36 h-36 -rotate-90 flex-shrink-0">
+          <svg viewBox="0 0 100 100" class="w-36 h-36 -rotate-90 flex-shrink-0 donut">
             <circle cx="50" cy="50" r="45" fill="none" stroke="rgba(255,255,255,0.06)" stroke-width="10" />
             @for (arc of donut.arcs; track arc.key) {
               @if (arc.count > 0) {


### PR DESCRIPTION
## Summary

The radial dial in **My Status Breakdown** (My Tasks → Overview) was rendering with hard cutoffs on the edges of its glow. Each arc applies `drop-shadow(0 0 4px ...)` for the cyber-glow look, but the SVG viewBox is `0 0 100 100` and the stroke spans exactly to the edges (cx=50, r=45, stroke-width=10), so the blur halo was being clipped at the SVG viewport boundary.

The dashboard's project overview donut already solved this with a `.donut { overflow: visible; }` rule on `project-overview.component.css`. This PR mirrors the same fix on the My Tasks overview donut.

## Changes

- `my-tasks-overview.component.html`: add the `donut` class to the status SVG.
- `my-tasks-overview.component.css`: add a local `.donut { overflow: visible; }` rule (the styles in this component are scoped, so we can't rely on the project-overview stylesheet).

## Test plan

- [ ] Open the My Tasks page and inspect the **My Status Breakdown** donut — glow halos should fade smoothly outward instead of cutting off at the SVG box.
- [ ] Resize the window / verify the legend layout next to the donut isn't visually shifted.
- [ ] Confirm the dashboard project overview donut still renders correctly (untouched, but worth a glance).

https://claude.ai/code/session_01AvL11SGHGvUEhE5i58LPo3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvL11SGHGvUEhE5i58LPo3)_