### PR TITLE
fix(ci): make live deploy resilient to existing release tags

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - live
 
+concurrency:
+  group: deploy-live
+  cancel-in-progress: false
+
 env:
   # Note: GCP_PROJECT_ID must be set in repository secrets
   PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
@@ -41,17 +45,30 @@ jobs:
       - name: Get version
         id: version
         run: |
-          # Get the latest tag or start from v0.0.00
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.00")
-          # Extract version numbers
+          # Refresh tags from origin so concurrent or re-run deploys don't
+          # collide on a tag that already exists remotely.
+          git fetch --tags --force origin
+          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.00"
+          fi
           MAJOR=$(echo $LATEST_TAG | cut -d. -f1 | tr -d 'v')
           MINOR=$(echo $LATEST_TAG | cut -d. -f2)
           PATCH=$(echo $LATEST_TAG | cut -d. -f3)
-          # Increment patch version by 1 (display format will be .01, .02, etc.)
-          NEW_PATCH=$((PATCH + 1))
-          # Format patch with leading zero if needed (01, 02, etc.)
-          FORMATTED_PATCH=$(printf "%02d" $NEW_PATCH)
-          NEW_VERSION="v${MAJOR}.${MINOR}.${FORMATTED_PATCH}"
+          # Increment patch until we find a tag that doesn't exist locally or
+          # on the remote. Guards against re-runs landing on an existing tag.
+          NEW_PATCH=$((10#$PATCH + 1))
+          while : ; do
+            FORMATTED_PATCH=$(printf "%02d" $NEW_PATCH)
+            CANDIDATE="v${MAJOR}.${MINOR}.${FORMATTED_PATCH}"
+            if git rev-parse -q --verify "refs/tags/${CANDIDATE}" >/dev/null \
+               || git ls-remote --exit-code --tags origin "refs/tags/${CANDIDATE}" >/dev/null 2>&1; then
+              NEW_PATCH=$((NEW_PATCH + 1))
+              continue
+            fi
+            break
+          done
+          NEW_VERSION="$CANDIDATE"
           DISPLAY_VERSION="${MAJOR}.${MINOR}.${FORMATTED_PATCH}"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "display_version=$DISPLAY_VERSION" >> $GITHUB_OUTPUT
@@ -112,8 +129,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ steps.version.outputs.version }}
-          git push origin ${{ steps.version.outputs.version }}
+          TAG="${{ steps.version.outputs.version }}"
+          # If the tag was created out-of-band between the version step and now
+          # (e.g. another pipeline run), skip rather than fail the deploy.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping tag push."
+            exit 0
+          fi
+          git tag "${TAG}"
+          git push origin "${TAG}"
 
       - name: Output deployment URLs
         run: |


### PR DESCRIPTION
## Summary

The `Deploy to Cloud Run & Firebase` workflow has been failing on `live` at the final `Create Release Tag` step:

```
! [rejected]          v0.0.81 -> v0.0.81 (already exists)
error: failed to push some refs to 'https://github.com/OmniFlexFitness/OmniTask'
```

Root cause: the version step uses `git describe --tags --abbrev=0` and increments by one, but the workflow has no concurrency control and no defense against the computed tag already existing on the remote. A re-run or a second push to `live` that overlaps an in-flight deploy can produce two runs that both compute the same patch number — the second loses the race and fails the whole pipeline (after build, image push, Cloud Run deploy, and Firebase deploy already completed).

## Fix

- Add `concurrency: deploy-live` so deploys serialize on `live`.
- Refresh tags from origin in the version step and walk forward past any existing tag — both locally and on origin — when computing the next version. Also forces base-10 evaluation (`10#$PATCH`) so a zero-padded patch like `08` doesn't trip the octal parser.
- In the tag step, if the tag has appeared on origin between the version step and the push (e.g. another run won the race), skip the push instead of erroring the entire deploy.

## Test plan

- [ ] After merge, push to `live` and confirm the workflow computes the next available patch (`v0.0.82`+) and pushes the tag successfully.
- [ ] Re-run the same workflow run; confirm it no-ops the tag push instead of failing.
- [ ] Trigger two pushes to `live` close together and confirm the concurrency group serializes them and neither fails on the tag step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGVgVEEtUoN7qv3h4oyZpn)_