### PR TITLE
Add configurable per-project task point values with PERT support

### DIFF
--- a/docs/plans/task-point-values.md
+++ b/docs/plans/task-point-values.md
@@ -1,0 +1,103 @@
+# Task Point Values — Implementation Plan
+
+## Scope
+
+Add a per-project, configurable "point value" system so every task can carry an
+effort rating. Six scale types are supported; three of them support optional
+PERT (Optimistic / Most Likely / Pessimistic) inputs that compute a weighted
+estimate and standard deviation. The configuration lives on the `Project`
+document; the value lives on each `Task` document.
+
+## Files affected
+
+1. `src/app/core/models/domain.model.ts` — add types and interfaces for scale
+   configs and per-task values, extend `Project` and `Task`.
+2. `src/app/core/utils/point-scale.utils.ts` (new) — value generation, PERT
+   computation, aggregation, validation, migration helpers.
+3. `src/app/core/utils/point-scale.utils.spec.ts` (new) — unit tests.
+4. `src/app/features/projects/components/point-scale-manager.component.{ts,html,css}` (new) —
+   project-settings UI: choose a scale, configure it, preset templates,
+   PERT toggle.
+5. `src/app/features/projects/components/project-settings-panel.component.html` —
+   wire the new manager into the settings panel.
+6. `src/app/features/projects/components/project-settings-panel.component.ts` —
+   import the new manager.
+7. `src/app/features/tasks/components/task-point-value-input.component.{ts,html,css}` (new) —
+   per-task input that adapts to the scale and PERT toggle.
+8. `src/app/features/tasks/task-create-modal.component.ts` + html — wire the
+   input into task creation.
+9. `src/app/features/tasks/task-detail-modal.component.ts` + html — wire the
+   input into task editing.
+10. `src/app/features/tasks/task-list-view.component.html` — display the point
+    value as a badge in the list.
+11. `src/app/core/services/project.service.ts` — `updatePointScaleConfig`
+    helper that triggers nearest-equivalent migration of existing task values.
+
+## Implementation steps
+
+### 1. Types and utilities
+- `PointScaleId` discriminator + per-scale config interface
+  (`NumericScaleConfig`, `TimeScaleConfig`, `TShirtScaleConfig`,
+  `AnimalScaleConfig`, `MultiFactorScaleConfig`, `CreditHoursScaleConfig`).
+- `PointValue` discriminated union covering single values, PERT triples,
+  T-shirt / animal labels, and multi-factor maps.
+- Utilities:
+  - `getAllowedValues(config)` — for numeric / time-preset / credit-hours-bucket.
+  - `computePertEstimate({ o, m, p })` — (O + 4M + P)/6.
+  - `computePertStdDev({ o, m, p })` — (P − O)/6.
+  - `pointValueScalar(value, config)` — projection of any value to a number
+    for aggregation.
+  - `aggregateValues(values, config)` — totals, PERT roll-up with total SD.
+  - `formatPointValue(value, config)` — string for display.
+  - `migrateValue(value, fromConfig, toConfig)` — nearest-equivalent mapping
+    used when the project changes its scale.
+
+### 2. Project config storage
+- Extend `Project` with `pointScaleConfig?: PointScaleConfig`. Absent =
+  feature off for that project.
+- `ProjectService.updatePointScaleConfig(projectId, newConfig)`: read all
+  tasks, map their values via `migrateValue`, write the new config + the
+  per-task value migrations. Batch updates.
+
+### 3. Project settings UI
+- New component `<app-point-scale-manager>` rendered in
+  `project-settings-panel`.
+- Scale-type selector with cards (one per scale). Selecting a scale shows a
+  template / preset picker (numeric) or shows the scale-specific config form
+  (time, multi-factor, credit-hours).
+- For numeric and time-unit scales: PERT toggle.
+- "Save" persists via `updatePointScaleConfig`. Confirm before changing
+  scale type when tasks already have values.
+
+### 4. Task input UI
+- New component `<app-task-point-value-input>` accepts the project's
+  `pointScaleConfig` and a current `PointValue` and emits changes.
+- Renders different controls:
+  - Numeric / time / credit_hours non-PERT → single select or numeric input.
+  - PERT mode → three controls (O / M / P) with the same allowed values.
+  - T-Shirt → segmented control of size labels.
+  - Animal → segmented control of animal labels with icons.
+  - Multi-Factor → one input per configured factor.
+- Shows the computed score / weighted average underneath.
+
+### 5. Wire into modals
+- Add input + form-control binding in `task-create-modal` and
+  `task-detail-modal`. Store on `Task.pointValue`.
+- Project-level aggregation in `project-detail` header (left to a follow-up
+  if time-bound; the manager already exposes the helpers).
+
+### 6. Display
+- In `task-list-view`, show a compact badge next to priority. Use
+  `formatPointValue` for the label.
+
+## Test plan
+- Unit tests for value generation (`linear`, `fibonacci`, `powers_of_two`),
+  PERT math, aggregation, migration of single-value tasks to PERT and vice
+  versa.
+- Smoke: open a project, enable a numeric scale, set a value on a task,
+  switch to T-Shirt — confirm values map to nearest, no console errors.
+
+## Rollback
+- Field is optional on `Project` and `Task`; clearing `pointScaleConfig`
+  hides the feature without affecting other data.
+- Old documents without the new fields render exactly as before.

--- a/src/app/core/models/domain.model.ts
+++ b/src/app/core/models/domain.model.ts
@@ -162,6 +162,11 @@ export interface Project {
   tags?: Tag[]; // Defined tags for this project
   /** Admin-managed dashboard customization (widgets, colors, display style). */
   dashboardPreferences?: DashboardPreferences;
+  /**
+   * Per-project task-effort scale. When absent, the point-value UI is hidden
+   * for this project. See `PointScaleConfig` for the discriminated union.
+   */
+  pointScaleConfig?: PointScaleConfig;
   createdAt: FirestoreDate;
   updatedAt?: FirestoreDate;
   status: 'active' | 'archived';
@@ -205,6 +210,12 @@ export interface Task {
   blockingIds?: string[]; // IDs of tasks this task blocks
   blockedByIds?: string[]; // IDs of tasks that block this task from being completed
   customFieldValues?: Record<string, any>;
+  /**
+   * Per-task effort estimate. Shape is determined by the project's active
+   * `pointScaleConfig` (numeric, PERT triple, T-shirt, animal, or per-factor
+   * map). Cleared automatically when migration cannot map a value.
+   */
+  pointValue?: PointValue;
   attachments?: string[]; // Image/file URLs (Firebase Storage)
   createdAt: FirestoreDate;
   updatedAt: FirestoreDate;
@@ -324,3 +335,205 @@ export const DEFAULT_SECTIONS: Omit<Section, 'id'>[] = [
  * View mode for task display
  */
 export type TaskViewMode = 'overview' | 'list' | 'board' | 'calendar' | 'timeline';
+
+// ---------------------------------------------------------------------------
+// Task Point Values
+// ---------------------------------------------------------------------------
+
+export type PointScaleId =
+  | 'numeric_configurable'
+  | 'time_unit'
+  | 'tshirt'
+  | 'animal'
+  | 'custom_multi_factor'
+  | 'credit_hours';
+
+export type NumericIncrementType = 'linear' | 'fibonacci' | 'powers_of_two' | 'custom';
+
+export interface NumericScaleConfig {
+  scale: 'numeric_configurable';
+  min_value: number;
+  max_value: number;
+  increment_type: NumericIncrementType;
+  increment_step?: number;
+  custom_values?: number[];
+  allow_zero?: boolean;
+  pert_mode_enabled?: boolean;
+}
+
+export type TimeUnit = 'minutes' | 'hours' | 'days' | 'weeks';
+
+export interface TimeScaleConfig {
+  scale: 'time_unit';
+  unit: TimeUnit;
+  decimal_precision?: number;
+  input_mode: 'freeform' | 'preset';
+  preset_values?: number[];
+  load_factor?: number;
+  pert_mode_enabled?: boolean;
+}
+
+export type TShirtSize = 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL';
+export const TSHIRT_SIZES: readonly TShirtSize[] = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
+export const DEFAULT_TSHIRT_MAPPING: Readonly<Record<TShirtSize, number>> = {
+  XS: 1,
+  S: 2,
+  M: 3,
+  L: 5,
+  XL: 8,
+  XXL: 13,
+};
+
+export interface TShirtScaleConfig {
+  scale: 'tshirt';
+  mapping?: Record<TShirtSize, number>;
+}
+
+export type AnimalSize = 'Mouse' | 'Cat' | 'Dog' | 'Horse' | 'Elephant' | 'Whale';
+export const ANIMAL_SIZES: readonly AnimalSize[] = [
+  'Mouse',
+  'Cat',
+  'Dog',
+  'Horse',
+  'Elephant',
+  'Whale',
+];
+export const DEFAULT_ANIMAL_MAPPING: Readonly<Record<AnimalSize, number>> = {
+  Mouse: 1,
+  Cat: 2,
+  Dog: 3,
+  Horse: 5,
+  Elephant: 8,
+  Whale: 13,
+};
+export const ANIMAL_ICONS: Readonly<Record<AnimalSize, string>> = {
+  Mouse: '🐭',
+  Cat: '🐱',
+  Dog: '🐶',
+  Horse: '🐴',
+  Elephant: '🐘',
+  Whale: '🐋',
+};
+
+export interface MultiFactor {
+  id: string;
+  name: string;
+  scale: number[];
+  weight: number;
+}
+
+export interface MultiFactorScaleConfig {
+  scale: 'custom_multi_factor';
+  factors: MultiFactor[];
+  formula: 'sum' | 'product' | 'weighted_sum';
+}
+
+export type CreditHoursInputMode = 'direct' | 'bucket' | 'fibonacci';
+export const CREDIT_HOURS_BUCKETS: readonly number[] = [0.25, 0.5, 1, 2, 4, 8];
+export const CREDIT_HOURS_FIB: readonly number[] = [0.5, 1, 2, 3, 5, 8, 13];
+
+export interface CreditHoursScaleConfig {
+  scale: 'credit_hours';
+  total_credit_hours: number;
+  total_work_hours: number;
+  start_date?: FirestoreDate;
+  end_date?: FirestoreDate;
+  weekly_target_hours?: number;
+  input_mode: CreditHoursInputMode;
+  pert_mode_enabled?: boolean;
+}
+
+export type PointScaleConfig =
+  | NumericScaleConfig
+  | TimeScaleConfig
+  | TShirtScaleConfig
+  | AnimalScaleConfig
+  | MultiFactorScaleConfig
+  | CreditHoursScaleConfig;
+
+export type PointValue =
+  | { type: 'numeric'; value: number }
+  | { type: 'numeric_pert'; optimistic: number; mostLikely: number; pessimistic: number }
+  | { type: 'tshirt'; value: TShirtSize }
+  | { type: 'animal'; value: AnimalSize }
+  | { type: 'multi_factor'; values: Record<string, number> };
+
+/** Built-in preset templates for the Configurable Numeric scale. */
+export interface NumericPreset {
+  id: string;
+  label: string;
+  config: Omit<NumericScaleConfig, 'pert_mode_enabled'>;
+}
+
+export const NUMERIC_PRESETS: readonly NumericPreset[] = [
+  {
+    id: 'linear_1_5',
+    label: 'Linear 1-5',
+    config: {
+      scale: 'numeric_configurable',
+      min_value: 1,
+      max_value: 5,
+      increment_type: 'linear',
+      increment_step: 1,
+    },
+  },
+  {
+    id: 'linear_1_10',
+    label: 'Linear 1-10',
+    config: {
+      scale: 'numeric_configurable',
+      min_value: 1,
+      max_value: 10,
+      increment_type: 'linear',
+      increment_step: 1,
+    },
+  },
+  {
+    id: 'fibonacci',
+    label: 'Fibonacci',
+    config: {
+      scale: 'numeric_configurable',
+      min_value: 1,
+      max_value: 100,
+      increment_type: 'fibonacci',
+    },
+  },
+  {
+    id: 'modified_fibonacci',
+    label: 'Modified Fibonacci',
+    config: {
+      scale: 'numeric_configurable',
+      min_value: 0,
+      max_value: 100,
+      increment_type: 'custom',
+      custom_values: [0, 0.5, 1, 2, 3, 5, 8, 13, 20, 40, 100],
+      allow_zero: true,
+    },
+  },
+  {
+    id: 'powers_of_two',
+    label: 'Powers of 2',
+    config: {
+      scale: 'numeric_configurable',
+      min_value: 1,
+      max_value: 64,
+      increment_type: 'powers_of_two',
+    },
+  },
+  {
+    id: 'bucket',
+    label: 'Bucket',
+    config: {
+      scale: 'numeric_configurable',
+      min_value: 1,
+      max_value: 100,
+      increment_type: 'custom',
+      custom_values: [1, 2, 3, 5, 8, 13, 20, 40, 100],
+    },
+  },
+] as const;
+
+export interface AnimalScaleConfig {
+  scale: 'animal';
+  mapping?: Record<AnimalSize, number>;
+}

--- a/src/app/core/models/domain.model.ts
+++ b/src/app/core/models/domain.model.ts
@@ -445,6 +445,16 @@ export interface CreditHoursScaleConfig {
   end_date?: FirestoreDate;
   weekly_target_hours?: number;
   input_mode: CreditHoursInputMode;
+  /**
+   * Optional inclusive lower bound applied to the bucket / fibonacci value
+   * lists. When omitted, the full default list is offered. Ignored when
+   * `input_mode` is `direct` since direct entry has no fixed value set.
+   */
+  min_value?: number;
+  /**
+   * Optional inclusive upper bound. See `min_value` for semantics.
+   */
+  max_value?: number;
   pert_mode_enabled?: boolean;
 }
 

--- a/src/app/core/models/domain.model.ts
+++ b/src/app/core/models/domain.model.ts
@@ -415,6 +415,11 @@ export const ANIMAL_ICONS: Readonly<Record<AnimalSize, string>> = {
   Whale: '🐋',
 };
 
+export interface AnimalScaleConfig {
+  scale: 'animal';
+  mapping?: Record<AnimalSize, number>;
+}
+
 export interface MultiFactor {
   id: string;
   name: string;
@@ -532,8 +537,3 @@ export const NUMERIC_PRESETS: readonly NumericPreset[] = [
     },
   },
 ] as const;
-
-export interface AnimalScaleConfig {
-  scale: 'animal';
-  mapping?: Record<AnimalSize, number>;
-}

--- a/src/app/core/services/project.service.ts
+++ b/src/app/core/services/project.service.ts
@@ -435,6 +435,10 @@ export class ProjectService {
    * `pointValue` set, each value is migrated through `migrateValue` so that
    * switching scale shape (e.g. linear → Fibonacci, or toggling PERT) keeps
    * the closest equivalent rather than dropping data.
+   *
+   * Order matters: we migrate task values FIRST and only update the project
+   * config after every batch has committed. If a batch fails, the project
+   * still reflects the old config so the UI and the task data stay in sync.
    */
   async updatePointScaleConfig(projectId: string, newConfig: PointScaleConfig | null): Promise<void> {
     const project = await this.getProject(projectId);
@@ -442,28 +446,15 @@ export class ProjectService {
 
     const prevConfig = project.pointScaleConfig;
 
-    // Update the project document first; this is the single source of truth
-    // even if the migration loop below fails partway.
-    if (newConfig === null) {
-      const docRef = doc(this.firestore, `projects/${projectId}`);
-      await updateDoc(docRef, {
-        pointScaleConfig: deleteField(),
-        updatedAt: new Date(),
-      });
-    } else {
-      await this.updateProject(projectId, { pointScaleConfig: newConfig });
-    }
-
-    // Migrate existing task values. We need this even when clearing the
-    // config so stale `pointValue` objects don't render in a now-unconfigured
-    // project. Batch in chunks of 400 to stay under Firestore's 500-op limit.
+    // 1. Migrate existing task values first. Batched in chunks of 400 to stay
+    //    under Firestore's 500-op limit. If any batch throws, we bail before
+    //    touching the project doc so state stays consistent.
     const tasksQuery = query(
       collection(this.firestore, 'tasks'),
       where('projectId', '==', projectId),
     );
     const snap = await getDocs(tasksQuery);
     const docs = snap.docs.filter((d) => (d.data() as { pointValue?: unknown }).pointValue);
-    if (!docs.length) return;
 
     for (let i = 0; i < docs.length; i += 400) {
       const batch = writeBatch(this.firestore);
@@ -481,6 +472,17 @@ export class ProjectService {
         }
       }
       await batch.commit();
+    }
+
+    // 2. Now that every task is on the new shape, flip the project config.
+    if (newConfig === null) {
+      const docRef = doc(this.firestore, `projects/${projectId}`);
+      await updateDoc(docRef, {
+        pointScaleConfig: deleteField(),
+        updatedAt: new Date(),
+      });
+    } else {
+      await this.updateProject(projectId, { pointScaleConfig: newConfig });
     }
   }
 

--- a/src/app/core/services/project.service.ts
+++ b/src/app/core/services/project.service.ts
@@ -446,35 +446,66 @@ export class ProjectService {
 
     const prevConfig = project.pointScaleConfig;
 
-    // 1. Migrate existing task values first. Batched in chunks of 400 to stay
-    //    under Firestore's 500-op limit. If any batch throws, we bail before
-    //    touching the project doc so state stays consistent.
+    // 1. Pre-compute every migration in memory so the project document is
+    //    only updated when we know we have a complete plan. Firestore's
+    //    500-op-per-batch limit means we can't make the task rewrites truly
+    //    atomic, but committing all batches up-front and rolling back
+    //    committed slices on failure keeps the project + task state aligned.
     const tasksQuery = query(
       collection(this.firestore, 'tasks'),
       where('projectId', '==', projectId),
     );
-    const snap = await getDocs(tasksQuery);
-    const docs = snap.docs.filter((d) => (d.data() as { pointValue?: unknown }).pointValue);
-
-    for (let i = 0; i < docs.length; i += 400) {
-      const batch = writeBatch(this.firestore);
-      const slice = docs.slice(i, i + 400);
-      for (const d of slice) {
+    const snapshot = await getDocs(tasksQuery);
+    const plan = snapshot.docs
+      .filter((d) => (d.data() as { pointValue?: unknown }).pointValue)
+      .map((d) => {
         const data = d.data() as { pointValue?: unknown };
         const oldValue = data.pointValue as Parameters<typeof migrateValue>[0];
         const migrated = newConfig
           ? migrateValue(oldValue, prevConfig, newConfig)
           : undefined;
-        if (migrated) {
-          batch.update(d.ref, { pointValue: migrated, updatedAt: new Date() });
-        } else {
-          batch.update(d.ref, { pointValue: deleteField(), updatedAt: new Date() });
+        return { ref: d.ref, oldValue, migrated } as const;
+      });
+
+    // Track which entries have been successfully committed so we can roll
+    // them back if a later batch fails.
+    const committed: typeof plan = [];
+
+    try {
+      for (let i = 0; i < plan.length; i += 400) {
+        const slice = plan.slice(i, i + 400);
+        const batch = writeBatch(this.firestore);
+        for (const entry of slice) {
+          if (entry.migrated) {
+            batch.update(entry.ref, { pointValue: entry.migrated, updatedAt: new Date() });
+          } else {
+            batch.update(entry.ref, { pointValue: deleteField(), updatedAt: new Date() });
+          }
+        }
+        await batch.commit();
+        committed.push(...slice);
+      }
+    } catch (err) {
+      // Best-effort rollback: restore the original pointValue on every task
+      // that we already overwrote. Each rollback batch is committed even if
+      // later ones fail, so the project document is never flipped when the
+      // task data is in a mixed state.
+      for (let i = 0; i < committed.length; i += 400) {
+        const slice = committed.slice(i, i + 400);
+        const batch = writeBatch(this.firestore);
+        for (const entry of slice) {
+          batch.update(entry.ref, { pointValue: entry.oldValue, updatedAt: new Date() });
+        }
+        try {
+          await batch.commit();
+        } catch (rollbackErr) {
+          console.error('Rollback failed for batch starting at', i, rollbackErr);
         }
       }
-      await batch.commit();
+      throw err;
     }
 
-    // 2. Now that every task is on the new shape, flip the project config.
+    // 2. Every task is on the new shape — flip the project config last.
     if (newConfig === null) {
       const docRef = doc(this.firestore, `projects/${projectId}`);
       await updateDoc(docRef, {

--- a/src/app/core/services/project.service.ts
+++ b/src/app/core/services/project.service.ts
@@ -7,19 +7,23 @@ import {
   updateDoc,
   deleteDoc,
   getDoc,
+  getDocs,
   query,
   where,
   collectionData,
   deleteField,
   DocumentReference,
+  writeBatch,
 } from '@angular/fire/firestore';
 import {
   Project,
   Section,
   DEFAULT_SECTIONS,
   CustomFieldDefinition,
+  PointScaleConfig,
   Tag,
 } from '../models/domain.model';
+import { migrateValue } from '../utils/point-scale.utils';
 import { AuthService } from '../auth/auth.service';
 import { Observable, switchMap, of, map, firstValueFrom } from 'rxjs';
 import { GoogleTasksSyncService } from './google-tasks-sync.service';
@@ -424,6 +428,60 @@ export class ProjectService {
     await this.updateProject(projectId, { tags: updatedTags });
 
     return newTag;
+  }
+
+  /**
+   * Update the project's point-scale configuration. If existing tasks have
+   * `pointValue` set, each value is migrated through `migrateValue` so that
+   * switching scale shape (e.g. linear → Fibonacci, or toggling PERT) keeps
+   * the closest equivalent rather than dropping data.
+   */
+  async updatePointScaleConfig(projectId: string, newConfig: PointScaleConfig | null): Promise<void> {
+    const project = await this.getProject(projectId);
+    if (!project) throw new Error('Project not found');
+
+    const prevConfig = project.pointScaleConfig;
+
+    // Update the project document first; this is the single source of truth
+    // even if the migration loop below fails partway.
+    if (newConfig === null) {
+      const docRef = doc(this.firestore, `projects/${projectId}`);
+      await updateDoc(docRef, {
+        pointScaleConfig: deleteField(),
+        updatedAt: new Date(),
+      });
+    } else {
+      await this.updateProject(projectId, { pointScaleConfig: newConfig });
+    }
+
+    // Migrate existing task values. We need this even when clearing the
+    // config so stale `pointValue` objects don't render in a now-unconfigured
+    // project. Batch in chunks of 400 to stay under Firestore's 500-op limit.
+    const tasksQuery = query(
+      collection(this.firestore, 'tasks'),
+      where('projectId', '==', projectId),
+    );
+    const snap = await getDocs(tasksQuery);
+    const docs = snap.docs.filter((d) => (d.data() as { pointValue?: unknown }).pointValue);
+    if (!docs.length) return;
+
+    for (let i = 0; i < docs.length; i += 400) {
+      const batch = writeBatch(this.firestore);
+      const slice = docs.slice(i, i + 400);
+      for (const d of slice) {
+        const data = d.data() as { pointValue?: unknown };
+        const oldValue = data.pointValue as Parameters<typeof migrateValue>[0];
+        const migrated = newConfig
+          ? migrateValue(oldValue, prevConfig, newConfig)
+          : undefined;
+        if (migrated) {
+          batch.update(d.ref, { pointValue: migrated, updatedAt: new Date() });
+        } else {
+          batch.update(d.ref, { pointValue: deleteField(), updatedAt: new Date() });
+        }
+      }
+      await batch.commit();
+    }
   }
 
   /**

--- a/src/app/core/services/task.service.ts
+++ b/src/app/core/services/task.service.ts
@@ -6,6 +6,7 @@ import {
   doc,
   updateDoc,
   deleteDoc,
+  deleteField,
   query,
   where,
   or,
@@ -610,6 +611,17 @@ export class TaskService {
     } finally {
       this.loading.set(false);
     }
+  }
+
+  /**
+   * Remove the per-task point value entirely. `stripUndefined` in `updateTask`
+   * silently drops `undefined` fields, which means a clearing autosave would
+   * otherwise never reach Firestore — the on-screen value would reappear on
+   * reload. This path uses `deleteField()` so the document field is removed.
+   */
+  async clearPointValue(id: string): Promise<void> {
+    const taskRef = doc(this.firestore, `tasks/${id}`);
+    await updateDoc(taskRef, { pointValue: deleteField(), updatedAt: new Date() });
   }
 
   /**

--- a/src/app/core/utils/point-scale.utils.spec.ts
+++ b/src/app/core/utils/point-scale.utils.spec.ts
@@ -7,6 +7,8 @@ import {
   getNumericAllowedValues,
   migrateValue,
   nearestNumericValue,
+  pointValueGradientColor,
+  pointValueNormalized,
   pointValueScalar,
 } from './point-scale.utils';
 import {
@@ -310,6 +312,46 @@ describe('point-scale.utils', () => {
       expect(nearestNumericValue(6, cfg)).toBe(5);
       expect(nearestNumericValue(7, cfg)).toBe(8);
       expect(nearestNumericValue(50, cfg)).toBe(55);
+    });
+  });
+
+  describe('pointValueGradientColor', () => {
+    it('anchors at the cyan stop for position 0', () => {
+      expect(pointValueGradientColor(0)).toBe('rgb(0, 210, 255)');
+    });
+    it('hits the hot-pink stop at position 1', () => {
+      expect(pointValueGradientColor(1)).toBe('rgb(255, 20, 147)');
+    });
+    it('passes through magenta near the midpoint', () => {
+      expect(pointValueGradientColor(0.5)).toBe('rgb(224, 64, 251)');
+    });
+  });
+
+  describe('pointValueNormalized', () => {
+    it('numeric scale: low value reads as 0', () => {
+      const cfg = {
+        scale: 'numeric_configurable' as const,
+        min_value: 1,
+        max_value: 8,
+        increment_type: 'fibonacci' as const,
+      };
+      expect(pointValueNormalized({ type: 'numeric', value: 1 }, cfg)).toBeCloseTo(0, 5);
+    });
+
+    it('numeric scale: high value reads as 1', () => {
+      const cfg = {
+        scale: 'numeric_configurable' as const,
+        min_value: 1,
+        max_value: 8,
+        increment_type: 'fibonacci' as const,
+      };
+      expect(pointValueNormalized({ type: 'numeric', value: 8 }, cfg)).toBeCloseTo(1, 5);
+    });
+
+    it('tshirt: XS at 0, XXL at 1', () => {
+      const cfg = { scale: 'tshirt' as const };
+      expect(pointValueNormalized({ type: 'tshirt', value: 'XS' }, cfg)).toBeCloseTo(0, 5);
+      expect(pointValueNormalized({ type: 'tshirt', value: 'XXL' }, cfg)).toBeCloseTo(1, 5);
     });
   });
 

--- a/src/app/core/utils/point-scale.utils.spec.ts
+++ b/src/app/core/utils/point-scale.utils.spec.ts
@@ -313,6 +313,61 @@ describe('point-scale.utils', () => {
       expect(result).toEqual({ type: 'tshirt', value: 'L' });
     });
 
+    it('preserves PERT triples when migrating time_unit with PERT still on', () => {
+      const from = {
+        scale: 'time_unit' as const,
+        unit: 'hours' as const,
+        input_mode: 'freeform' as const,
+        pert_mode_enabled: true,
+      };
+      const to = {
+        scale: 'time_unit' as const,
+        unit: 'hours' as const,
+        input_mode: 'freeform' as const,
+        pert_mode_enabled: true,
+      };
+      const result = migrateValue(
+        { type: 'numeric_pert', optimistic: 2, mostLikely: 5, pessimistic: 12 },
+        from,
+        to,
+      );
+      // None of the bounds should collapse to the weighted estimate.
+      expect(result).toEqual({
+        type: 'numeric_pert',
+        optimistic: 2,
+        mostLikely: 5,
+        pessimistic: 12,
+      });
+    });
+
+    it('preserves PERT triples when migrating credit_hours with PERT still on', () => {
+      const from = {
+        scale: 'credit_hours' as const,
+        total_credit_hours: 3,
+        total_work_hours: 135,
+        input_mode: 'fibonacci' as const,
+        pert_mode_enabled: true,
+      };
+      const to = {
+        scale: 'credit_hours' as const,
+        total_credit_hours: 3,
+        total_work_hours: 135,
+        input_mode: 'fibonacci' as const,
+        pert_mode_enabled: true,
+      };
+      const result = migrateValue(
+        { type: 'numeric_pert', optimistic: 1, mostLikely: 3, pessimistic: 8 },
+        from,
+        to,
+      );
+      expect(result).toEqual({
+        type: 'numeric_pert',
+        optimistic: 1,
+        mostLikely: 3,
+        pessimistic: 8,
+      });
+    });
+
     it('clears multi_factor when factor IDs change entirely', () => {
       const from: PointScaleConfig = {
         scale: 'custom_multi_factor',

--- a/src/app/core/utils/point-scale.utils.spec.ts
+++ b/src/app/core/utils/point-scale.utils.spec.ts
@@ -99,6 +99,34 @@ describe('point-scale.utils', () => {
       ).toEqual([0.5, 1, 2, 4]);
     });
 
+    it('generates new buckets past the default 8h cap when max is raised', () => {
+      // max_value=24 should add 16h (doubling) but stop before 32h.
+      expect(
+        getCreditHoursAllowedValues({
+          scale: 'credit_hours',
+          total_credit_hours: 3,
+          total_work_hours: 135,
+          input_mode: 'bucket',
+          min_value: 1,
+          max_value: 24,
+        }),
+      ).toEqual([1, 2, 4, 8, 16]);
+    });
+
+    it('generates new Fibonacci hours past the default 13h cap when max is raised', () => {
+      // max_value=30 should add 21h but stop before 34h.
+      expect(
+        getCreditHoursAllowedValues({
+          scale: 'credit_hours',
+          total_credit_hours: 3,
+          total_work_hours: 135,
+          input_mode: 'fibonacci',
+          min_value: 2,
+          max_value: 30,
+        }),
+      ).toEqual([2, 3, 5, 8, 13, 21]);
+    });
+
     it('filters fibonacci hours similarly', () => {
       expect(
         getCreditHoursAllowedValues({

--- a/src/app/core/utils/point-scale.utils.spec.ts
+++ b/src/app/core/utils/point-scale.utils.spec.ts
@@ -3,6 +3,7 @@ import {
   computePertEstimate,
   computePertStdDev,
   formatPointValue,
+  getCreditHoursAllowedValues,
   getNumericAllowedValues,
   migrateValue,
   nearestNumericValue,
@@ -70,6 +71,56 @@ describe('point-scale.utils', () => {
       };
       // 40 > max, 0 stripped by allow_zero:false
       expect(getNumericAllowedValues(cfg)).toEqual([0.5, 1, 5, 13]);
+    });
+  });
+
+  describe('getCreditHoursAllowedValues', () => {
+    it('returns the full bucket list when no bounds are set', () => {
+      expect(
+        getCreditHoursAllowedValues({
+          scale: 'credit_hours',
+          total_credit_hours: 3,
+          total_work_hours: 135,
+          input_mode: 'bucket',
+        }),
+      ).toEqual([0.25, 0.5, 1, 2, 4, 8]);
+    });
+
+    it('filters bucket list by min_value and max_value', () => {
+      expect(
+        getCreditHoursAllowedValues({
+          scale: 'credit_hours',
+          total_credit_hours: 3,
+          total_work_hours: 135,
+          input_mode: 'bucket',
+          min_value: 0.5,
+          max_value: 4,
+        }),
+      ).toEqual([0.5, 1, 2, 4]);
+    });
+
+    it('filters fibonacci hours similarly', () => {
+      expect(
+        getCreditHoursAllowedValues({
+          scale: 'credit_hours',
+          total_credit_hours: 3,
+          total_work_hours: 135,
+          input_mode: 'fibonacci',
+          min_value: 2,
+          max_value: 8,
+        }),
+      ).toEqual([2, 3, 5, 8]);
+    });
+
+    it('returns empty for direct entry mode', () => {
+      expect(
+        getCreditHoursAllowedValues({
+          scale: 'credit_hours',
+          total_credit_hours: 3,
+          total_work_hours: 135,
+          input_mode: 'direct',
+        }),
+      ).toEqual([]);
     });
   });
 

--- a/src/app/core/utils/point-scale.utils.spec.ts
+++ b/src/app/core/utils/point-scale.utils.spec.ts
@@ -1,0 +1,330 @@
+import {
+  aggregateValues,
+  computePertEstimate,
+  computePertStdDev,
+  formatPointValue,
+  getNumericAllowedValues,
+  migrateValue,
+  nearestNumericValue,
+  pointValueScalar,
+} from './point-scale.utils';
+import {
+  NumericScaleConfig,
+  PointScaleConfig,
+  TimeScaleConfig,
+} from '../models/domain.model';
+
+describe('point-scale.utils', () => {
+  describe('getNumericAllowedValues', () => {
+    it('generates linear values from step', () => {
+      const cfg: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 5,
+        increment_type: 'linear',
+        increment_step: 1,
+      };
+      expect(getNumericAllowedValues(cfg)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('respects fractional linear step', () => {
+      const cfg: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 0,
+        max_value: 1,
+        increment_type: 'linear',
+        increment_step: 0.25,
+        allow_zero: true,
+      };
+      expect(getNumericAllowedValues(cfg)).toEqual([0, 0.25, 0.5, 0.75, 1]);
+    });
+
+    it('generates fibonacci within min/max', () => {
+      const cfg: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 100,
+        increment_type: 'fibonacci',
+      };
+      expect(getNumericAllowedValues(cfg)).toEqual([1, 2, 3, 5, 8, 13, 21, 34, 55, 89]);
+    });
+
+    it('generates powers of two', () => {
+      const cfg: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 64,
+        increment_type: 'powers_of_two',
+      };
+      expect(getNumericAllowedValues(cfg)).toEqual([1, 2, 4, 8, 16, 32, 64]);
+    });
+
+    it('filters custom values by min/max and zero', () => {
+      const cfg: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 0,
+        max_value: 20,
+        increment_type: 'custom',
+        custom_values: [0, 0.5, 1, 5, 13, 40],
+        allow_zero: false,
+      };
+      // 40 > max, 0 stripped by allow_zero:false
+      expect(getNumericAllowedValues(cfg)).toEqual([0.5, 1, 5, 13]);
+    });
+  });
+
+  describe('PERT math', () => {
+    it('weighted estimate is (O + 4M + P)/6', () => {
+      expect(computePertEstimate(2, 5, 10)).toBeCloseTo((2 + 20 + 10) / 6, 5);
+    });
+
+    it('standard deviation is (P - O)/6', () => {
+      expect(computePertStdDev(2, 5, 10)).toBeCloseTo(8 / 6, 5);
+    });
+  });
+
+  describe('pointValueScalar', () => {
+    const numericCfg: NumericScaleConfig = {
+      scale: 'numeric_configurable',
+      min_value: 1,
+      max_value: 10,
+      increment_type: 'linear',
+      increment_step: 1,
+    };
+
+    it('returns value for simple numeric', () => {
+      expect(pointValueScalar({ type: 'numeric', value: 5 }, numericCfg)).toBe(5);
+    });
+
+    it('returns PERT estimate for triple', () => {
+      const result = pointValueScalar(
+        { type: 'numeric_pert', optimistic: 1, mostLikely: 3, pessimistic: 8 },
+        numericCfg,
+      );
+      expect(result).toBeCloseTo((1 + 12 + 8) / 6, 5);
+    });
+
+    it('maps T-shirt sizes via default mapping', () => {
+      expect(pointValueScalar({ type: 'tshirt', value: 'L' }, { scale: 'tshirt' })).toBe(5);
+    });
+
+    it('multi-factor sum formula', () => {
+      const cfg: PointScaleConfig = {
+        scale: 'custom_multi_factor',
+        formula: 'sum',
+        factors: [
+          { id: 'a', name: 'A', scale: [1, 2, 3], weight: 1 },
+          { id: 'b', name: 'B', scale: [1, 2, 3], weight: 1 },
+        ],
+      };
+      const result = pointValueScalar({ type: 'multi_factor', values: { a: 2, b: 3 } }, cfg);
+      expect(result).toBe(5);
+    });
+
+    it('multi-factor weighted sum formula', () => {
+      const cfg: PointScaleConfig = {
+        scale: 'custom_multi_factor',
+        formula: 'weighted_sum',
+        factors: [
+          { id: 'a', name: 'A', scale: [1, 2, 3], weight: 2 },
+          { id: 'b', name: 'B', scale: [1, 2, 3], weight: 0.5 },
+        ],
+      };
+      const result = pointValueScalar({ type: 'multi_factor', values: { a: 2, b: 4 } }, cfg);
+      expect(result).toBe(2 * 2 + 4 * 0.5);
+    });
+  });
+
+  describe('aggregateValues', () => {
+    const numericCfg: NumericScaleConfig = {
+      scale: 'numeric_configurable',
+      min_value: 0,
+      max_value: 100,
+      increment_type: 'linear',
+      increment_step: 1,
+      allow_zero: true,
+      pert_mode_enabled: true,
+    };
+
+    it('sums simple values', () => {
+      const result = aggregateValues(
+        [
+          { type: 'numeric', value: 3 },
+          { type: 'numeric', value: 5 },
+        ],
+        numericCfg,
+      );
+      expect(result.total).toBe(8);
+      expect(result.totalStdDev).toBe(0);
+      expect(result.contributingCount).toBe(2);
+    });
+
+    it('computes total SD via sum of variances', () => {
+      const result = aggregateValues(
+        [
+          { type: 'numeric_pert', optimistic: 0, mostLikely: 0, pessimistic: 6 }, // sd = 1
+          { type: 'numeric_pert', optimistic: 0, mostLikely: 0, pessimistic: 12 }, // sd = 2
+        ],
+        numericCfg,
+      );
+      // variance = 1 + 4 = 5, sd = sqrt(5)
+      expect(result.totalStdDev).toBeCloseTo(Math.sqrt(5), 5);
+    });
+
+    it('applies load_factor for time scale', () => {
+      const timeCfg: TimeScaleConfig = {
+        scale: 'time_unit',
+        unit: 'hours',
+        input_mode: 'freeform',
+        load_factor: 1.5,
+      };
+      const result = aggregateValues([{ type: 'numeric', value: 10 }], timeCfg);
+      expect(result.total).toBe(10);
+      expect(result.forecastTotal).toBe(15);
+    });
+  });
+
+  describe('formatPointValue', () => {
+    it('formats simple numeric with no trailing zeros', () => {
+      expect(
+        formatPointValue(
+          { type: 'numeric', value: 3 },
+          {
+            scale: 'numeric_configurable',
+            min_value: 1,
+            max_value: 10,
+            increment_type: 'linear',
+            increment_step: 1,
+          },
+        ),
+      ).toBe('3');
+    });
+
+    it('formats PERT with confidence range and unit', () => {
+      const cfg: TimeScaleConfig = {
+        scale: 'time_unit',
+        unit: 'hours',
+        input_mode: 'freeform',
+        pert_mode_enabled: true,
+      };
+      const out = formatPointValue(
+        { type: 'numeric_pert', optimistic: 2, mostLikely: 5, pessimistic: 10 },
+        cfg,
+      );
+      // estimate = (2 + 20 + 10)/6 = 5.33, sd = 8/6 = 1.33
+      expect(out).toMatch(/^5\.33 ± 1\.33h$/);
+    });
+
+    it('formats tshirt as label', () => {
+      expect(formatPointValue({ type: 'tshirt', value: 'M' }, { scale: 'tshirt' })).toBe('M');
+    });
+  });
+
+  describe('nearestNumericValue', () => {
+    it('snaps to closest allowed value', () => {
+      const cfg: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 100,
+        increment_type: 'fibonacci',
+      };
+      expect(nearestNumericValue(6, cfg)).toBe(5);
+      expect(nearestNumericValue(7, cfg)).toBe(8);
+      expect(nearestNumericValue(50, cfg)).toBe(55);
+    });
+  });
+
+  describe('migrateValue', () => {
+    it('snaps numeric → Fibonacci', () => {
+      const from: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 10,
+        increment_type: 'linear',
+        increment_step: 1,
+      };
+      const to: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 100,
+        increment_type: 'fibonacci',
+      };
+      expect(migrateValue({ type: 'numeric', value: 6 }, from, to)).toEqual({
+        type: 'numeric',
+        value: 5,
+      });
+    });
+
+    it('expands single value to PERT triple when PERT enabled', () => {
+      const from: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 10,
+        increment_type: 'linear',
+        increment_step: 1,
+      };
+      const to: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 10,
+        increment_type: 'linear',
+        increment_step: 1,
+        pert_mode_enabled: true,
+      };
+      expect(migrateValue({ type: 'numeric', value: 3 }, from, to)).toEqual({
+        type: 'numeric_pert',
+        optimistic: 3,
+        mostLikely: 3,
+        pessimistic: 3,
+      });
+    });
+
+    it('collapses PERT to weighted estimate when PERT disabled', () => {
+      const from: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 100,
+        increment_type: 'fibonacci',
+        pert_mode_enabled: true,
+      };
+      const to: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 100,
+        increment_type: 'fibonacci',
+      };
+      const result = migrateValue(
+        { type: 'numeric_pert', optimistic: 1, mostLikely: 3, pessimistic: 8 },
+        from,
+        to,
+      );
+      // estimate = (1+12+8)/6 = 3.5 → nearest fib = 3
+      expect(result).toEqual({ type: 'numeric', value: 3 });
+    });
+
+    it('numeric → tshirt maps via mapping', () => {
+      const from: NumericScaleConfig = {
+        scale: 'numeric_configurable',
+        min_value: 1,
+        max_value: 100,
+        increment_type: 'fibonacci',
+      };
+      const result = migrateValue({ type: 'numeric', value: 5 }, from, { scale: 'tshirt' });
+      expect(result).toEqual({ type: 'tshirt', value: 'L' });
+    });
+
+    it('clears multi_factor when factor IDs change entirely', () => {
+      const from: PointScaleConfig = {
+        scale: 'custom_multi_factor',
+        formula: 'sum',
+        factors: [{ id: 'old', name: 'X', scale: [1, 2], weight: 1 }],
+      };
+      const to: PointScaleConfig = {
+        scale: 'custom_multi_factor',
+        formula: 'sum',
+        factors: [{ id: 'new', name: 'Y', scale: [1, 2], weight: 1 }],
+      };
+      expect(migrateValue({ type: 'multi_factor', values: { old: 2 } }, from, to)).toBeUndefined();
+    });
+  });
+});

--- a/src/app/core/utils/point-scale.utils.ts
+++ b/src/app/core/utils/point-scale.utils.ts
@@ -86,24 +86,56 @@ function round(n: number, decimals: number): number {
 }
 
 /**
- * Allowed hour-bucket values for a credit-hours scale, after applying any
- * configured min/max bounds. Falls back to the full default list when
- * bounds are not set. `direct` mode has no fixed list, so this returns an
- * empty array for it (callers should treat that as "use continuous input").
+ * Allowed hour-bucket values for a credit-hours scale. When `max_value` is
+ * set, the list is *generated* up to that bound rather than being filtered
+ * from the default range — raising the max past the built-in 8h cap adds
+ * 16h, 32h, … (doubling) for buckets, and the next Fibonacci hours
+ * (21, 34, 55, …) for Fibonacci mode. Lower-bound filtering is applied
+ * after generation. `direct` mode has no fixed list (continuous input).
  */
 export function getCreditHoursAllowedValues(config: CreditHoursScaleConfig): number[] {
-  let base: readonly number[];
-  if (config.input_mode === 'bucket') {
-    base = CREDIT_HOURS_BUCKETS;
-  } else if (config.input_mode === 'fibonacci') {
-    base = CREDIT_HOURS_FIB;
-  } else {
-    return [];
+  if (config.input_mode === 'direct') return [];
+
+  const defaultMax =
+    config.input_mode === 'bucket'
+      ? CREDIT_HOURS_BUCKETS[CREDIT_HOURS_BUCKETS.length - 1]
+      : CREDIT_HOURS_FIB[CREDIT_HOURS_FIB.length - 1];
+  const maxHint = config.max_value !== undefined ? config.max_value : defaultMax;
+
+  const generated =
+    config.input_mode === 'bucket'
+      ? generateCreditHoursBucketList(maxHint)
+      : generateCreditHoursFibList(maxHint);
+
+  if (config.min_value === undefined) return generated;
+  return generated.filter((v) => v >= config.min_value!);
+}
+
+/**
+ * Doubling progression starting at 0.25 (matches the built-in
+ * `CREDIT_HOURS_BUCKETS` and extends past 8h on demand: 16, 32, 64, …).
+ */
+export function generateCreditHoursBucketList(maxHint: number): number[] {
+  if (!isFinite(maxHint) || maxHint < 0.25) return [0.25];
+  const out: number[] = [];
+  for (let v = 0.25; v <= maxHint + 1e-9; v *= 2) out.push(v);
+  return out;
+}
+
+/**
+ * Fibonacci hour list starting at 0.5, 1, then the standard Fibonacci
+ * sequence (2, 3, 5, 8, 13, 21, …) up to `maxHint` inclusive.
+ */
+export function generateCreditHoursFibList(maxHint: number): number[] {
+  if (!isFinite(maxHint) || maxHint < 0.5) return [0.5];
+  const out: number[] = [0.5];
+  let a = 1;
+  let b = 2;
+  while (a <= maxHint + 1e-9) {
+    out.push(a);
+    [a, b] = [b, a + b];
   }
-  const min = config.min_value;
-  const max = config.max_value;
-  if (min === undefined && max === undefined) return [...base];
-  return base.filter((v) => (min === undefined || v >= min) && (max === undefined || v <= max));
+  return out;
 }
 
 /** Time-unit suffix used for display. */

--- a/src/app/core/utils/point-scale.utils.ts
+++ b/src/app/core/utils/point-scale.utils.ts
@@ -499,3 +499,135 @@ export const SCALE_LABELS: Readonly<Record<PointScaleConfig['scale'], string>> =
 export function scaleSupportsPert(scale: PointScaleConfig['scale']): boolean {
   return scale === 'numeric_configurable' || scale === 'time_unit' || scale === 'credit_hours';
 }
+
+/**
+ * Project a task's point value onto a 0..1 position within the scale's
+ * configured range. Drives the badge gradient: 0 = lowest effort
+ * (light blue), 1 = highest (hot pink). Returns 0.5 when the scale doesn't
+ * expose a meaningful range so the badge picks a neutral mid-gradient hue.
+ */
+export function pointValueNormalized(
+  value: PointValue,
+  config: PointScaleConfig,
+): number {
+  if (value.type === 'tshirt') {
+    const idx = TSHIRT_SIZES.indexOf(value.value);
+    return idx === -1 ? 0 : idx / Math.max(TSHIRT_SIZES.length - 1, 1);
+  }
+  if (value.type === 'animal') {
+    const idx = ANIMAL_SIZES.indexOf(value.value);
+    return idx === -1 ? 0 : idx / Math.max(ANIMAL_SIZES.length - 1, 1);
+  }
+  if (value.type === 'multi_factor') {
+    if (config.scale !== 'custom_multi_factor') return 0.5;
+    return normalizeMultiFactor(value.values, config);
+  }
+  // numeric / numeric_pert
+  const scalar = pointValueScalar(value, config);
+  if (config.scale === 'numeric_configurable') {
+    const allowed = getNumericAllowedValues(config);
+    return rangePosition(scalar, allowed);
+  }
+  if (config.scale === 'time_unit') {
+    if (config.input_mode === 'preset') {
+      const allowed = (config.preset_values || []).slice().sort((a, b) => a - b);
+      return rangePosition(scalar, allowed);
+    }
+    // Freeform — use a unit-specific upper bound so the gradient still has
+    // shape without an explicit scale max.
+    const maxByUnit = { minutes: 480, hours: 40, days: 30, weeks: 12 };
+    return clamp01(scalar / maxByUnit[config.unit]);
+  }
+  if (config.scale === 'credit_hours') {
+    const allowed = getCreditHoursAllowedValues(config);
+    if (allowed.length > 0) return rangePosition(scalar, allowed);
+    return clamp01(scalar / Math.max(config.total_work_hours || 1, 1));
+  }
+  return 0.5;
+}
+
+/**
+ * Resolve a badge color from a PointValue. Interpolates between
+ * `low` (light cyan blue) at position 0 and `high` (hot pink) at position 1
+ * with a mid-stop through magenta so the gradient feels brand-correct.
+ */
+export function pointValueColor(value: PointValue, config: PointScaleConfig): string {
+  return pointValueGradientColor(pointValueNormalized(value, config));
+}
+
+/** Standalone gradient sampler for a normalized 0..1 position. */
+export function pointValueGradientColor(position: number): string {
+  const t = clamp01(position);
+  // Three-stop gradient: #00d2ff → #e040fb → #ff1493
+  const stops: [number, [number, number, number]][] = [
+    [0, [0, 210, 255]],
+    [0.5, [224, 64, 251]],
+    [1, [255, 20, 147]],
+  ];
+  for (let i = 0; i < stops.length - 1; i++) {
+    const [t0, c0] = stops[i];
+    const [t1, c1] = stops[i + 1];
+    if (t <= t1) {
+      const local = (t - t0) / Math.max(t1 - t0, 1e-9);
+      const r = Math.round(c0[0] + (c1[0] - c0[0]) * local);
+      const g = Math.round(c0[1] + (c1[1] - c0[1]) * local);
+      const b = Math.round(c0[2] + (c1[2] - c0[2]) * local);
+      return `rgb(${r}, ${g}, ${b})`;
+    }
+  }
+  const [, last] = stops[stops.length - 1];
+  return `rgb(${last[0]}, ${last[1]}, ${last[2]})`;
+}
+
+function rangePosition(scalar: number, allowed: number[]): number {
+  if (allowed.length === 0) return 0.5;
+  const lo = allowed[0];
+  const hi = allowed[allowed.length - 1];
+  if (hi === lo) return 0.5;
+  return clamp01((scalar - lo) / (hi - lo));
+}
+
+function clamp01(n: number): number {
+  if (!isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function normalizeMultiFactor(
+  values: Record<string, number>,
+  config: MultiFactorScaleConfig,
+): number {
+  const factors = config.factors || [];
+  if (factors.length === 0) return 0.5;
+  // Per-factor min/max from the configured scale list.
+  let lo = 0;
+  let hi = 0;
+  let cur = 0;
+  if (config.formula === 'product') {
+    lo = 1;
+    hi = 1;
+    cur = 1;
+  }
+  for (const f of factors) {
+    if (!f.scale.length) continue;
+    const sorted = [...f.scale].sort((a, b) => a - b);
+    const fLo = sorted[0];
+    const fHi = sorted[sorted.length - 1];
+    const v = Number(values[f.id]);
+    const useV = isFinite(v) ? v : fLo;
+    if (config.formula === 'weighted_sum') {
+      lo += fLo * (f.weight || 0);
+      hi += fHi * (f.weight || 0);
+      cur += useV * (f.weight || 0);
+    } else if (config.formula === 'product') {
+      lo *= fLo;
+      hi *= fHi;
+      cur *= useV;
+    } else {
+      lo += fLo;
+      hi += fHi;
+      cur += useV;
+    }
+  }
+  if (hi === lo) return 0.5;
+  return clamp01((cur - lo) / (hi - lo));
+}

--- a/src/app/core/utils/point-scale.utils.ts
+++ b/src/app/core/utils/point-scale.utils.ts
@@ -290,35 +290,26 @@ export function migrateValue(
 
   // Numeric-like target scales (numeric_configurable, time_unit, credit_hours)
   if (isNumericLikeScale(toConfig)) {
-    const scalar =
-      fromConfig !== undefined ? pointValueScalar(value, fromConfig) : numericFromValue(value);
-    if (!isFinite(scalar)) return undefined;
     const pertOn = isPertEnabled(toConfig);
 
-    if (value.type === 'numeric_pert' && pertOn && toConfig.scale === 'numeric_configurable') {
+    // When the source is a PERT triple and the target also supports PERT,
+    // preserve the optimistic / most-likely / pessimistic bounds independently
+    // so uncertainty data is never silently collapsed to a scalar. Snapping
+    // is done per-bound against the target's allowed values.
+    if (value.type === 'numeric_pert' && pertOn) {
       return {
         type: 'numeric_pert',
-        optimistic: nearestNumericValue(value.optimistic, toConfig),
-        mostLikely: nearestNumericValue(value.mostLikely, toConfig),
-        pessimistic: nearestNumericValue(value.pessimistic, toConfig),
+        optimistic: snapNumericLike(value.optimistic, toConfig),
+        mostLikely: snapNumericLike(value.mostLikely, toConfig),
+        pessimistic: snapNumericLike(value.pessimistic, toConfig),
       };
     }
 
-    let snap = scalar;
-    if (toConfig.scale === 'numeric_configurable') {
-      snap = nearestNumericValue(scalar, toConfig);
-    } else if (toConfig.scale === 'time_unit' && toConfig.input_mode === 'preset') {
-      snap = nearestFromList(scalar, toConfig.preset_values || []);
-    } else if (toConfig.scale === 'credit_hours') {
-      const allowed =
-        toConfig.input_mode === 'bucket'
-          ? CREDIT_HOURS_BUCKETS
-          : toConfig.input_mode === 'fibonacci'
-            ? CREDIT_HOURS_FIB
-            : null;
-      if (allowed) snap = nearestFromList(scalar, [...allowed]);
-    }
+    const scalar =
+      fromConfig !== undefined ? pointValueScalar(value, fromConfig) : numericFromValue(value);
+    if (!isFinite(scalar)) return undefined;
 
+    const snap = snapNumericLike(scalar, toConfig);
     if (pertOn) {
       return { type: 'numeric_pert', optimistic: snap, mostLikely: snap, pessimistic: snap };
     }
@@ -365,6 +356,34 @@ function isNumericLikeScale(
     config.scale === 'time_unit' ||
     config.scale === 'credit_hours'
   );
+}
+
+/**
+ * Snap a single number to the closest value allowed by a numeric-like scale.
+ * Used for both single values and per-bound PERT migration so the rules are
+ * identical regardless of how the source value was encoded.
+ */
+function snapNumericLike(
+  raw: number,
+  toConfig: NumericScaleConfig | TimeScaleConfig | CreditHoursScaleConfig,
+): number {
+  if (toConfig.scale === 'numeric_configurable') {
+    return nearestNumericValue(raw, toConfig);
+  }
+  if (toConfig.scale === 'time_unit') {
+    if (toConfig.input_mode === 'preset') {
+      return nearestFromList(raw, toConfig.preset_values || []);
+    }
+    return raw;
+  }
+  // credit_hours
+  if (toConfig.input_mode === 'bucket') {
+    return nearestFromList(raw, [...CREDIT_HOURS_BUCKETS]);
+  }
+  if (toConfig.input_mode === 'fibonacci') {
+    return nearestFromList(raw, [...CREDIT_HOURS_FIB]);
+  }
+  return raw;
 }
 
 function isPertEnabled(config: PointScaleConfig): boolean {

--- a/src/app/core/utils/point-scale.utils.ts
+++ b/src/app/core/utils/point-scale.utils.ts
@@ -1,0 +1,430 @@
+import {
+  AnimalScaleConfig,
+  AnimalSize,
+  ANIMAL_SIZES,
+  CreditHoursScaleConfig,
+  CREDIT_HOURS_BUCKETS,
+  CREDIT_HOURS_FIB,
+  DEFAULT_ANIMAL_MAPPING,
+  DEFAULT_TSHIRT_MAPPING,
+  MultiFactorScaleConfig,
+  NumericScaleConfig,
+  PointScaleConfig,
+  PointValue,
+  TimeScaleConfig,
+  TShirtScaleConfig,
+  TShirtSize,
+  TSHIRT_SIZES,
+} from '../models/domain.model';
+
+/**
+ * Generate the allowed numeric values from a numeric scale config.
+ * For `custom`, returns the user-defined list (clipped to allow_zero).
+ */
+export function getNumericAllowedValues(config: NumericScaleConfig): number[] {
+  const values = generateNumericValues(config);
+  if (!config.allow_zero) {
+    return values.filter((v) => v !== 0);
+  }
+  return values;
+}
+
+function generateNumericValues(config: NumericScaleConfig): number[] {
+  const { min_value, max_value, increment_type } = config;
+
+  switch (increment_type) {
+    case 'linear': {
+      const step = config.increment_step && config.increment_step > 0 ? config.increment_step : 1;
+      const out: number[] = [];
+      // Use rounding to avoid floating point drift on non-integer steps.
+      const decimals = decimalPlaces(step);
+      for (let v = min_value; v <= max_value + 1e-9; v += step) {
+        out.push(round(v, decimals));
+      }
+      return out;
+    }
+    case 'fibonacci': {
+      const out: number[] = [];
+      let a = 1;
+      let b = 1;
+      // Include 0 only if min_value is 0; otherwise start at 1.
+      if (min_value <= 0) out.push(0);
+      while (a <= max_value) {
+        if (a >= min_value) out.push(a);
+        [a, b] = [b, a + b];
+      }
+      return out;
+    }
+    case 'powers_of_two': {
+      const out: number[] = [];
+      let v = 1;
+      // Reach min_value first.
+      while (v < min_value) v *= 2;
+      while (v <= max_value) {
+        out.push(v);
+        v *= 2;
+      }
+      return out;
+    }
+    case 'custom': {
+      const values = (config.custom_values || []).slice().sort((a, b) => a - b);
+      return values.filter((v) => v >= min_value && v <= max_value);
+    }
+  }
+}
+
+function decimalPlaces(n: number): number {
+  if (!isFinite(n)) return 0;
+  const s = n.toString();
+  if (s.indexOf('.') === -1) return 0;
+  return s.split('.')[1].length;
+}
+
+function round(n: number, decimals: number): number {
+  const factor = Math.pow(10, decimals);
+  return Math.round(n * factor) / factor;
+}
+
+/** Time-unit suffix used for display. */
+export function timeUnitSuffix(unit: TimeScaleConfig['unit']): string {
+  switch (unit) {
+    case 'minutes':
+      return 'm';
+    case 'hours':
+      return 'h';
+    case 'days':
+      return 'd';
+    case 'weeks':
+      return 'w';
+  }
+}
+
+/** PERT weighted estimate: (O + 4M + P) / 6. */
+export function computePertEstimate(o: number, m: number, p: number): number {
+  return (o + 4 * m + p) / 6;
+}
+
+/** PERT standard deviation: (P - O) / 6. */
+export function computePertStdDev(o: number, m: number, p: number): number {
+  return (p - o) / 6;
+}
+
+/**
+ * Project any PointValue down to a single number so it can be summed or
+ * compared. For PERT values, returns the weighted estimate. Used for
+ * roll-ups and credit-fraction calculations.
+ */
+export function pointValueScalar(
+  value: PointValue | undefined,
+  config: PointScaleConfig,
+): number {
+  if (!value) return 0;
+  switch (value.type) {
+    case 'numeric':
+      return value.value;
+    case 'numeric_pert':
+      return computePertEstimate(value.optimistic, value.mostLikely, value.pessimistic);
+    case 'tshirt': {
+      const mapping = (config as TShirtScaleConfig).mapping || DEFAULT_TSHIRT_MAPPING;
+      return mapping[value.value] ?? 0;
+    }
+    case 'animal': {
+      const mapping = (config as AnimalScaleConfig).mapping || DEFAULT_ANIMAL_MAPPING;
+      return mapping[value.value] ?? 0;
+    }
+    case 'multi_factor':
+      return multiFactorScore(value.values, config as MultiFactorScaleConfig);
+  }
+}
+
+function multiFactorScore(
+  values: Record<string, number>,
+  config: MultiFactorScaleConfig,
+): number {
+  const factors = config.factors || [];
+  if (factors.length === 0) return 0;
+
+  switch (config.formula) {
+    case 'product': {
+      let acc = 1;
+      for (const f of factors) {
+        const v = Number(values[f.id]);
+        if (!isFinite(v)) return 0;
+        acc *= v;
+      }
+      return acc;
+    }
+    case 'weighted_sum': {
+      let acc = 0;
+      for (const f of factors) {
+        const v = Number(values[f.id]) || 0;
+        acc += v * (f.weight || 0);
+      }
+      return acc;
+    }
+    case 'sum':
+    default: {
+      let acc = 0;
+      for (const f of factors) {
+        acc += Number(values[f.id]) || 0;
+      }
+      return acc;
+    }
+  }
+}
+
+export interface AggregateResult {
+  total: number;
+  /** Total standard deviation for PERT roll-ups; 0 when not applicable. */
+  totalStdDev: number;
+  /** Forecasted total after applying load factor (time scale only). */
+  forecastTotal?: number;
+  /** Number of tasks contributing a non-zero value. */
+  contributingCount: number;
+}
+
+export function aggregateValues(
+  values: (PointValue | undefined)[],
+  config: PointScaleConfig,
+): AggregateResult {
+  let total = 0;
+  let variance = 0;
+  let contributing = 0;
+  for (const v of values) {
+    if (!v) continue;
+    const scalar = pointValueScalar(v, config);
+    if (scalar !== 0) contributing += 1;
+    total += scalar;
+    if (v.type === 'numeric_pert') {
+      const sd = computePertStdDev(v.optimistic, v.mostLikely, v.pessimistic);
+      variance += sd * sd;
+    }
+  }
+  const result: AggregateResult = {
+    total,
+    totalStdDev: Math.sqrt(variance),
+    contributingCount: contributing,
+  };
+  if (config.scale === 'time_unit' && config.load_factor && config.load_factor !== 1) {
+    result.forecastTotal = total * config.load_factor;
+  }
+  return result;
+}
+
+/** Format a single PointValue for compact display (badge / sidebar). */
+export function formatPointValue(
+  value: PointValue | undefined,
+  config: PointScaleConfig | undefined,
+): string {
+  if (!value || !config) return '';
+  switch (value.type) {
+    case 'numeric': {
+      if (config.scale === 'time_unit') {
+        return `${formatNumber(value.value)}${timeUnitSuffix(config.unit)}`;
+      }
+      if (config.scale === 'credit_hours') {
+        return `${formatNumber(value.value)}h`;
+      }
+      return formatNumber(value.value);
+    }
+    case 'numeric_pert': {
+      const est = computePertEstimate(value.optimistic, value.mostLikely, value.pessimistic);
+      const sd = computePertStdDev(value.optimistic, value.mostLikely, value.pessimistic);
+      const suffix =
+        config.scale === 'time_unit'
+          ? timeUnitSuffix(config.unit)
+          : config.scale === 'credit_hours'
+            ? 'h'
+            : '';
+      return `${formatNumber(est)} ± ${formatNumber(sd)}${suffix}`;
+    }
+    case 'tshirt':
+      return value.value;
+    case 'animal':
+      return value.value;
+    case 'multi_factor': {
+      const total = multiFactorScore(value.values, config as MultiFactorScaleConfig);
+      return formatNumber(total);
+    }
+  }
+}
+
+function formatNumber(n: number): string {
+  if (!isFinite(n)) return '0';
+  // Trim trailing zeros while keeping useful precision.
+  const rounded = Math.round(n * 100) / 100;
+  return Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2).replace(/\.?0+$/, '');
+}
+
+/**
+ * Snap an arbitrary numeric input to the nearest allowed value in a numeric
+ * config. Used when switching scale shapes (e.g. linear → Fibonacci).
+ */
+export function nearestNumericValue(target: number, config: NumericScaleConfig): number {
+  const allowed = getNumericAllowedValues(config);
+  if (allowed.length === 0) return target;
+  return allowed.reduce((best, v) =>
+    Math.abs(v - target) < Math.abs(best - target) ? v : best,
+  );
+}
+
+/**
+ * Map an existing PointValue to the new scale using a best-effort
+ * nearest-equivalent strategy. Returns `undefined` when no sensible mapping
+ * exists so the task's value is cleared.
+ *
+ * Behavior:
+ *  - Switching numeric → numeric snaps to nearest allowed value (per O/M/P).
+ *  - Toggling PERT on for an existing single value sets O=M=P=value (zero SD).
+ *  - Toggling PERT off collapses to the weighted estimate.
+ *  - Numeric → T-shirt / animal maps via the default numeric mapping.
+ *  - T-shirt ↔ animal maps via mapped scalar then back to nearest label.
+ *  - Multi-factor and credit-hours: clear unless the target is the same scale.
+ */
+export function migrateValue(
+  value: PointValue | undefined,
+  fromConfig: PointScaleConfig | undefined,
+  toConfig: PointScaleConfig,
+): PointValue | undefined {
+  if (!value) return undefined;
+
+  // Numeric-like target scales (numeric_configurable, time_unit, credit_hours)
+  if (isNumericLikeScale(toConfig)) {
+    const scalar =
+      fromConfig !== undefined ? pointValueScalar(value, fromConfig) : numericFromValue(value);
+    if (!isFinite(scalar)) return undefined;
+    const pertOn = isPertEnabled(toConfig);
+
+    if (value.type === 'numeric_pert' && pertOn && toConfig.scale === 'numeric_configurable') {
+      return {
+        type: 'numeric_pert',
+        optimistic: nearestNumericValue(value.optimistic, toConfig),
+        mostLikely: nearestNumericValue(value.mostLikely, toConfig),
+        pessimistic: nearestNumericValue(value.pessimistic, toConfig),
+      };
+    }
+
+    let snap = scalar;
+    if (toConfig.scale === 'numeric_configurable') {
+      snap = nearestNumericValue(scalar, toConfig);
+    } else if (toConfig.scale === 'time_unit' && toConfig.input_mode === 'preset') {
+      snap = nearestFromList(scalar, toConfig.preset_values || []);
+    } else if (toConfig.scale === 'credit_hours') {
+      const allowed =
+        toConfig.input_mode === 'bucket'
+          ? CREDIT_HOURS_BUCKETS
+          : toConfig.input_mode === 'fibonacci'
+            ? CREDIT_HOURS_FIB
+            : null;
+      if (allowed) snap = nearestFromList(scalar, [...allowed]);
+    }
+
+    if (pertOn) {
+      return { type: 'numeric_pert', optimistic: snap, mostLikely: snap, pessimistic: snap };
+    }
+    return { type: 'numeric', value: snap };
+  }
+
+  if (toConfig.scale === 'tshirt') {
+    const mapping = toConfig.mapping || DEFAULT_TSHIRT_MAPPING;
+    const scalar =
+      fromConfig !== undefined ? pointValueScalar(value, fromConfig) : numericFromValue(value);
+    const size = nearestLabel<TShirtSize>(scalar, TSHIRT_SIZES, mapping);
+    return size ? { type: 'tshirt', value: size } : undefined;
+  }
+
+  if (toConfig.scale === 'animal') {
+    const mapping = toConfig.mapping || DEFAULT_ANIMAL_MAPPING;
+    const scalar =
+      fromConfig !== undefined ? pointValueScalar(value, fromConfig) : numericFromValue(value);
+    const size = nearestLabel<AnimalSize>(scalar, ANIMAL_SIZES, mapping);
+    return size ? { type: 'animal', value: size } : undefined;
+  }
+
+  // Multi-factor: only keep the existing map if the new config matches by ID.
+  if (toConfig.scale === 'custom_multi_factor') {
+    if (value.type === 'multi_factor') {
+      const allowedIds = new Set(toConfig.factors.map((f) => f.id));
+      const next: Record<string, number> = {};
+      for (const [k, v] of Object.entries(value.values)) {
+        if (allowedIds.has(k)) next[k] = v;
+      }
+      return Object.keys(next).length > 0 ? { type: 'multi_factor', values: next } : undefined;
+    }
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function isNumericLikeScale(
+  config: PointScaleConfig,
+): config is NumericScaleConfig | TimeScaleConfig | CreditHoursScaleConfig {
+  return (
+    config.scale === 'numeric_configurable' ||
+    config.scale === 'time_unit' ||
+    config.scale === 'credit_hours'
+  );
+}
+
+function isPertEnabled(config: PointScaleConfig): boolean {
+  return (
+    (config.scale === 'numeric_configurable' ||
+      config.scale === 'time_unit' ||
+      config.scale === 'credit_hours') &&
+    !!config.pert_mode_enabled
+  );
+}
+
+function numericFromValue(value: PointValue): number {
+  switch (value.type) {
+    case 'numeric':
+      return value.value;
+    case 'numeric_pert':
+      return computePertEstimate(value.optimistic, value.mostLikely, value.pessimistic);
+    case 'tshirt':
+      return DEFAULT_TSHIRT_MAPPING[value.value] ?? 0;
+    case 'animal':
+      return DEFAULT_ANIMAL_MAPPING[value.value] ?? 0;
+    case 'multi_factor':
+      return Object.values(value.values).reduce((a, b) => a + (Number(b) || 0), 0);
+  }
+}
+
+function nearestFromList(target: number, list: number[]): number {
+  if (!list.length) return target;
+  return list.reduce((best, v) => (Math.abs(v - target) < Math.abs(best - target) ? v : best));
+}
+
+function nearestLabel<T extends string>(
+  target: number,
+  labels: readonly T[],
+  mapping: Record<T, number>,
+): T | undefined {
+  if (!labels.length) return undefined;
+  let best = labels[0];
+  let bestDist = Math.abs(mapping[best] - target);
+  for (const l of labels) {
+    const d = Math.abs(mapping[l] - target);
+    if (d < bestDist) {
+      best = l;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+/** Human label for the scale, used in pickers. */
+export const SCALE_LABELS: Readonly<Record<PointScaleConfig['scale'], string>> = {
+  numeric_configurable: 'Numeric (Points)',
+  time_unit: 'Time-Based',
+  tshirt: 'T-Shirt Sizing',
+  animal: 'Animal Sizing',
+  custom_multi_factor: 'Custom Multi-Factor',
+  credit_hours: 'Internship Credit Hours',
+};
+
+/** Returns true when this scale type supports a PERT toggle. */
+export function scaleSupportsPert(scale: PointScaleConfig['scale']): boolean {
+  return scale === 'numeric_configurable' || scale === 'time_unit' || scale === 'credit_hours';
+}

--- a/src/app/core/utils/point-scale.utils.ts
+++ b/src/app/core/utils/point-scale.utils.ts
@@ -85,6 +85,27 @@ function round(n: number, decimals: number): number {
   return Math.round(n * factor) / factor;
 }
 
+/**
+ * Allowed hour-bucket values for a credit-hours scale, after applying any
+ * configured min/max bounds. Falls back to the full default list when
+ * bounds are not set. `direct` mode has no fixed list, so this returns an
+ * empty array for it (callers should treat that as "use continuous input").
+ */
+export function getCreditHoursAllowedValues(config: CreditHoursScaleConfig): number[] {
+  let base: readonly number[];
+  if (config.input_mode === 'bucket') {
+    base = CREDIT_HOURS_BUCKETS;
+  } else if (config.input_mode === 'fibonacci') {
+    base = CREDIT_HOURS_FIB;
+  } else {
+    return [];
+  }
+  const min = config.min_value;
+  const max = config.max_value;
+  if (min === undefined && max === undefined) return [...base];
+  return base.filter((v) => (min === undefined || v >= min) && (max === undefined || v <= max));
+}
+
 /** Time-unit suffix used for display. */
 export function timeUnitSuffix(unit: TimeScaleConfig['unit']): string {
   switch (unit) {
@@ -377,11 +398,10 @@ function snapNumericLike(
     return raw;
   }
   // credit_hours
-  if (toConfig.input_mode === 'bucket') {
-    return nearestFromList(raw, [...CREDIT_HOURS_BUCKETS]);
-  }
-  if (toConfig.input_mode === 'fibonacci') {
-    return nearestFromList(raw, [...CREDIT_HOURS_FIB]);
+  if (toConfig.input_mode === 'bucket' || toConfig.input_mode === 'fibonacci') {
+    const allowed = getCreditHoursAllowedValues(toConfig);
+    if (allowed.length === 0) return raw;
+    return nearestFromList(raw, allowed);
   }
   return raw;
 }

--- a/src/app/features/dashboard/components/project-overview.component.html
+++ b/src/app/features/dashboard/components/project-overview.component.html
@@ -503,6 +503,11 @@
           [class.active]="activePanel() === 'fields'"
           (click)="togglePanel('fields')"
         >Custom fields</button>
+        <button
+          class="omni-glitch-btn manage-tab"
+          [class.active]="activePanel() === 'points'"
+          (click)="togglePanel('points')"
+        >Point values</button>
         @if (canManageDashboard()) {
           <button
             class="omni-glitch-btn manage-tab"
@@ -532,6 +537,9 @@
         }
         @case ('fields') {
           <app-custom-field-manager [project]="proj"></app-custom-field-manager>
+        }
+        @case ('points') {
+          <app-point-scale-manager [project]="proj"></app-point-scale-manager>
         }
         @case ('dashboard') {
           <app-dashboard-preferences-manager

--- a/src/app/features/dashboard/components/project-overview.component.ts
+++ b/src/app/features/dashboard/components/project-overview.component.ts
@@ -31,6 +31,7 @@ import { TagManagerComponent } from '../../projects/components/tag-manager.compo
 import { ProjectMemberManagerComponent } from '../../projects/components/project-member-manager.component';
 import { CustomFieldManagerComponent } from '../../projects/components/custom-field-manager/custom-field-manager.component';
 import { DashboardPreferencesManagerComponent } from '../../projects/components/dashboard-preferences-manager.component';
+import { PointScaleManagerComponent } from '../../projects/components/point-scale-manager.component';
 import { AuthService } from '../../../core/auth/auth.service';
 
 interface SectionStat {
@@ -78,6 +79,7 @@ interface ActivityItem {
     ProjectMemberManagerComponent,
     CustomFieldManagerComponent,
     DashboardPreferencesManagerComponent,
+    PointScaleManagerComponent,
   ],
   templateUrl: './project-overview.component.html',
   styleUrls: ['./project-overview.component.css'],
@@ -97,7 +99,7 @@ export class ProjectOverviewComponent {
   // Which "manager" panel is expanded inline. Default to sections so users
   // immediately see the most common edit surface. Null collapses all.
   activePanel = signal<
-    'sections' | 'tags' | 'members' | 'fields' | 'dashboard' | null
+    'sections' | 'tags' | 'members' | 'fields' | 'dashboard' | 'points' | null
   >('sections');
 
   readonly defaultColor = CYBERPUNK_COLORS.TODO;
@@ -422,7 +424,7 @@ export class ProjectOverviewComponent {
     return !!uid && this.project().ownerId === uid;
   }
 
-  togglePanel(panel: 'sections' | 'tags' | 'members' | 'fields' | 'dashboard') {
+  togglePanel(panel: 'sections' | 'tags' | 'members' | 'fields' | 'dashboard' | 'points') {
     this.activePanel.set(this.activePanel() === panel ? null : panel);
   }
 

--- a/src/app/features/projects/components/point-scale-manager.component.css
+++ b/src/app/features/projects/components/point-scale-manager.component.css
@@ -1,0 +1,4 @@
+/* Point-scale manager component */
+:host {
+  display: block;
+}

--- a/src/app/features/projects/components/point-scale-manager.component.html
+++ b/src/app/features/projects/components/point-scale-manager.component.html
@@ -1,0 +1,359 @@
+<div class="space-y-5">
+  <div class="flex items-center justify-between">
+    <div>
+      <h3 class="text-sm font-semibold text-slate-200">Task Point Values</h3>
+      <p class="text-xs text-slate-500 mt-1">
+        Pick a scale to rate task effort. Toggle PERT for probability-aware estimates on supported scales.
+      </p>
+    </div>
+  </div>
+
+  <!-- Scale selector -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+    <button
+      type="button"
+      class="text-left p-3 rounded-lg border transition-all"
+      [class.border-cyan-500]="selectedScaleId() === 'none'"
+      [class.bg-cyan-500_10]="selectedScaleId() === 'none'"
+      [class.border-white_10]="selectedScaleId() !== 'none'"
+      [class.bg-slate-800_40]="selectedScaleId() !== 'none'"
+      [ngClass]="{
+        'border-cyan-500 bg-cyan-500/10': selectedScaleId() === 'none',
+        'border-white/10 bg-slate-800/40 hover:bg-slate-800/60': selectedScaleId() !== 'none',
+      }"
+      (click)="selectScale('none')"
+    >
+      <div class="text-sm font-semibold text-slate-200">No point values</div>
+      <div class="text-xs text-slate-500 mt-1">Hide the point-value field on tasks.</div>
+    </button>
+
+    @for (opt of scaleOptions; track opt.id) {
+      <button
+        type="button"
+        class="text-left p-3 rounded-lg border transition-all"
+        [ngClass]="{
+          'border-cyan-500 bg-cyan-500/10': selectedScaleId() === opt.id,
+          'border-white/10 bg-slate-800/40 hover:bg-slate-800/60': selectedScaleId() !== opt.id,
+        }"
+        (click)="selectScale(opt.id)"
+      >
+        <div class="text-sm font-semibold text-slate-200">{{ opt.label }}</div>
+        <div class="text-xs text-slate-500 mt-1">{{ opt.description }}</div>
+      </button>
+    }
+  </div>
+
+  <!-- Per-scale configuration -->
+  @if (asNumeric(); as cfg) {
+    <div class="p-4 rounded-lg border border-white/10 bg-slate-900/60 space-y-4">
+      <div>
+        <label class="block text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+          Preset
+        </label>
+        <div class="flex flex-wrap gap-2">
+          @for (preset of numericPresets; track preset.id) {
+            <button
+              type="button"
+              class="px-2.5 py-1 text-xs rounded-md border border-white/10 bg-slate-800/60 hover:bg-slate-700/60 text-slate-200"
+              (click)="applyNumericPreset(preset.id)"
+            >
+              {{ preset.label }}
+            </button>
+          }
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs text-slate-400">
+          Min
+          <input
+            type="number"
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.min_value"
+            (ngModelChange)="updateNumeric('min_value', $event)"
+          />
+        </label>
+        <label class="text-xs text-slate-400">
+          Max
+          <input
+            type="number"
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.max_value"
+            (ngModelChange)="updateNumeric('max_value', $event)"
+          />
+        </label>
+        <label class="text-xs text-slate-400 col-span-2">
+          Increment type
+          <select
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.increment_type"
+            (ngModelChange)="updateNumeric('increment_type', $event)"
+          >
+            <option value="linear">Linear</option>
+            <option value="fibonacci">Fibonacci</option>
+            <option value="powers_of_two">Powers of two</option>
+            <option value="custom">Custom values</option>
+          </select>
+        </label>
+        @if (cfg.increment_type === 'linear') {
+          <label class="text-xs text-slate-400 col-span-2">
+            Step
+            <input
+              type="number"
+              class="ofx-input mt-1 text-sm"
+              [ngModel]="cfg.increment_step"
+              (ngModelChange)="updateNumeric('increment_step', $event)"
+            />
+          </label>
+        }
+        @if (cfg.increment_type === 'custom') {
+          <label class="text-xs text-slate-400 col-span-2">
+            Custom values (comma-separated)
+            <input
+              type="text"
+              class="ofx-input mt-1 text-sm"
+              [ngModel]="(cfg.custom_values || []).join(', ')"
+              (ngModelChange)="updateNumericCustomValues($event)"
+              placeholder="0, 0.5, 1, 2, 3, 5"
+            />
+          </label>
+        }
+        <label class="text-xs text-slate-400 col-span-2 inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            [checked]="cfg.allow_zero === true"
+            (change)="updateNumeric('allow_zero', $any($event.target).checked)"
+          />
+          Allow zero
+        </label>
+      </div>
+    </div>
+  }
+
+  @if (asTime(); as cfg) {
+    <div class="p-4 rounded-lg border border-white/10 bg-slate-900/60 space-y-3">
+      <div class="grid grid-cols-2 gap-3">
+        <label class="text-xs text-slate-400">
+          Unit
+          <select
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.unit"
+            (ngModelChange)="updateTime('unit', $event)"
+          >
+            <option value="minutes">Minutes</option>
+            <option value="hours">Hours</option>
+            <option value="days">Days</option>
+            <option value="weeks">Weeks</option>
+          </select>
+        </label>
+        <label class="text-xs text-slate-400">
+          Decimal precision
+          <input
+            type="number"
+            min="0"
+            max="4"
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.decimal_precision ?? 2"
+            (ngModelChange)="updateTime('decimal_precision', $event)"
+          />
+        </label>
+        <label class="text-xs text-slate-400 col-span-2">
+          Input mode
+          <select
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.input_mode"
+            (ngModelChange)="updateTime('input_mode', $event)"
+          >
+            <option value="freeform">Free-form</option>
+            <option value="preset">Preset values</option>
+          </select>
+        </label>
+        @if (cfg.input_mode === 'preset') {
+          <label class="text-xs text-slate-400 col-span-2">
+            Preset values (comma-separated)
+            <input
+              type="text"
+              class="ofx-input mt-1 text-sm"
+              [ngModel]="(cfg.preset_values || []).join(', ')"
+              (ngModelChange)="updateTimePresets($event)"
+              placeholder="0.25, 0.5, 1, 2, 4"
+            />
+          </label>
+        }
+        <label class="text-xs text-slate-400 col-span-2">
+          Load factor (applied to roll-up totals)
+          <input
+            type="number"
+            step="0.1"
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.load_factor ?? 1"
+            (ngModelChange)="updateTime('load_factor', $event)"
+          />
+        </label>
+      </div>
+    </div>
+  }
+
+  @if (selectedScaleId() === 'tshirt') {
+    <div class="p-4 rounded-lg border border-white/10 bg-slate-900/60 text-xs text-slate-400">
+      Sizes <span class="text-slate-200 font-mono">XS · S · M · L · XL · XXL</span> map to
+      <span class="text-slate-200 font-mono">1 · 2 · 3 · 5 · 8 · 13</span> for aggregation.
+    </div>
+  }
+
+  @if (selectedScaleId() === 'animal') {
+    <div class="p-4 rounded-lg border border-white/10 bg-slate-900/60 text-xs text-slate-400">
+      Animals 🐭 🐱 🐶 🐴 🐘 🐋 map to
+      <span class="text-slate-200 font-mono">1 · 2 · 3 · 5 · 8 · 13</span>.
+    </div>
+  }
+
+  @if (asMultiFactor(); as cfg) {
+    <div class="p-4 rounded-lg border border-white/10 bg-slate-900/60 space-y-3">
+      <label class="text-xs text-slate-400 block">
+        Formula
+        <select
+          class="ofx-input mt-1 text-sm"
+          [ngModel]="cfg.formula"
+          (ngModelChange)="updateMultiFactorFormula($event)"
+        >
+          <option value="sum">Sum</option>
+          <option value="product">Product</option>
+          <option value="weighted_sum">Weighted sum</option>
+        </select>
+      </label>
+
+      <div class="space-y-2">
+        @for (factor of cfg.factors; track factor.id) {
+          <div class="grid grid-cols-12 gap-2 items-end">
+            <label class="col-span-4 text-[10px] text-slate-400">
+              Name
+              <input
+                type="text"
+                class="ofx-input mt-1 text-sm"
+                [ngModel]="factor.name"
+                (ngModelChange)="updateFactor(factor.id, { name: $event })"
+              />
+            </label>
+            <label class="col-span-5 text-[10px] text-slate-400">
+              Scale (comma-separated)
+              <input
+                type="text"
+                class="ofx-input mt-1 text-sm"
+                [ngModel]="factor.scale.join(', ')"
+                (ngModelChange)="updateFactorScale(factor.id, $event)"
+              />
+            </label>
+            <label class="col-span-2 text-[10px] text-slate-400">
+              Weight
+              <input
+                type="number"
+                step="0.1"
+                class="ofx-input mt-1 text-sm"
+                [ngModel]="factor.weight"
+                (ngModelChange)="updateFactor(factor.id, { weight: $event })"
+              />
+            </label>
+            <button
+              type="button"
+              class="col-span-1 h-8 text-slate-500 hover:text-rose-400 text-lg"
+              (click)="removeFactor(factor.id)"
+              [disabled]="cfg.factors.length <= 1"
+              title="Remove factor"
+            >
+              ×
+            </button>
+          </div>
+        }
+      </div>
+
+      <button
+        type="button"
+        class="ofx-ghost-button text-xs"
+        (click)="addFactor()"
+      >
+        + Add factor
+      </button>
+    </div>
+  }
+
+  @if (asCreditHours(); as cfg) {
+    <div class="p-4 rounded-lg border border-white/10 bg-slate-900/60 space-y-3 grid grid-cols-2 gap-3">
+      <label class="text-xs text-slate-400">
+        Total credit hours
+        <input
+          type="number"
+          class="ofx-input mt-1 text-sm"
+          [ngModel]="cfg.total_credit_hours"
+          (ngModelChange)="updateCreditHours('total_credit_hours', $event)"
+        />
+      </label>
+      <label class="text-xs text-slate-400">
+        Total work hours
+        <input
+          type="number"
+          class="ofx-input mt-1 text-sm"
+          [ngModel]="cfg.total_work_hours"
+          (ngModelChange)="updateCreditHours('total_work_hours', $event)"
+        />
+      </label>
+      <label class="text-xs text-slate-400 col-span-2">
+        Input mode
+        <select
+          class="ofx-input mt-1 text-sm"
+          [ngModel]="cfg.input_mode"
+          (ngModelChange)="updateCreditHours('input_mode', $event)"
+        >
+          <option value="direct">Direct entry</option>
+          <option value="bucket">Hour buckets (0.25–8)</option>
+          <option value="fibonacci">Fibonacci hours</option>
+        </select>
+      </label>
+      <label class="text-xs text-slate-400 col-span-2">
+        Weekly target hours (optional)
+        <input
+          type="number"
+          class="ofx-input mt-1 text-sm"
+          [ngModel]="cfg.weekly_target_hours"
+          (ngModelChange)="updateCreditHours('weekly_target_hours', $event)"
+        />
+      </label>
+    </div>
+  }
+
+  <!-- PERT toggle -->
+  @if (draft(); as cfg) {
+    @if (scaleSupportsPert(cfg.scale)) {
+      <label class="inline-flex items-center gap-2 text-sm text-slate-200">
+        <input
+          type="checkbox"
+          [checked]="$any(cfg).pert_mode_enabled === true"
+          (change)="togglePert($any($event.target).checked)"
+        />
+        <span>Enable PERT (Optimistic / Most Likely / Pessimistic)</span>
+      </label>
+    }
+  }
+
+  @if (error()) {
+    <div class="p-3 rounded-lg bg-rose-500/10 border border-rose-500/20 text-rose-400 text-sm">
+      {{ error() }}
+    </div>
+  }
+
+  <div class="flex items-center gap-2 justify-end pt-2">
+    @if (hasChanges()) {
+      <button class="ofx-ghost-button text-xs" type="button" (click)="reset()" [disabled]="saving()">
+        Reset
+      </button>
+    }
+    <button
+      class="ofx-gradient-button text-xs"
+      type="button"
+      (click)="save()"
+      [disabled]="!hasChanges() || saving()"
+    >
+      {{ saving() ? 'Saving…' : 'Save' }}
+    </button>
+  </div>
+</div>

--- a/src/app/features/projects/components/point-scale-manager.component.html
+++ b/src/app/features/projects/components/point-scale-manager.component.html
@@ -305,6 +305,40 @@
           <option value="fibonacci">Fibonacci hours</option>
         </select>
       </label>
+
+      @if (cfg.input_mode === 'bucket' || cfg.input_mode === 'fibonacci') {
+        <label class="text-xs text-slate-400">
+          Minimum hours
+          <input
+            type="number"
+            min="0"
+            step="0.25"
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.min_value"
+            (ngModelChange)="updateCreditHours('min_value', $event)"
+            [placeholder]="creditHoursDefaultMin(cfg)"
+          />
+        </label>
+        <label class="text-xs text-slate-400">
+          Maximum hours
+          <input
+            type="number"
+            min="0"
+            step="0.25"
+            class="ofx-input mt-1 text-sm"
+            [ngModel]="cfg.max_value"
+            (ngModelChange)="updateCreditHours('max_value', $event)"
+            [placeholder]="creditHoursDefaultMax(cfg)"
+          />
+        </label>
+        <div class="col-span-2 text-[11px] text-slate-500">
+          Buckets in range:
+          <span class="text-slate-300 font-mono">
+            {{ creditHoursAllowedPreview(cfg) }}
+          </span>
+        </div>
+      }
+
       <label class="text-xs text-slate-400 col-span-2">
         Weekly target hours (optional)
         <input

--- a/src/app/features/projects/components/point-scale-manager.component.html
+++ b/src/app/features/projects/components/point-scale-manager.component.html
@@ -307,6 +307,31 @@
       </label>
 
       @if (cfg.input_mode === 'bucket' || cfg.input_mode === 'fibonacci') {
+        <div class="col-span-2 space-y-2">
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-slate-400">Bucket range</span>
+            @if (cfg.min_value !== undefined || cfg.max_value !== undefined) {
+              <button
+                type="button"
+                class="text-[10px] text-slate-500 hover:text-slate-200"
+                (click)="clearCreditHoursBounds()"
+              >
+                Reset to default
+              </button>
+            }
+          </div>
+          <app-snap-slider
+            [values]="creditHoursRangeStops(cfg)"
+            [labels]="creditHoursRangeLabels(cfg)"
+            [range]="true"
+            [minValue]="cfg.min_value ?? creditHoursDefaultMin(cfg)"
+            [maxValue]="cfg.max_value ?? creditHoursDefaultMax(cfg)"
+            accent="#a564ff"
+            ariaLabel="Bucket range"
+            (rangeChange)="onCreditHoursRangeChange($event)"
+          ></app-snap-slider>
+        </div>
+
         <label class="text-xs text-slate-400">
           Minimum hours
           <input

--- a/src/app/features/projects/components/point-scale-manager.component.html
+++ b/src/app/features/projects/components/point-scale-manager.component.html
@@ -13,10 +13,6 @@
     <button
       type="button"
       class="text-left p-3 rounded-lg border transition-all"
-      [class.border-cyan-500]="selectedScaleId() === 'none'"
-      [class.bg-cyan-500_10]="selectedScaleId() === 'none'"
-      [class.border-white_10]="selectedScaleId() !== 'none'"
-      [class.bg-slate-800_40]="selectedScaleId() !== 'none'"
       [ngClass]="{
         'border-cyan-500 bg-cyan-500/10': selectedScaleId() === 'none',
         'border-white/10 bg-slate-800/40 hover:bg-slate-800/60': selectedScaleId() !== 'none',
@@ -338,6 +334,12 @@
   @if (error()) {
     <div class="p-3 rounded-lg bg-rose-500/10 border border-rose-500/20 text-rose-400 text-sm">
       {{ error() }}
+    </div>
+  }
+
+  @if (successMessage()) {
+    <div class="p-3 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 text-sm">
+      {{ successMessage() }}
     </div>
   }
 

--- a/src/app/features/projects/components/point-scale-manager.component.ts
+++ b/src/app/features/projects/components/point-scale-manager.component.ts
@@ -26,10 +26,13 @@ import {
   TimeScaleConfig,
 } from '../../../core/models/domain.model';
 import {
+  generateCreditHoursBucketList,
+  generateCreditHoursFibList,
   getCreditHoursAllowedValues,
   SCALE_LABELS,
   scaleSupportsPert,
 } from '../../../core/utils/point-scale.utils';
+import { SnapSliderComponent } from '../../../shared/components/snap-slider/snap-slider.component';
 
 interface ScaleOption {
   id: PointScaleId;
@@ -73,7 +76,7 @@ const SCALE_OPTIONS: readonly ScaleOption[] = [
 @Component({
   selector: 'app-point-scale-manager',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, SnapSliderComponent],
   templateUrl: './point-scale-manager.component.html',
   styleUrls: ['./point-scale-manager.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -313,6 +316,47 @@ export class PointScaleManagerComponent {
     const allowed = getCreditHoursAllowedValues(cfg);
     if (!allowed.length) return '—';
     return allowed.map((v) => `${v}h`).join(', ');
+  }
+
+  /**
+   * Full list of bucket stops the range slider can reach. We extend past the
+   * user's currently-configured max so they can drag the upper thumb to
+   * raise the cap, not just lower it — without arbitrarily large fallback
+   * lists. Default cap: 64h for buckets, 89h for Fibonacci. Stays at least
+   * one step past the configured max so the upper thumb has room to grow.
+   */
+  creditHoursRangeStops(cfg: CreditHoursScaleConfig): number[] {
+    if (cfg.input_mode === 'bucket') {
+      const ceiling = Math.max(64, (cfg.max_value ?? 8) * 2);
+      return generateCreditHoursBucketList(ceiling);
+    }
+    if (cfg.input_mode === 'fibonacci') {
+      const ceiling = Math.max(89, (cfg.max_value ?? 13) * 2);
+      return generateCreditHoursFibList(ceiling);
+    }
+    return [];
+  }
+
+  /** Labels for the range slider stops ("0.25h", "0.5h", "1h", …). */
+  creditHoursRangeLabels(cfg: CreditHoursScaleConfig): string[] {
+    return this.creditHoursRangeStops(cfg).map((v) => `${v}h`);
+  }
+
+  /** Apply a range emitted by the slider. */
+  onCreditHoursRangeChange(value: { min: number; max: number }): void {
+    const d = this.asCreditHours();
+    if (!d) return;
+    this.draft.set({ ...d, min_value: value.min, max_value: value.max });
+  }
+
+  /** Reset min/max to defaults so the slider snaps back to the full range. */
+  clearCreditHoursBounds(): void {
+    const d = this.asCreditHours();
+    if (!d) return;
+    const next = { ...d } as CreditHoursScaleConfig;
+    delete next.min_value;
+    delete next.max_value;
+    this.draft.set(next);
   }
 
   // Persist ------------------------------------------------------------------

--- a/src/app/features/projects/components/point-scale-manager.component.ts
+++ b/src/app/features/projects/components/point-scale-manager.component.ts
@@ -1,0 +1,316 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ProjectService } from '../../../core/services/project.service';
+import { DialogService } from '../../../core/services/dialog.service';
+import {
+  CreditHoursScaleConfig,
+  MultiFactor,
+  MultiFactorScaleConfig,
+  NUMERIC_PRESETS,
+  NumericScaleConfig,
+  PointScaleConfig,
+  PointScaleId,
+  Project,
+  TimeScaleConfig,
+} from '../../../core/models/domain.model';
+import { SCALE_LABELS, scaleSupportsPert } from '../../../core/utils/point-scale.utils';
+
+interface ScaleOption {
+  id: PointScaleId;
+  label: string;
+  description: string;
+}
+
+const SCALE_OPTIONS: readonly ScaleOption[] = [
+  {
+    id: 'numeric_configurable',
+    label: 'Numeric (Points)',
+    description: 'Abstract effort points — linear, Fibonacci, powers of two, or custom.',
+  },
+  {
+    id: 'time_unit',
+    label: 'Time-Based',
+    description: 'Estimate in minutes, hours, days, or weeks with optional load factor.',
+  },
+  {
+    id: 'tshirt',
+    label: 'T-Shirt Sizing',
+    description: 'XS · S · M · L · XL · XXL. Optional numeric mapping for roll-ups.',
+  },
+  {
+    id: 'animal',
+    label: 'Animal Sizing',
+    description: 'Mouse · Cat · Dog · Horse · Elephant · Whale.',
+  },
+  {
+    id: 'custom_multi_factor',
+    label: 'Custom Multi-Factor',
+    description: 'Score each task across multiple effort dimensions.',
+  },
+  {
+    id: 'credit_hours',
+    label: 'Internship Credit Hours',
+    description: 'Track work-hours against credit-hour requirements for academic programs.',
+  },
+];
+
+@Component({
+  selector: 'app-point-scale-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './point-scale-manager.component.html',
+  styleUrls: ['./point-scale-manager.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PointScaleManagerComponent {
+  private readonly projectService = inject(ProjectService);
+  private readonly dialogService = inject(DialogService);
+
+  project = input.required<Project>();
+  projectChanged = output<void>();
+
+  readonly scaleOptions = SCALE_OPTIONS;
+  readonly numericPresets = NUMERIC_PRESETS;
+  readonly scaleLabels = SCALE_LABELS;
+  readonly scaleSupportsPert = scaleSupportsPert;
+
+  /**
+   * Draft of the project's point-scale configuration. Null = the feature is
+   * off for this project. Edits don't persist until the user clicks "Save".
+   */
+  draft = signal<PointScaleConfig | null>(null);
+  saving = signal(false);
+  error = signal<string | null>(null);
+
+  /** ID of the previously-loaded project, used to detect switches. */
+  private lastProjectId: string | null = null;
+
+  constructor() {
+    effect(() => {
+      const p = this.project();
+      if (p.id !== this.lastProjectId) {
+        this.lastProjectId = p.id;
+        this.draft.set(this.cloneConfig(p.pointScaleConfig) ?? null);
+        this.error.set(null);
+      }
+    });
+  }
+
+  /** Snapshot the persisted config for diffing. */
+  private persisted = computed<PointScaleConfig | undefined>(() => this.project().pointScaleConfig);
+
+  /** Whether the draft differs from the persisted config. */
+  hasChanges = computed<boolean>(() => {
+    return JSON.stringify(this.draft()) !== JSON.stringify(this.persisted() ?? null);
+  });
+
+  /** Currently-selected scale id ("none" sentinel when feature is off). */
+  selectedScaleId = computed<PointScaleId | 'none'>(() => {
+    const d = this.draft();
+    return d ? d.scale : 'none';
+  });
+
+  /** Cast helpers used by the template (Angular templates can't narrow unions). */
+  asNumeric = computed<NumericScaleConfig | null>(() => {
+    const d = this.draft();
+    return d && d.scale === 'numeric_configurable' ? d : null;
+  });
+  asTime = computed<TimeScaleConfig | null>(() => {
+    const d = this.draft();
+    return d && d.scale === 'time_unit' ? d : null;
+  });
+  asMultiFactor = computed<MultiFactorScaleConfig | null>(() => {
+    const d = this.draft();
+    return d && d.scale === 'custom_multi_factor' ? d : null;
+  });
+  asCreditHours = computed<CreditHoursScaleConfig | null>(() => {
+    const d = this.draft();
+    return d && d.scale === 'credit_hours' ? d : null;
+  });
+
+  selectScale(id: PointScaleId | 'none'): void {
+    if (id === 'none') {
+      this.draft.set(null);
+      return;
+    }
+    if (this.draft()?.scale === id) return;
+    this.draft.set(this.defaultsFor(id));
+  }
+
+  /** Build a sensible default for each scale so the form is usable on first click. */
+  private defaultsFor(id: PointScaleId): PointScaleConfig {
+    switch (id) {
+      case 'numeric_configurable':
+        return { ...NUMERIC_PRESETS[0].config };
+      case 'time_unit':
+        return {
+          scale: 'time_unit',
+          unit: 'hours',
+          decimal_precision: 2,
+          input_mode: 'freeform',
+          load_factor: 1,
+        };
+      case 'tshirt':
+        return { scale: 'tshirt' };
+      case 'animal':
+        return { scale: 'animal' };
+      case 'custom_multi_factor':
+        return {
+          scale: 'custom_multi_factor',
+          formula: 'sum',
+          factors: [
+            { id: crypto.randomUUID(), name: 'Complexity', scale: [1, 2, 3, 5, 8], weight: 1 },
+          ],
+        };
+      case 'credit_hours':
+        return {
+          scale: 'credit_hours',
+          total_credit_hours: 3,
+          total_work_hours: 135,
+          input_mode: 'direct',
+        };
+    }
+  }
+
+  applyNumericPreset(presetId: string): void {
+    const preset = NUMERIC_PRESETS.find((p) => p.id === presetId);
+    if (!preset) return;
+    const pertOn = !!(this.asNumeric()?.pert_mode_enabled);
+    this.draft.set({ ...preset.config, pert_mode_enabled: pertOn });
+  }
+
+  togglePert(checked: boolean): void {
+    const d = this.draft();
+    if (!d || !scaleSupportsPert(d.scale)) return;
+    this.draft.set({ ...d, pert_mode_enabled: checked } as PointScaleConfig);
+  }
+
+  // Numeric scale field edits ------------------------------------------------
+  updateNumeric<K extends keyof NumericScaleConfig>(key: K, value: NumericScaleConfig[K]): void {
+    const d = this.asNumeric();
+    if (!d) return;
+    this.draft.set({ ...d, [key]: value });
+  }
+
+  updateNumericCustomValues(raw: string): void {
+    const values = raw
+      .split(',')
+      .map((s) => parseFloat(s.trim()))
+      .filter((n) => isFinite(n));
+    this.updateNumeric('custom_values', values);
+  }
+
+  // Time scale field edits ---------------------------------------------------
+  updateTime<K extends keyof TimeScaleConfig>(key: K, value: TimeScaleConfig[K]): void {
+    const d = this.asTime();
+    if (!d) return;
+    this.draft.set({ ...d, [key]: value });
+  }
+
+  updateTimePresets(raw: string): void {
+    const values = raw
+      .split(',')
+      .map((s) => parseFloat(s.trim()))
+      .filter((n) => isFinite(n));
+    this.updateTime('preset_values', values);
+  }
+
+  // Multi-factor edits -------------------------------------------------------
+  updateMultiFactorFormula(formula: MultiFactorScaleConfig['formula']): void {
+    const d = this.asMultiFactor();
+    if (!d) return;
+    this.draft.set({ ...d, formula });
+  }
+
+  addFactor(): void {
+    const d = this.asMultiFactor();
+    if (!d) return;
+    const next: MultiFactor = {
+      id: crypto.randomUUID(),
+      name: `Factor ${d.factors.length + 1}`,
+      scale: [1, 2, 3],
+      weight: 1,
+    };
+    this.draft.set({ ...d, factors: [...d.factors, next] });
+  }
+
+  removeFactor(id: string): void {
+    const d = this.asMultiFactor();
+    if (!d) return;
+    this.draft.set({ ...d, factors: d.factors.filter((f) => f.id !== id) });
+  }
+
+  updateFactor(id: string, patch: Partial<MultiFactor>): void {
+    const d = this.asMultiFactor();
+    if (!d) return;
+    this.draft.set({
+      ...d,
+      factors: d.factors.map((f) => (f.id === id ? { ...f, ...patch } : f)),
+    });
+  }
+
+  updateFactorScale(id: string, raw: string): void {
+    const scale = raw
+      .split(',')
+      .map((s) => parseFloat(s.trim()))
+      .filter((n) => isFinite(n));
+    this.updateFactor(id, { scale });
+  }
+
+  // Credit-hours edits -------------------------------------------------------
+  updateCreditHours<K extends keyof CreditHoursScaleConfig>(
+    key: K,
+    value: CreditHoursScaleConfig[K],
+  ): void {
+    const d = this.asCreditHours();
+    if (!d) return;
+    this.draft.set({ ...d, [key]: value });
+  }
+
+  // Persist ------------------------------------------------------------------
+  async save(): Promise<void> {
+    this.saving.set(true);
+    this.error.set(null);
+    try {
+      const draft = this.draft();
+      const previous = this.project().pointScaleConfig;
+
+      // Warn before changing scale type when tasks may have values.
+      if (previous && (!draft || draft.scale !== previous.scale)) {
+        const confirmed = await this.dialogService.confirm(
+          'Changing the scale type will remap existing task point values to the nearest equivalent. Continue?',
+          'Confirm scale change',
+        );
+        if (!confirmed) return;
+      }
+
+      await this.projectService.updatePointScaleConfig(this.project().id, draft);
+      this.projectChanged.emit();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to save point-scale configuration';
+      this.error.set(message);
+    } finally {
+      this.saving.set(false);
+    }
+  }
+
+  reset(): void {
+    this.draft.set(this.cloneConfig(this.project().pointScaleConfig) ?? null);
+    this.error.set(null);
+  }
+
+  private cloneConfig(c: PointScaleConfig | undefined): PointScaleConfig | undefined {
+    return c ? (JSON.parse(JSON.stringify(c)) as PointScaleConfig) : undefined;
+  }
+}

--- a/src/app/features/projects/components/point-scale-manager.component.ts
+++ b/src/app/features/projects/components/point-scale-manager.component.ts
@@ -13,6 +13,8 @@ import { FormsModule } from '@angular/forms';
 import { ProjectService } from '../../../core/services/project.service';
 import { DialogService } from '../../../core/services/dialog.service';
 import {
+  CREDIT_HOURS_BUCKETS,
+  CREDIT_HOURS_FIB,
   CreditHoursScaleConfig,
   MultiFactor,
   MultiFactorScaleConfig,
@@ -23,7 +25,11 @@ import {
   Project,
   TimeScaleConfig,
 } from '../../../core/models/domain.model';
-import { SCALE_LABELS, scaleSupportsPert } from '../../../core/utils/point-scale.utils';
+import {
+  getCreditHoursAllowedValues,
+  SCALE_LABELS,
+  scaleSupportsPert,
+} from '../../../core/utils/point-scale.utils';
 
 interface ScaleOption {
   id: PointScaleId;
@@ -276,7 +282,37 @@ export class PointScaleManagerComponent {
   ): void {
     const d = this.asCreditHours();
     if (!d) return;
-    this.draft.set({ ...d, [key]: value });
+    // An empty input (`null`/`''`/`NaN`) for the bounds should clear them
+    // rather than persist as 0 — that's how the user goes back to "use the
+    // full default range".
+    const cleared =
+      (key === 'min_value' || key === 'max_value') &&
+      (value === null || (value as unknown) === '' || Number.isNaN(value as number))
+        ? undefined
+        : value;
+    const next = { ...d, [key]: cleared as CreditHoursScaleConfig[K] };
+    if (cleared === undefined && (key === 'min_value' || key === 'max_value')) {
+      delete (next as Partial<CreditHoursScaleConfig>)[key];
+    }
+    this.draft.set(next);
+  }
+
+  /** Default lower bound for the bucket/fibonacci list (shown as placeholder). */
+  creditHoursDefaultMin(cfg: CreditHoursScaleConfig): number {
+    const list = cfg.input_mode === 'bucket' ? CREDIT_HOURS_BUCKETS : CREDIT_HOURS_FIB;
+    return list[0];
+  }
+
+  creditHoursDefaultMax(cfg: CreditHoursScaleConfig): number {
+    const list = cfg.input_mode === 'bucket' ? CREDIT_HOURS_BUCKETS : CREDIT_HOURS_FIB;
+    return list[list.length - 1];
+  }
+
+  /** Comma-joined preview of the buckets that will be offered to task authors. */
+  creditHoursAllowedPreview(cfg: CreditHoursScaleConfig): string {
+    const allowed = getCreditHoursAllowedValues(cfg);
+    if (!allowed.length) return '—';
+    return allowed.map((v) => `${v}h`).join(', ');
   }
 
   // Persist ------------------------------------------------------------------

--- a/src/app/features/projects/components/point-scale-manager.component.ts
+++ b/src/app/features/projects/components/point-scale-manager.component.ts
@@ -91,6 +91,8 @@ export class PointScaleManagerComponent {
   draft = signal<PointScaleConfig | null>(null);
   saving = signal(false);
   error = signal<string | null>(null);
+  successMessage = signal<string | null>(null);
+  private successTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** ID of the previously-loaded project, used to detect switches. */
   private lastProjectId: string | null = null;
@@ -281,6 +283,7 @@ export class PointScaleManagerComponent {
   async save(): Promise<void> {
     this.saving.set(true);
     this.error.set(null);
+    this.successMessage.set(null);
     try {
       const draft = this.draft();
       const previous = this.project().pointScaleConfig;
@@ -296,6 +299,7 @@ export class PointScaleManagerComponent {
 
       await this.projectService.updatePointScaleConfig(this.project().id, draft);
       this.projectChanged.emit();
+      this.flashSuccess(draft ? 'Point-scale settings saved' : 'Point-scale disabled for project');
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Failed to save point-scale configuration';
@@ -303,6 +307,12 @@ export class PointScaleManagerComponent {
     } finally {
       this.saving.set(false);
     }
+  }
+
+  private flashSuccess(message: string): void {
+    this.successMessage.set(message);
+    if (this.successTimer) clearTimeout(this.successTimer);
+    this.successTimer = setTimeout(() => this.successMessage.set(null), 4000);
   }
 
   reset(): void {

--- a/src/app/features/projects/components/project-settings-panel.component.html
+++ b/src/app/features/projects/components/project-settings-panel.component.html
@@ -29,6 +29,16 @@
 
   <hr class="border-white/10" />
 
+  <!-- Task Point Values -->
+  <section class="ofx-settings-section">
+    <app-point-scale-manager
+      [project]="project()"
+      (projectChanged)="projectChanged.emit()"
+    ></app-point-scale-manager>
+  </section>
+
+  <hr class="border-white/10" />
+
   <!-- Custom Fields -->
   <section class="ofx-settings-section">
     <h3 class="text-sm font-semibold text-slate-200 mb-4">Custom Fields</h3>

--- a/src/app/features/projects/components/project-settings-panel.component.ts
+++ b/src/app/features/projects/components/project-settings-panel.component.ts
@@ -9,6 +9,7 @@ import { ProjectBasicInfoComponent } from './project-basic-info.component';
 import { ProjectDangerZoneComponent } from './project-danger-zone.component';
 import { ProjectGoogleTasksSyncComponent } from './project-google-tasks-sync.component';
 import { ProjectGoogleSheetsSyncComponent } from './project-google-sheets-sync.component';
+import { PointScaleManagerComponent } from './point-scale-manager.component';
 
 /**
  * Project Settings Panel Component
@@ -27,6 +28,7 @@ import { ProjectGoogleSheetsSyncComponent } from './project-google-sheets-sync.c
     ProjectDangerZoneComponent,
     ProjectGoogleTasksSyncComponent,
     ProjectGoogleSheetsSyncComponent,
+    PointScaleManagerComponent,
   ],
   templateUrl: './project-settings-panel.component.html',
   styleUrls: ['./project-settings-panel.component.css'],

--- a/src/app/features/tasks/components/point-value-badge.css
+++ b/src/app/features/tasks/components/point-value-badge.css
@@ -1,0 +1,55 @@
+:host {
+  display: inline-flex;
+  --pv-color: #00d2ff;
+}
+
+.pv-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  color: #fff;
+  background:
+    radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.35), transparent 60%),
+    radial-gradient(circle at 70% 80%, color-mix(in srgb, var(--pv-color) 70%, transparent), transparent 70%),
+    color-mix(in srgb, var(--pv-color) 18%, #0a0f1e);
+  border: 1.5px solid var(--pv-color);
+  box-shadow:
+    0 0 6px color-mix(in srgb, var(--pv-color) 70%, transparent),
+    0 0 14px color-mix(in srgb, var(--pv-color) 55%, transparent),
+    0 0 26px color-mix(in srgb, var(--pv-color) 30%, transparent),
+    inset 0 0 8px color-mix(in srgb, var(--pv-color) 35%, transparent);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--pv-color) 70%, transparent);
+  transition:
+    transform 120ms ease,
+    box-shadow 160ms ease;
+}
+
+.pv-badge:hover {
+  transform: scale(1.05);
+  box-shadow:
+    0 0 8px var(--pv-color),
+    0 0 18px color-mix(in srgb, var(--pv-color) 70%, transparent),
+    0 0 30px color-mix(in srgb, var(--pv-color) 40%, transparent),
+    inset 0 0 10px color-mix(in srgb, var(--pv-color) 45%, transparent);
+}
+
+.pv-badge--pill {
+  width: auto;
+  min-width: 2.5rem;
+  height: 1.75rem;
+  padding: 0 0.65rem;
+  border-radius: 9999px;
+  font-size: 11px;
+}
+
+.pv-badge__text {
+  position: relative;
+  z-index: 1;
+}

--- a/src/app/features/tasks/components/point-value-badge.ts
+++ b/src/app/features/tasks/components/point-value-badge.ts
@@ -1,0 +1,102 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PointScaleConfig, PointValue } from '../../../core/models/domain.model';
+import {
+  computePertEstimate,
+  formatPointValue,
+  pointValueColor,
+} from '../../../core/utils/point-scale.utils';
+
+/**
+ * Circular neon-glow badge that renders a task's point value. The color is
+ * sampled along a cyan → magenta → hot-pink gradient based on the value's
+ * normalized position in the scale's configured range, so heavier tasks
+ * read as hotter than lighter ones at a glance.
+ *
+ * Long labels (PERT triples) fall back to a pill shape; the full label is
+ * available via the native title tooltip.
+ */
+@Component({
+  selector: 'app-point-value-badge',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    @if (config(); as cfg) {
+      @if (value(); as v) {
+        <span
+          class="pv-badge"
+          [class.pv-badge--pill]="isLong()"
+          [style.--pv-color]="color()"
+          [title]="fullLabel()"
+        >
+          <span class="pv-badge__text">{{ displayLabel() }}</span>
+        </span>
+      }
+    }
+  `,
+  styleUrls: ['./point-value-badge.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PointValueBadgeComponent {
+  config = input.required<PointScaleConfig | undefined>();
+  value = input.required<PointValue | undefined>();
+
+  /** Hex/rgb colour resolved from the gradient. Computed once per value. */
+  color = computed<string>(() => {
+    const v = this.value();
+    const c = this.config();
+    if (!v || !c) return '#00d2ff';
+    return pointValueColor(v, c);
+  });
+
+  /** Full label for the title tooltip. */
+  fullLabel = computed<string>(() => {
+    const v = this.value();
+    const c = this.config();
+    if (!v || !c) return '';
+    return formatPointValue(v, c);
+  });
+
+  /**
+   * Compact label shown inside the circle. PERT triples collapse to the
+   * weighted estimate so the badge stays readable; the full "5 ± 1.3h"
+   * remains available in the tooltip and on the detail modal.
+   */
+  displayLabel = computed<string>(() => {
+    const v = this.value();
+    const c = this.config();
+    if (!v || !c) return '';
+    if (v.type === 'numeric_pert') {
+      const est = computePertEstimate(v.optimistic, v.mostLikely, v.pessimistic);
+      const suffix =
+        c.scale === 'time_unit' || c.scale === 'credit_hours' ? this.unitChar(c) : '';
+      return `${this.round(est)}${suffix}`;
+    }
+    return this.fullLabel();
+  });
+
+  /** Falls back to a pill shape when the display label can't fit in a circle. */
+  isLong = computed<boolean>(() => this.displayLabel().length > 4);
+
+  private unitChar(c: PointScaleConfig): string {
+    if (c.scale === 'time_unit') {
+      switch (c.unit) {
+        case 'minutes':
+          return 'm';
+        case 'hours':
+          return 'h';
+        case 'days':
+          return 'd';
+        case 'weeks':
+          return 'w';
+      }
+    }
+    if (c.scale === 'credit_hours') return 'h';
+    return '';
+  }
+
+  private round(n: number): string {
+    const rounded = Math.round(n * 10) / 10;
+    return Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1).replace(/\.0$/, '');
+  }
+}

--- a/src/app/features/tasks/components/task-point-value-input.css
+++ b/src/app/features/tasks/components/task-point-value-input.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/tasks/components/task-point-value-input.css
+++ b/src/app/features/tasks/components/task-point-value-input.css
@@ -1,3 +1,32 @@
 :host {
   display: block;
 }
+
+.ofx-range {
+  appearance: none;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 9999px;
+  outline: none;
+}
+
+.ofx-range::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #fff, #06b6d4);
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 8px rgba(6, 182, 212, 0.6);
+  cursor: pointer;
+}
+
+.ofx-range::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #fff, #06b6d4);
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 8px rgba(6, 182, 212, 0.6);
+  cursor: pointer;
+}

--- a/src/app/features/tasks/components/task-point-value-input.html
+++ b/src/app/features/tasks/components/task-point-value-input.html
@@ -1,0 +1,207 @@
+@if (config(); as cfg) {
+  <div class="space-y-2">
+    <!-- Numeric (single value mode) -->
+    @if (numericConfig(); as n) {
+      @if (!pertSupported()) {
+        <select
+          class="ofx-input text-sm"
+          [ngModel]="numericValue() ?? ''"
+          (ngModelChange)="setNumeric($event)"
+        >
+          <option value="">—</option>
+          @for (v of numericAllowed(); track v) {
+            <option [ngValue]="v">{{ v }}</option>
+          }
+        </select>
+      }
+    }
+
+    <!-- Time-based (single value mode) -->
+    @if (timeConfig(); as t) {
+      @if (!pertSupported()) {
+        @if (t.input_mode === 'preset') {
+          <select
+            class="ofx-input text-sm"
+            [ngModel]="numericValue() ?? ''"
+            (ngModelChange)="setNumeric($event)"
+          >
+            <option value="">—</option>
+            @for (v of t.preset_values || []; track v) {
+              <option [ngValue]="v">{{ v }}{{ unitSuffix() }}</option>
+            }
+          </select>
+        } @else {
+          <div class="flex items-center gap-2">
+            <input
+              type="number"
+              [step]="1 / (10 ** (t.decimal_precision ?? 2))"
+              class="ofx-input text-sm flex-1"
+              [ngModel]="numericValue() ?? ''"
+              (ngModelChange)="setNumeric($event)"
+              placeholder="0"
+            />
+            <span class="text-xs text-slate-400">{{ unitSuffix() }}</span>
+          </div>
+        }
+      }
+    }
+
+    <!-- Credit hours (single value mode) -->
+    @if (creditHoursConfig(); as ch) {
+      @if (!pertSupported()) {
+        @if (ch.input_mode === 'bucket') {
+          <div class="flex flex-wrap gap-1.5">
+            @for (b of creditBuckets; track b) {
+              <button
+                type="button"
+                class="px-2 py-1 text-xs rounded-md border transition-colors"
+                [ngClass]="numericValue() === b
+                  ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
+                  : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
+                (click)="setNumeric(b)"
+              >
+                {{ b }}h
+              </button>
+            }
+          </div>
+        } @else if (ch.input_mode === 'fibonacci') {
+          <div class="flex flex-wrap gap-1.5">
+            @for (b of creditFib; track b) {
+              <button
+                type="button"
+                class="px-2 py-1 text-xs rounded-md border transition-colors"
+                [ngClass]="numericValue() === b
+                  ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
+                  : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
+                (click)="setNumeric(b)"
+              >
+                {{ b }}h
+              </button>
+            }
+          </div>
+        } @else {
+          <div class="flex items-center gap-2">
+            <input
+              type="number"
+              step="0.25"
+              min="0"
+              class="ofx-input text-sm flex-1"
+              [ngModel]="numericValue() ?? ''"
+              (ngModelChange)="setNumeric($event)"
+              placeholder="0"
+            />
+            <span class="text-xs text-slate-400">h</span>
+          </div>
+        }
+      }
+    }
+
+    <!-- PERT mode (numeric / time / credit_hours) -->
+    @if (pertSupported()) {
+      <div class="grid grid-cols-3 gap-2">
+        <label class="text-[10px] text-slate-400 uppercase tracking-wide">
+          Optimistic
+          <input
+            type="number"
+            step="0.5"
+            class="ofx-input text-sm mt-1"
+            [ngModel]="pertValue()?.o ?? ''"
+            (ngModelChange)="setPert('o', $event)"
+          />
+        </label>
+        <label class="text-[10px] text-slate-400 uppercase tracking-wide">
+          Most Likely
+          <input
+            type="number"
+            step="0.5"
+            class="ofx-input text-sm mt-1"
+            [ngModel]="pertValue()?.m ?? ''"
+            (ngModelChange)="setPert('m', $event)"
+          />
+        </label>
+        <label class="text-[10px] text-slate-400 uppercase tracking-wide">
+          Pessimistic
+          <input
+            type="number"
+            step="0.5"
+            class="ofx-input text-sm mt-1"
+            [ngModel]="pertValue()?.p ?? ''"
+            (ngModelChange)="setPert('p', $event)"
+          />
+        </label>
+      </div>
+      @if (pertValue()) {
+        <div class="text-xs text-cyan-400">{{ pertSummary() }}</div>
+      }
+    }
+
+    <!-- T-Shirt -->
+    @if (cfg.scale === 'tshirt') {
+      <div class="flex flex-wrap gap-1.5">
+        @for (s of tshirtSizes; track s) {
+          <button
+            type="button"
+            class="px-2.5 py-1 text-xs rounded-md border font-semibold transition-colors"
+            [ngClass]="tshirtValue() === s
+              ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
+              : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
+            (click)="setTShirt(s)"
+          >
+            {{ s }}
+          </button>
+        }
+      </div>
+    }
+
+    <!-- Animal -->
+    @if (cfg.scale === 'animal') {
+      <div class="flex flex-wrap gap-1.5">
+        @for (a of animalSizes; track a) {
+          <button
+            type="button"
+            class="px-2 py-1 text-xs rounded-md border transition-colors flex items-center gap-1.5"
+            [ngClass]="animalValue() === a
+              ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
+              : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
+            (click)="setAnimal(a)"
+          >
+            <span>{{ animalIcons[a] }}</span>
+            <span>{{ a }}</span>
+          </button>
+        }
+      </div>
+    }
+
+    <!-- Multi-factor -->
+    @if (multiFactorConfig(); as mf) {
+      <div class="space-y-2">
+        @for (f of mf.factors; track f.id) {
+          <label class="block text-[10px] text-slate-400 uppercase tracking-wide">
+            {{ f.name }}
+            <select
+              class="ofx-input text-sm mt-1"
+              [ngModel]="$any(multiFactorValue()[f.id])"
+              (ngModelChange)="setFactor(f.id, $event)"
+            >
+              <option value="">—</option>
+              @for (v of f.scale; track v) {
+                <option [ngValue]="v">{{ v }}</option>
+              }
+            </select>
+          </label>
+        }
+      </div>
+    }
+
+    <!-- Clear button -->
+    @if (value()) {
+      <button
+        type="button"
+        class="text-[11px] text-slate-500 hover:text-slate-200"
+        (click)="clear()"
+      >
+        Clear value
+      </button>
+    }
+  </div>
+}

--- a/src/app/features/tasks/components/task-point-value-input.html
+++ b/src/app/features/tasks/components/task-point-value-input.html
@@ -1,194 +1,162 @@
 @if (config(); as cfg) {
-  <div class="space-y-2">
-    <!-- Numeric (single value mode) -->
-    @if (numericConfig(); as n) {
-      @if (!pertSupported()) {
-        <select
-          class="ofx-input text-sm"
+  <div class="space-y-3">
+    <!-- Numeric / time-preset / credit-hours discrete scales (single value) -->
+    @if (!pertSupported() && hasDiscreteValues()) {
+      <app-snap-slider
+        [values]="sliderValues()"
+        [labels]="sliderLabels()"
+        [value]="numericValue()"
+        ariaLabel="Effort points"
+        (valueChange)="setNumeric($event)"
+      ></app-snap-slider>
+    }
+
+    <!-- Continuous time-freeform / credit-hours direct entry -->
+    @if (!pertSupported() && !hasDiscreteValues() && continuousRange(); as range) {
+      <div class="flex items-center gap-3">
+        <input
+          type="range"
+          class="ofx-range flex-1"
+          [min]="range.min"
+          [max]="range.max"
+          [step]="range.step"
+          [ngModel]="numericValue() ?? range.min"
+          (ngModelChange)="setNumeric($event)"
+        />
+        <input
+          type="number"
+          class="ofx-input text-sm w-20"
+          [min]="range.min"
+          [max]="range.max"
+          [step]="range.step"
           [ngModel]="numericValue() ?? ''"
           (ngModelChange)="setNumeric($event)"
-        >
-          <option value="">—</option>
-          @for (v of numericAllowed(); track v) {
-            <option [ngValue]="v">{{ v }}</option>
-          }
-        </select>
-      }
-    }
-
-    <!-- Time-based (single value mode) -->
-    @if (timeConfig(); as t) {
-      @if (!pertSupported()) {
-        @if (t.input_mode === 'preset') {
-          <select
-            class="ofx-input text-sm"
-            [ngModel]="numericValue() ?? ''"
-            (ngModelChange)="setNumeric($event)"
-          >
-            <option value="">—</option>
-            @for (v of t.preset_values || []; track v) {
-              <option [ngValue]="v">{{ v }}{{ unitSuffix() }}</option>
-            }
-          </select>
-        } @else {
-          <div class="flex items-center gap-2">
-            <input
-              type="number"
-              [step]="1 / (10 ** (t.decimal_precision ?? 2))"
-              class="ofx-input text-sm flex-1"
-              [ngModel]="numericValue() ?? ''"
-              (ngModelChange)="setNumeric($event)"
-              placeholder="0"
-            />
-            <span class="text-xs text-slate-400">{{ unitSuffix() }}</span>
-          </div>
-        }
-      }
-    }
-
-    <!-- Credit hours (single value mode) -->
-    @if (creditHoursConfig(); as ch) {
-      @if (!pertSupported()) {
-        @if (ch.input_mode === 'bucket') {
-          <div class="flex flex-wrap gap-1.5">
-            @for (b of creditBuckets; track b) {
-              <button
-                type="button"
-                class="px-2 py-1 text-xs rounded-md border transition-colors"
-                [ngClass]="numericValue() === b
-                  ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
-                  : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
-                (click)="setNumeric(b)"
-              >
-                {{ b }}h
-              </button>
-            }
-          </div>
-        } @else if (ch.input_mode === 'fibonacci') {
-          <div class="flex flex-wrap gap-1.5">
-            @for (b of creditFib; track b) {
-              <button
-                type="button"
-                class="px-2 py-1 text-xs rounded-md border transition-colors"
-                [ngClass]="numericValue() === b
-                  ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
-                  : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
-                (click)="setNumeric(b)"
-              >
-                {{ b }}h
-              </button>
-            }
-          </div>
-        } @else {
-          <div class="flex items-center gap-2">
-            <input
-              type="number"
-              step="0.25"
-              min="0"
-              class="ofx-input text-sm flex-1"
-              [ngModel]="numericValue() ?? ''"
-              (ngModelChange)="setNumeric($event)"
-              placeholder="0"
-            />
-            <span class="text-xs text-slate-400">h</span>
-          </div>
-        }
-      }
-    }
-
-    <!-- PERT mode (numeric / time / credit_hours) -->
-    @if (pertSupported()) {
-      <div class="grid grid-cols-3 gap-2">
-        <label class="text-[10px] text-slate-400 uppercase tracking-wide">
-          Optimistic
-          <input
-            type="number"
-            step="0.5"
-            class="ofx-input text-sm mt-1"
-            [ngModel]="pertValue()?.o ?? ''"
-            (ngModelChange)="setPert('o', $event)"
-          />
-        </label>
-        <label class="text-[10px] text-slate-400 uppercase tracking-wide">
-          Most Likely
-          <input
-            type="number"
-            step="0.5"
-            class="ofx-input text-sm mt-1"
-            [ngModel]="pertValue()?.m ?? ''"
-            (ngModelChange)="setPert('m', $event)"
-          />
-        </label>
-        <label class="text-[10px] text-slate-400 uppercase tracking-wide">
-          Pessimistic
-          <input
-            type="number"
-            step="0.5"
-            class="ofx-input text-sm mt-1"
-            [ngModel]="pertValue()?.p ?? ''"
-            (ngModelChange)="setPert('p', $event)"
-          />
-        </label>
+        />
+        <span class="text-xs text-slate-400">{{ unitSuffix() }}</span>
       </div>
-      @if (pertValue()) {
-        <div class="text-xs text-cyan-400">{{ pertSummary() }}</div>
-      }
+    }
+
+    <!-- PERT mode: three sliders for the same scale -->
+    @if (pertSupported()) {
+      <div class="space-y-2">
+        @if (hasDiscreteValues()) {
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <div class="text-[10px] text-slate-400 uppercase tracking-wide mb-1">Optimistic</div>
+              <app-snap-slider
+                [values]="sliderValues()"
+                [labels]="sliderLabels()"
+                [value]="pertValue()?.o ?? null"
+                accent="#10b981"
+                ariaLabel="Optimistic"
+                (valueChange)="setPert('o', $event)"
+              ></app-snap-slider>
+            </div>
+            <div>
+              <div class="text-[10px] text-slate-400 uppercase tracking-wide mb-1">Most likely</div>
+              <app-snap-slider
+                [values]="sliderValues()"
+                [labels]="sliderLabels()"
+                [value]="pertValue()?.m ?? null"
+                accent="#06b6d4"
+                ariaLabel="Most likely"
+                (valueChange)="setPert('m', $event)"
+              ></app-snap-slider>
+            </div>
+            <div>
+              <div class="text-[10px] text-slate-400 uppercase tracking-wide mb-1">Pessimistic</div>
+              <app-snap-slider
+                [values]="sliderValues()"
+                [labels]="sliderLabels()"
+                [value]="pertValue()?.p ?? null"
+                accent="#f43f5e"
+                ariaLabel="Pessimistic"
+                (valueChange)="setPert('p', $event)"
+              ></app-snap-slider>
+            </div>
+          </div>
+        } @else if (continuousRange(); as range) {
+          <div class="space-y-2">
+            <label class="block text-[10px] text-slate-400 uppercase tracking-wide">
+              Optimistic
+              <input
+                type="range"
+                class="ofx-range mt-1 w-full"
+                [min]="range.min"
+                [max]="range.max"
+                [step]="range.step"
+                [ngModel]="pertValue()?.o ?? range.min"
+                (ngModelChange)="setPert('o', $event)"
+              />
+            </label>
+            <label class="block text-[10px] text-slate-400 uppercase tracking-wide">
+              Most likely
+              <input
+                type="range"
+                class="ofx-range mt-1 w-full"
+                [min]="range.min"
+                [max]="range.max"
+                [step]="range.step"
+                [ngModel]="pertValue()?.m ?? range.min"
+                (ngModelChange)="setPert('m', $event)"
+              />
+            </label>
+            <label class="block text-[10px] text-slate-400 uppercase tracking-wide">
+              Pessimistic
+              <input
+                type="range"
+                class="ofx-range mt-1 w-full"
+                [min]="range.min"
+                [max]="range.max"
+                [step]="range.step"
+                [ngModel]="pertValue()?.p ?? range.min"
+                (ngModelChange)="setPert('p', $event)"
+              />
+            </label>
+          </div>
+        }
+        @if (pertValue()) {
+          <div class="text-xs text-cyan-400">{{ pertSummary() }}</div>
+        }
+      </div>
     }
 
     <!-- T-Shirt -->
     @if (cfg.scale === 'tshirt') {
-      <div class="flex flex-wrap gap-1.5">
-        @for (s of tshirtSizes; track s) {
-          <button
-            type="button"
-            class="px-2.5 py-1 text-xs rounded-md border font-semibold transition-colors"
-            [ngClass]="tshirtValue() === s
-              ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
-              : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
-            (click)="setTShirt(s)"
-          >
-            {{ s }}
-          </button>
-        }
-      </div>
+      <app-snap-slider
+        [values]="tshirtSliderValues()"
+        [labels]="$any(tshirtSizes)"
+        [value]="tshirtSliderActive()"
+        ariaLabel="T-shirt size"
+        (valueChange)="setTShirtFromSlider($event)"
+      ></app-snap-slider>
     }
 
     <!-- Animal -->
     @if (cfg.scale === 'animal') {
-      <div class="flex flex-wrap gap-1.5">
-        @for (a of animalSizes; track a) {
-          <button
-            type="button"
-            class="px-2 py-1 text-xs rounded-md border transition-colors flex items-center gap-1.5"
-            [ngClass]="animalValue() === a
-              ? 'border-cyan-500 bg-cyan-500/15 text-cyan-300'
-              : 'border-white/10 bg-slate-800/60 text-slate-300 hover:bg-slate-700/60'"
-            (click)="setAnimal(a)"
-          >
-            <span>{{ animalIcons[a] }}</span>
-            <span>{{ a }}</span>
-          </button>
-        }
-      </div>
+      <app-snap-slider
+        [values]="animalSliderValues()"
+        [labels]="animalSliderLabels()"
+        [value]="animalSliderActive()"
+        accent="#a564ff"
+        ariaLabel="Animal size"
+        (valueChange)="setAnimalFromSlider($event)"
+      ></app-snap-slider>
     }
 
-    <!-- Multi-factor -->
+    <!-- Multi-factor: one slider per factor -->
     @if (multiFactorConfig(); as mf) {
-      <div class="space-y-2">
+      <div class="space-y-3">
         @for (f of mf.factors; track f.id) {
-          <label class="block text-[10px] text-slate-400 uppercase tracking-wide">
-            {{ f.name }}
-            <select
-              class="ofx-input text-sm mt-1"
-              [ngModel]="$any(multiFactorValue()[f.id])"
-              (ngModelChange)="setFactor(f.id, $event)"
-            >
-              <option value="">—</option>
-              @for (v of f.scale; track v) {
-                <option [ngValue]="v">{{ v }}</option>
-              }
-            </select>
-          </label>
+          <div>
+            <div class="text-[10px] text-slate-400 uppercase tracking-wide mb-1">{{ f.name }}</div>
+            <app-snap-slider
+              [values]="f.scale"
+              [value]="$any(multiFactorValue()[f.id]) ?? null"
+              [ariaLabel]="f.name"
+              (valueChange)="setFactor(f.id, $event)"
+            ></app-snap-slider>
+          </div>
         }
       </div>
     }

--- a/src/app/features/tasks/components/task-point-value-input.ts
+++ b/src/app/features/tasks/components/task-point-value-input.ts
@@ -1,0 +1,188 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  AnimalSize,
+  ANIMAL_ICONS,
+  ANIMAL_SIZES,
+  CreditHoursScaleConfig,
+  CREDIT_HOURS_BUCKETS,
+  CREDIT_HOURS_FIB,
+  MultiFactorScaleConfig,
+  NumericScaleConfig,
+  PointScaleConfig,
+  PointValue,
+  TimeScaleConfig,
+  TShirtSize,
+  TSHIRT_SIZES,
+} from '../../../core/models/domain.model';
+import {
+  computePertEstimate,
+  computePertStdDev,
+  formatPointValue,
+  getNumericAllowedValues,
+  timeUnitSuffix,
+} from '../../../core/utils/point-scale.utils';
+
+@Component({
+  selector: 'app-task-point-value-input',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './task-point-value-input.html',
+  styleUrls: ['./task-point-value-input.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TaskPointValueInputComponent {
+  config = input.required<PointScaleConfig | undefined>();
+  value = input<PointValue | undefined>(undefined);
+
+  valueChange = output<PointValue | undefined>();
+
+  // Constants exposed to template
+  readonly tshirtSizes = TSHIRT_SIZES;
+  readonly animalSizes = ANIMAL_SIZES;
+  readonly animalIcons = ANIMAL_ICONS;
+  readonly creditBuckets = CREDIT_HOURS_BUCKETS;
+  readonly creditFib = CREDIT_HOURS_FIB;
+  readonly formatPointValue = formatPointValue;
+
+  // --- Type-narrowed config accessors ----------------------------------------
+  numericConfig = computed<NumericScaleConfig | null>(() => {
+    const c = this.config();
+    return c?.scale === 'numeric_configurable' ? c : null;
+  });
+  timeConfig = computed<TimeScaleConfig | null>(() => {
+    const c = this.config();
+    return c?.scale === 'time_unit' ? c : null;
+  });
+  multiFactorConfig = computed<MultiFactorScaleConfig | null>(() => {
+    const c = this.config();
+    return c?.scale === 'custom_multi_factor' ? c : null;
+  });
+  creditHoursConfig = computed<CreditHoursScaleConfig | null>(() => {
+    const c = this.config();
+    return c?.scale === 'credit_hours' ? c : null;
+  });
+
+  // --- Type-narrowed value accessors -----------------------------------------
+  numericValue = computed<number | null>(() => {
+    const v = this.value();
+    return v?.type === 'numeric' ? v.value : null;
+  });
+  pertValue = computed<{ o: number; m: number; p: number } | null>(() => {
+    const v = this.value();
+    return v?.type === 'numeric_pert'
+      ? { o: v.optimistic, m: v.mostLikely, p: v.pessimistic }
+      : null;
+  });
+  tshirtValue = computed<TShirtSize | null>(() => {
+    const v = this.value();
+    return v?.type === 'tshirt' ? v.value : null;
+  });
+  animalValue = computed<AnimalSize | null>(() => {
+    const v = this.value();
+    return v?.type === 'animal' ? v.value : null;
+  });
+  multiFactorValue = computed<Record<string, number>>(() => {
+    const v = this.value();
+    return v?.type === 'multi_factor' ? v.values : {};
+  });
+
+  // --- Derived display -------------------------------------------------------
+  numericAllowed = computed<number[]>(() => {
+    const c = this.numericConfig();
+    return c ? getNumericAllowedValues(c) : [];
+  });
+
+  pertSupported = computed<boolean>(() => {
+    const c = this.config();
+    return (
+      (c?.scale === 'numeric_configurable' ||
+        c?.scale === 'time_unit' ||
+        c?.scale === 'credit_hours') &&
+      !!c.pert_mode_enabled
+    );
+  });
+
+  pertSummary = computed<string>(() => {
+    const v = this.pertValue();
+    const c = this.config();
+    if (!v || !c) return '';
+    const est = computePertEstimate(v.o, v.m, v.p);
+    const sd = computePertStdDev(v.o, v.m, v.p);
+    const suffix =
+      c.scale === 'time_unit'
+        ? timeUnitSuffix(c.unit)
+        : c.scale === 'credit_hours'
+          ? 'h'
+          : '';
+    return `Weighted ${this.round(est)} ± ${this.round(sd)}${suffix}`;
+  });
+
+  unitSuffix = computed<string>(() => {
+    const c = this.config();
+    if (!c) return '';
+    if (c.scale === 'time_unit') return timeUnitSuffix(c.unit);
+    if (c.scale === 'credit_hours') return 'h';
+    return '';
+  });
+
+  // --- Mutation handlers -----------------------------------------------------
+  setNumeric(raw: string | number): void {
+    if (raw === '' || raw === null || raw === undefined) {
+      this.valueChange.emit(undefined);
+      return;
+    }
+    const n = typeof raw === 'number' ? raw : parseFloat(raw);
+    if (!isFinite(n)) {
+      this.valueChange.emit(undefined);
+      return;
+    }
+    this.valueChange.emit({ type: 'numeric', value: n });
+  }
+
+  setPert(field: 'o' | 'm' | 'p', raw: string | number): void {
+    const v = this.pertValue() ?? { o: 0, m: 0, p: 0 };
+    const n = typeof raw === 'number' ? raw : parseFloat(raw);
+    if (!isFinite(n)) return;
+    const next = { ...v, [field]: n };
+    this.valueChange.emit({
+      type: 'numeric_pert',
+      optimistic: next.o,
+      mostLikely: next.m,
+      pessimistic: next.p,
+    });
+  }
+
+  setTShirt(size: TShirtSize): void {
+    if (this.tshirtValue() === size) {
+      this.valueChange.emit(undefined);
+    } else {
+      this.valueChange.emit({ type: 'tshirt', value: size });
+    }
+  }
+
+  setAnimal(size: AnimalSize): void {
+    if (this.animalValue() === size) {
+      this.valueChange.emit(undefined);
+    } else {
+      this.valueChange.emit({ type: 'animal', value: size });
+    }
+  }
+
+  setFactor(factorId: string, raw: string | number): void {
+    const n = typeof raw === 'number' ? raw : parseFloat(raw);
+    if (!isFinite(n)) return;
+    const current = { ...this.multiFactorValue(), [factorId]: n };
+    this.valueChange.emit({ type: 'multi_factor', values: current });
+  }
+
+  clear(): void {
+    this.valueChange.emit(undefined);
+  }
+
+  private round(n: number): string {
+    const rounded = Math.round(n * 100) / 100;
+    return Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(2).replace(/\.?0+$/, '');
+  }
+}

--- a/src/app/features/tasks/components/task-point-value-input.ts
+++ b/src/app/features/tasks/components/task-point-value-input.ts
@@ -8,6 +8,8 @@ import {
   CreditHoursScaleConfig,
   CREDIT_HOURS_BUCKETS,
   CREDIT_HOURS_FIB,
+  DEFAULT_ANIMAL_MAPPING,
+  DEFAULT_TSHIRT_MAPPING,
   MultiFactorScaleConfig,
   NumericScaleConfig,
   PointScaleConfig,
@@ -23,11 +25,12 @@ import {
   getNumericAllowedValues,
   timeUnitSuffix,
 } from '../../../core/utils/point-scale.utils';
+import { SnapSliderComponent } from '../../../shared/components/snap-slider/snap-slider.component';
 
 @Component({
   selector: 'app-task-point-value-input',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, SnapSliderComponent],
   templateUrl: './task-point-value-input.html',
   styleUrls: ['./task-point-value-input.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -126,6 +129,111 @@ export class TaskPointValueInputComponent {
     if (c.scale === 'credit_hours') return 'h';
     return '';
   });
+
+  // --- Slider source data ----------------------------------------------------
+  // Each scale projects to (values[], labels?[]) so the same slider component
+  // can drive every discrete picker.
+
+  /** Allowed numeric values, used by the numeric and time-preset sliders. */
+  sliderValues = computed<number[]>(() => {
+    const c = this.config();
+    if (!c) return [];
+    if (c.scale === 'numeric_configurable') return getNumericAllowedValues(c);
+    if (c.scale === 'time_unit') {
+      return c.input_mode === 'preset' ? c.preset_values || [] : [];
+    }
+    if (c.scale === 'credit_hours') {
+      if (c.input_mode === 'bucket') return [...CREDIT_HOURS_BUCKETS];
+      if (c.input_mode === 'fibonacci') return [...CREDIT_HOURS_FIB];
+      return [];
+    }
+    return [];
+  });
+
+  /** Optional labels for the slider — only the time-unit slider adds a suffix. */
+  sliderLabels = computed<string[] | undefined>(() => {
+    const c = this.config();
+    if (!c) return undefined;
+    if (c.scale === 'time_unit' && c.input_mode === 'preset') {
+      return (c.preset_values || []).map((v) => `${v}${timeUnitSuffix(c.unit)}`);
+    }
+    if (c.scale === 'credit_hours' && c.input_mode !== 'direct') {
+      return this.sliderValues().map((v) => `${v}h`);
+    }
+    return undefined;
+  });
+
+  /**
+   * Whether the active numeric-like scale picks values from a discrete set
+   * (so a snap-slider makes sense). Free-form time and direct-entry credit
+   * hours fall back to a continuous range input.
+   */
+  hasDiscreteValues = computed<boolean>(() => this.sliderValues().length > 0);
+
+  /** Min/max for the continuous range input (free-form time / direct credit hours). */
+  continuousRange = computed<{ min: number; max: number; step: number } | null>(() => {
+    const c = this.config();
+    if (!c) return null;
+    if (c.scale === 'time_unit' && c.input_mode === 'freeform') {
+      const precision = c.decimal_precision ?? 2;
+      const step = Math.pow(10, -precision);
+      // Time scales don't carry an explicit range; pick sensible defaults
+      // per unit so the slider has stops to drag between.
+      const maxByUnit = { minutes: 480, hours: 40, days: 30, weeks: 12 };
+      return { min: 0, max: maxByUnit[c.unit], step };
+    }
+    if (c.scale === 'credit_hours' && c.input_mode === 'direct') {
+      return { min: 0, max: c.total_work_hours || 100, step: 0.25 };
+    }
+    return null;
+  });
+
+  /** T-shirt slider values map to the configured numeric mapping. */
+  tshirtSliderValues = computed<number[]>(() => {
+    const c = this.config();
+    if (c?.scale !== 'tshirt') return [];
+    const mapping = c.mapping || DEFAULT_TSHIRT_MAPPING;
+    return TSHIRT_SIZES.map((s) => mapping[s]);
+  });
+
+  tshirtSliderActive = computed<number | null>(() => {
+    const c = this.config();
+    const v = this.tshirtValue();
+    if (c?.scale !== 'tshirt' || !v) return null;
+    return (c.mapping || DEFAULT_TSHIRT_MAPPING)[v];
+  });
+
+  animalSliderValues = computed<number[]>(() => {
+    const c = this.config();
+    if (c?.scale !== 'animal') return [];
+    const mapping = c.mapping || DEFAULT_ANIMAL_MAPPING;
+    return ANIMAL_SIZES.map((s) => mapping[s]);
+  });
+
+  animalSliderActive = computed<number | null>(() => {
+    const c = this.config();
+    const v = this.animalValue();
+    if (c?.scale !== 'animal' || !v) return null;
+    return (c.mapping || DEFAULT_ANIMAL_MAPPING)[v];
+  });
+
+  animalSliderLabels = computed<string[]>(() => ANIMAL_SIZES.map((s) => `${ANIMAL_ICONS[s]} ${s}`));
+
+  setTShirtFromSlider(mapped: number): void {
+    const c = this.config();
+    if (c?.scale !== 'tshirt') return;
+    const mapping = c.mapping || DEFAULT_TSHIRT_MAPPING;
+    const match = TSHIRT_SIZES.find((s) => mapping[s] === mapped);
+    if (match) this.valueChange.emit({ type: 'tshirt', value: match });
+  }
+
+  setAnimalFromSlider(mapped: number): void {
+    const c = this.config();
+    if (c?.scale !== 'animal') return;
+    const mapping = c.mapping || DEFAULT_ANIMAL_MAPPING;
+    const match = ANIMAL_SIZES.find((s) => mapping[s] === mapped);
+    if (match) this.valueChange.emit({ type: 'animal', value: match });
+  }
 
   // --- Mutation handlers -----------------------------------------------------
   setNumeric(raw: string | number): void {

--- a/src/app/features/tasks/components/task-point-value-input.ts
+++ b/src/app/features/tasks/components/task-point-value-input.ts
@@ -6,8 +6,6 @@ import {
   ANIMAL_ICONS,
   ANIMAL_SIZES,
   CreditHoursScaleConfig,
-  CREDIT_HOURS_BUCKETS,
-  CREDIT_HOURS_FIB,
   DEFAULT_ANIMAL_MAPPING,
   DEFAULT_TSHIRT_MAPPING,
   MultiFactorScaleConfig,
@@ -22,6 +20,7 @@ import {
   computePertEstimate,
   computePertStdDev,
   formatPointValue,
+  getCreditHoursAllowedValues,
   getNumericAllowedValues,
   timeUnitSuffix,
 } from '../../../core/utils/point-scale.utils';
@@ -45,8 +44,6 @@ export class TaskPointValueInputComponent {
   readonly tshirtSizes = TSHIRT_SIZES;
   readonly animalSizes = ANIMAL_SIZES;
   readonly animalIcons = ANIMAL_ICONS;
-  readonly creditBuckets = CREDIT_HOURS_BUCKETS;
-  readonly creditFib = CREDIT_HOURS_FIB;
   readonly formatPointValue = formatPointValue;
 
   // --- Type-narrowed config accessors ----------------------------------------
@@ -143,9 +140,7 @@ export class TaskPointValueInputComponent {
       return c.input_mode === 'preset' ? c.preset_values || [] : [];
     }
     if (c.scale === 'credit_hours') {
-      if (c.input_mode === 'bucket') return [...CREDIT_HOURS_BUCKETS];
-      if (c.input_mode === 'fibonacci') return [...CREDIT_HOURS_FIB];
-      return [];
+      return getCreditHoursAllowedValues(c);
     }
     return [];
   });

--- a/src/app/features/tasks/task-create-modal.component.html
+++ b/src/app/features/tasks/task-create-modal.component.html
@@ -67,6 +67,18 @@
         (fieldUpdated)="updateCustomField($event.fieldId, $event.value)"
       ></app-task-custom-fields-form>
 
+      <!-- Point Value -->
+      @if (project()?.pointScaleConfig) {
+        <div>
+          <label class="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-2">Effort / Points</label>
+          <app-task-point-value-input
+            [config]="project()?.pointScaleConfig"
+            [value]="pointValue()"
+            (valueChange)="pointValue.set($event)"
+          ></app-task-point-value-input>
+        </div>
+      }
+
       <!-- Tags -->
       <div>
         <label class="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-2">Tags</label>

--- a/src/app/features/tasks/task-create-modal.component.ts
+++ b/src/app/features/tasks/task-create-modal.component.ts
@@ -22,6 +22,7 @@ import {
   Section,
   Subtask,
   CustomFieldDefinition,
+  PointValue,
 } from '../../core/models/domain.model';
 import { toSignal, toObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { switchMap, of, map, startWith, debounceTime } from 'rxjs';
@@ -42,6 +43,7 @@ import { TaskFormFieldsComponent } from './components/task-form-fields';
 import { TaskAiSuggestionsComponent } from './components/task-ai-suggestions';
 import { TaskCustomFieldsFormComponent } from './components/task-custom-fields-form';
 import { TaskTagsComponent } from './components/task-tags';
+import { TaskPointValueInputComponent } from './components/task-point-value-input';
 
 @Component({
   selector: 'app-task-create-modal',
@@ -53,6 +55,7 @@ import { TaskTagsComponent } from './components/task-tags';
     TaskAiSuggestionsComponent,
     TaskCustomFieldsFormComponent,
     TaskTagsComponent,
+    TaskPointValueInputComponent,
   ],
   templateUrl: './task-create-modal.component.html',
   styleUrls: ['./task-create-modal.component.css'],
@@ -148,6 +151,7 @@ export class TaskCreateModalComponent {
   customFieldValues = signal<Record<string, any>>({});
   customFieldErrors = signal<Record<string, string>>({});
   selectedTags = signal<Set<string>>(new Set());
+  pointValue = signal<PointValue | undefined>(undefined);
 
   priorityOptions: SelectOption[] = [
     { value: 'low', label: 'Low', colorClass: 'bg-emerald-400 text-emerald-400' },
@@ -380,6 +384,7 @@ export class TaskCreateModalComponent {
         dueDate: dueDate as any,
         tags,
         customFieldValues: this.customFieldValues(),
+        pointValue: this.pointValue(),
         subtasks: this.aiSubtasks().length > 0 ? this.aiSubtasks() : undefined,
       };
 

--- a/src/app/features/tasks/task-detail-modal.component.html
+++ b/src/app/features/tasks/task-detail-modal.component.html
@@ -65,8 +65,18 @@
         />
       </div>
 
-      <!-- Subtasks -->
-      <!-- Subtasks -->
+      <!-- Point Value -->
+      @if (project()?.pointScaleConfig) {
+        <div class="mb-6">
+          <label class="block text-xs font-semibold text-slate-500 uppercase tracking-widest mb-2">Effort / Points</label>
+          <app-task-point-value-input
+            [config]="project()?.pointScaleConfig"
+            [value]="pointValue()"
+            (valueChange)="onPointValueChange($event)"
+          ></app-task-point-value-input>
+        </div>
+      }
+
       <app-task-subtasks
         [task]="task()"
         [project]="project() || null"

--- a/src/app/features/tasks/task-detail-modal.component.ts
+++ b/src/app/features/tasks/task-detail-modal.component.ts
@@ -18,7 +18,7 @@ import { Contact } from '../../core/models/contact.model';
 
 import { CustomFieldService } from '../../core/services/custom-field.service';
 import { TaskDependencyService } from '../../core/services/task-dependency.service';
-import { Task, Project, CustomFieldDefinition } from '../../core/models/domain.model';
+import { Task, Project, CustomFieldDefinition, PointValue } from '../../core/models/domain.model';
 import { UserGroupMember } from '../../core/models/user-group.model';
 import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 import { switchMap, of, map, BehaviorSubject, debounceTime, firstValueFrom } from 'rxjs';
@@ -38,6 +38,7 @@ import { TaskFieldsSidebarComponent } from './components/task-fields-sidebar';
 import { TaskSubtasksComponent } from './components/task-subtasks';
 import { TaskTagsComponent } from './components/task-tags';
 import { TaskAiActionsComponent } from './components/task-ai-actions';
+import { TaskPointValueInputComponent } from './components/task-point-value-input';
 
 @Component({
   selector: 'app-task-detail-modal',
@@ -53,6 +54,7 @@ import { TaskAiActionsComponent } from './components/task-ai-actions';
     TaskSubtasksComponent,
     TaskTagsComponent,
     TaskAiActionsComponent,
+    TaskPointValueInputComponent,
   ],
   templateUrl: './task-detail-modal.component.html',
   styleUrls: ['./task-detail-modal.component.css'],
@@ -174,6 +176,9 @@ export class TaskDetailModalComponent {
 
   customFieldValues = signal<Record<string, any>>({});
 
+  // Point value
+  pointValue = signal<PointValue | undefined>(undefined);
+
   // Tags
   selectedTags = signal<Set<string>>(new Set());
 
@@ -250,6 +255,9 @@ export class TaskDetailModalComponent {
 
         // Load custom fields
         this.customFieldValues.set(task.customFieldValues || {});
+
+        // Load point value
+        this.pointValue.set(task.pointValue);
 
         // Initialize selected tags
         this.selectedTags.set(new Set(task.tags || []));
@@ -392,6 +400,12 @@ export class TaskDetailModalComponent {
     this.autoSave();
   }
 
+  onPointValueChange(value: PointValue | undefined): void {
+    this.pointValue.set(value);
+    this.form.markAsDirty();
+    this.autoSave();
+  }
+
   async autoSave() {
     const task = this.task();
     const project = this.project();
@@ -420,6 +434,7 @@ export class TaskDetailModalComponent {
       priority: val.priority as Task['priority'],
       sectionId: val.sectionId || undefined,
       customFieldValues: this.customFieldValues(),
+      pointValue: this.pointValue(),
     };
 
     // Add startDate to updates (extending Task type for this)

--- a/src/app/features/tasks/task-detail-modal.component.ts
+++ b/src/app/features/tasks/task-detail-modal.component.ts
@@ -402,6 +402,19 @@ export class TaskDetailModalComponent {
 
   onPointValueChange(value: PointValue | undefined): void {
     this.pointValue.set(value);
+    if (value === undefined) {
+      // `updateTask` strips undefined fields before writing, so a plain
+      // autosave never removes an existing `pointValue` from Firestore.
+      // Use the dedicated delete path so the cleared state actually persists.
+      const task = this.task();
+      if (task?.id) {
+        this.taskService.clearPointValue(task.id).then(
+          () => this.updated.emit({ ...task, pointValue: undefined } as Task),
+          (err) => console.error('Failed to clear point value', err),
+        );
+      }
+      return;
+    }
     this.form.markAsDirty();
     this.autoSave();
   }

--- a/src/app/features/tasks/task-list-view.component.html
+++ b/src/app/features/tasks/task-list-view.component.html
@@ -256,6 +256,10 @@
           }}</span>
         </div>
 
+        @if (project()?.pointScaleConfig) {
+          <div class="text-slate-500">Points</div>
+        }
+
         @for (field of projectCustomFields(); track field.id) {
           <div class="text-slate-500 truncate" [title]="field.name">
             {{ field.name }}
@@ -466,6 +470,19 @@
                   {{ task.status.replace('-', ' ') }}
                 </span>
               </div>
+
+              <!-- Point Value -->
+              @if (project()?.pointScaleConfig) {
+                <div>
+                  @if (task.pointValue) {
+                    <span class="text-[11px] font-semibold px-2 py-0.5 rounded border border-cyan-500/30 bg-cyan-500/10 text-cyan-300">
+                      {{ formatPointValue(task.pointValue, project()?.pointScaleConfig) }}
+                    </span>
+                  } @else {
+                    <span class="text-xs text-slate-600">—</span>
+                  }
+                </div>
+              }
 
               <!-- Custom Fields -->
               @for (field of projectCustomFields(); track field.id) {

--- a/src/app/features/tasks/task-list-view.component.html
+++ b/src/app/features/tasks/task-list-view.component.html
@@ -473,11 +473,12 @@
 
               <!-- Point Value -->
               @if (project()?.pointScaleConfig) {
-                <div>
+                <div class="flex items-center justify-center">
                   @if (task.pointValue) {
-                    <span class="text-[11px] font-semibold px-2 py-0.5 rounded border border-cyan-500/30 bg-cyan-500/10 text-cyan-300">
-                      {{ formatPointValue(task.pointValue, project()?.pointScaleConfig) }}
-                    </span>
+                    <app-point-value-badge
+                      [config]="project()?.pointScaleConfig"
+                      [value]="task.pointValue"
+                    ></app-point-value-badge>
                   } @else {
                     <span class="text-xs text-slate-600">—</span>
                   }

--- a/src/app/features/tasks/task-list-view.component.ts
+++ b/src/app/features/tasks/task-list-view.component.ts
@@ -18,6 +18,7 @@ import { switchMap, of } from 'rxjs';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { MarkdownPipe, MarkdownPlainPipe } from '../../shared/pipes/markdown.pipe';
 import { formatPointValue } from '../../core/utils/point-scale.utils';
+import { PointValueBadgeComponent } from './components/point-value-badge';
 
 export interface TaskListViewNode extends Task {
   _depth: number;
@@ -26,7 +27,14 @@ export interface TaskListViewNode extends Task {
 @Component({
   selector: 'app-task-list-view',
   standalone: true,
-  imports: [CommonModule, FormsModule, DragDropModule, MarkdownPipe, MarkdownPlainPipe],
+  imports: [
+    CommonModule,
+    FormsModule,
+    DragDropModule,
+    MarkdownPipe,
+    MarkdownPlainPipe,
+    PointValueBadgeComponent,
+  ],
   templateUrl: './task-list-view.component.html',
   styleUrls: ['./task-list-view.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/tasks/task-list-view.component.ts
+++ b/src/app/features/tasks/task-list-view.component.ts
@@ -17,6 +17,7 @@ import { toSignal, toObservable } from '@angular/core/rxjs-interop';
 import { switchMap, of } from 'rxjs';
 import { CdkDragDrop, DragDropModule } from '@angular/cdk/drag-drop';
 import { MarkdownPipe, MarkdownPlainPipe } from '../../shared/pipes/markdown.pipe';
+import { formatPointValue } from '../../core/utils/point-scale.utils';
 
 export interface TaskListViewNode extends Task {
   _depth: number;
@@ -71,11 +72,15 @@ export class TaskListViewComponent {
   gridTemplateCols = computed(() => {
     const fieldCount = this.projectCustomFields().length;
     const customFieldCols = Array(fieldCount).fill('120px').join(' ');
+    const pointsCol = this.project()?.pointScaleConfig ? ' 120px' : '';
     if (this.selectionMode()) {
-      return `auto auto 1fr 120px 120px 120px ${customFieldCols} auto`;
+      return `auto auto 1fr 120px 120px 120px${pointsCol} ${customFieldCols} auto`;
     }
-    return `auto 1fr 120px 120px 120px ${customFieldCols} auto`;
+    return `auto 1fr 120px 120px 120px${pointsCol} ${customFieldCols} auto`;
   });
+
+  // Make formatter available to the template.
+  readonly formatPointValue = formatPointValue;
 
   // Track session start time to show recently completed tasks
   private sessionStartTime = new Date();

--- a/src/app/shared/components/snap-slider/snap-slider.component.css
+++ b/src/app/shared/components/snap-slider/snap-slider.component.css
@@ -46,6 +46,25 @@
   pointer-events: none;
 }
 
+.snap-slider__fill--between {
+  background: linear-gradient(90deg, var(--accent), var(--accent));
+  opacity: 0.45;
+}
+
+.snap-slider__tick.in-range {
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+}
+
+.snap-slider__label.in-range {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.snap-slider__thumb--min,
+.snap-slider__thumb--max {
+  background: linear-gradient(135deg, #fff, var(--accent));
+}
+
 .snap-slider__ticks {
   position: absolute;
   inset: 0;

--- a/src/app/shared/components/snap-slider/snap-slider.component.css
+++ b/src/app/shared/components/snap-slider/snap-slider.component.css
@@ -1,0 +1,104 @@
+:host {
+  display: block;
+  --accent: #06b6d4;
+}
+
+.snap-slider {
+  outline: none;
+  user-select: none;
+}
+
+.snap-slider:focus-visible .snap-slider__thumb {
+  box-shadow:
+    0 0 0 3px rgba(255, 255, 255, 0.12),
+    0 0 12px var(--accent);
+}
+
+.snap-slider__track {
+  position: relative;
+  height: 28px;
+  margin: 4px 0 2px;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.snap-slider__track::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 9999px;
+}
+
+.snap-slider__fill {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  height: 4px;
+  transform: translateY(-50%);
+  background: linear-gradient(90deg, transparent, var(--accent));
+  border-radius: 9999px;
+  pointer-events: none;
+}
+
+.snap-slider__ticks {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  pointer-events: none;
+}
+
+.snap-slider__tick {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.5);
+  transition: background 120ms ease;
+}
+
+.snap-slider__tick.active {
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+}
+
+.snap-slider__thumb {
+  position: absolute;
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  margin-left: -9px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #fff, var(--accent));
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 10px var(--accent);
+  transform: translateY(-50%);
+  transition: left 120ms ease;
+  pointer-events: none;
+}
+
+.snap-slider__labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  font-weight: 600;
+  color: rgb(148, 163, 184);
+  letter-spacing: 0.04em;
+}
+
+.snap-slider__label {
+  flex: 1;
+  text-align: center;
+  transition: color 120ms ease;
+}
+
+.snap-slider__label.active {
+  color: #fff;
+  text-shadow: 0 0 8px var(--accent);
+}

--- a/src/app/shared/components/snap-slider/snap-slider.component.html
+++ b/src/app/shared/components/snap-slider/snap-slider.component.html
@@ -1,11 +1,12 @@
 <div
   class="snap-slider"
+  [class.range]="range()"
   tabindex="0"
   role="slider"
   [attr.aria-label]="ariaLabel()"
   [attr.aria-valuemin]="values()[0]"
   [attr.aria-valuemax]="values()[values().length - 1]"
-  [attr.aria-valuenow]="value() ?? values()[0]"
+  [attr.aria-valuenow]="range() ? (minValue() ?? values()[0]) : (value() ?? values()[0])"
 >
   <div
     #track
@@ -16,24 +17,46 @@
     (pointerup)="onPointerUp($event)"
     (pointercancel)="onPointerUp($event)"
   >
-    @if (activeIndex() !== null) {
+    @if (!range() && activeIndex() !== null) {
       <div
         class="snap-slider__fill"
         [style.width.%]="thumbPercent()"
+      ></div>
+    }
+    @if (range()) {
+      <div
+        class="snap-slider__fill snap-slider__fill--between"
+        [style.left.%]="minPercent()"
+        [style.width.%]="maxPercent() - minPercent()"
       ></div>
     }
     <div class="snap-slider__ticks">
       @for (v of values(); track $index) {
         <span
           class="snap-slider__tick"
-          [class.active]="activeIndex() === $index"
+          [class.active]="!range() && activeIndex() === $index"
+          [class.in-range]="
+            range() &&
+            (minIndex() ?? 0) <= $index &&
+            $index <= (maxIndex() ?? values().length - 1)
+          "
         ></span>
       }
     </div>
-    @if (activeIndex() !== null) {
+    @if (!range() && activeIndex() !== null) {
       <div
         class="snap-slider__thumb"
         [style.left.%]="thumbPercent()"
+      ></div>
+    }
+    @if (range()) {
+      <div
+        class="snap-slider__thumb snap-slider__thumb--min"
+        [style.left.%]="minPercent()"
+      ></div>
+      <div
+        class="snap-slider__thumb snap-slider__thumb--max"
+        [style.left.%]="maxPercent()"
       ></div>
     }
   </div>
@@ -42,14 +65,24 @@
       @for (l of labelArr; track $index) {
         <span
           class="snap-slider__label"
-          [class.active]="activeIndex() === $index"
+          [class.active]="!range() && activeIndex() === $index"
+          [class.in-range]="
+            range() &&
+            (minIndex() ?? 0) <= $index &&
+            $index <= (maxIndex() ?? values().length - 1)
+          "
         >{{ l }}</span>
       }
     } @else {
       @for (v of values(); track $index) {
         <span
           class="snap-slider__label"
-          [class.active]="activeIndex() === $index"
+          [class.active]="!range() && activeIndex() === $index"
+          [class.in-range]="
+            range() &&
+            (minIndex() ?? 0) <= $index &&
+            $index <= (maxIndex() ?? values().length - 1)
+          "
         >{{ v }}</span>
       }
     }

--- a/src/app/shared/components/snap-slider/snap-slider.component.html
+++ b/src/app/shared/components/snap-slider/snap-slider.component.html
@@ -1,0 +1,57 @@
+<div
+  class="snap-slider"
+  tabindex="0"
+  role="slider"
+  [attr.aria-label]="ariaLabel()"
+  [attr.aria-valuemin]="values()[0]"
+  [attr.aria-valuemax]="values()[values().length - 1]"
+  [attr.aria-valuenow]="value() ?? values()[0]"
+>
+  <div
+    #track
+    class="snap-slider__track"
+    [style.--accent]="accent()"
+    (pointerdown)="onPointerDown($event)"
+    (pointermove)="onPointerMove($event)"
+    (pointerup)="onPointerUp($event)"
+    (pointercancel)="onPointerUp($event)"
+  >
+    @if (activeIndex() !== null) {
+      <div
+        class="snap-slider__fill"
+        [style.width.%]="thumbPercent()"
+      ></div>
+    }
+    <div class="snap-slider__ticks">
+      @for (v of values(); track $index) {
+        <span
+          class="snap-slider__tick"
+          [class.active]="activeIndex() === $index"
+        ></span>
+      }
+    </div>
+    @if (activeIndex() !== null) {
+      <div
+        class="snap-slider__thumb"
+        [style.left.%]="thumbPercent()"
+      ></div>
+    }
+  </div>
+  <div class="snap-slider__labels">
+    @if (labels(); as labelArr) {
+      @for (l of labelArr; track $index) {
+        <span
+          class="snap-slider__label"
+          [class.active]="activeIndex() === $index"
+        >{{ l }}</span>
+      }
+    } @else {
+      @for (v of values(); track $index) {
+        <span
+          class="snap-slider__label"
+          [class.active]="activeIndex() === $index"
+        >{{ v }}</span>
+      }
+    }
+  </div>
+</div>

--- a/src/app/shared/components/snap-slider/snap-slider.component.ts
+++ b/src/app/shared/components/snap-slider/snap-slider.component.ts
@@ -13,17 +13,14 @@ import { CommonModule } from '@angular/common';
 
 /**
  * Snap slider — a horizontal slider whose thumb snaps to a fixed list of
- * discrete values. Built for the task point-value input so users can drag a
- * thumb instead of clicking individual chips. Works for any monotonic value
- * set (Fibonacci, T-shirt sizes mapped to numbers, etc).
- *
- * The component intentionally exposes the raw selected number (the caller
- * decides how to render it as a label). When `labels` is provided, that
- * string is shown above the thumb; otherwise the raw value is used.
+ * discrete values. Used for the per-task point-value picker (single mode)
+ * and the min/max range picker on configurable hour-bucket scales (range
+ * mode with two thumbs).
  *
  * Drag interactions use pointer events so it works on mouse, touch, and pen
  * without separate code paths. Keyboard support uses ArrowLeft / ArrowRight
- * so the slider is reachable by users who can't drag.
+ * so the slider is reachable by users who can't drag — in range mode, the
+ * keyboard moves whichever thumb was last touched.
  */
 @Component({
   selector: 'app-snap-slider',
@@ -38,61 +35,99 @@ export class SnapSliderComponent {
   values = input.required<number[]>();
   /** Optional display labels parallel to `values` (e.g. ["XS","S",…]). */
   labels = input<string[] | undefined>(undefined);
-  /** Currently-selected value, or null when nothing is set. */
+  /** Single-mode: currently-selected value, or null when nothing is set. */
   value = input<number | null>(null);
+  /** Range-mode: lower bound (inclusive). Defaults to first value. */
+  minValue = input<number | null>(null);
+  /** Range-mode: upper bound (inclusive). Defaults to last value. */
+  maxValue = input<number | null>(null);
+  /** Whether the slider has two thumbs (min/max selection). */
+  range = input<boolean>(false);
   /** Accent color used for the active track + thumb glow. */
   accent = input<string>('#06b6d4');
   /** ARIA label for assistive tech. */
   ariaLabel = input<string>('Value');
 
   valueChange = output<number>();
+  rangeChange = output<{ min: number; max: number }>();
 
   @ViewChild('track', { static: true }) trackEl!: ElementRef<HTMLDivElement>;
 
-  private dragging = signal(false);
+  private dragging = signal<'single' | 'min' | 'max' | null>(null);
+  /** Which thumb was last touched — drives keyboard navigation in range mode. */
+  private lastActiveThumb = signal<'min' | 'max'>('min');
 
-  /** Index of the active value (0..values.length-1), or null. */
+  /** Single-mode active index. */
   activeIndex = computed<number | null>(() => {
+    if (this.range()) return null;
     const v = this.value();
     if (v === null) return null;
     const idx = this.values().indexOf(v);
     return idx === -1 ? this.nearestIndex(v) : idx;
   });
 
-  /** Thumb position as a percentage of track width. */
+  minIndex = computed<number | null>(() => {
+    if (!this.range()) return null;
+    const v = this.minValue();
+    if (v === null) return 0;
+    return Math.max(0, this.nearestIndex(v));
+  });
+
+  maxIndex = computed<number | null>(() => {
+    if (!this.range()) return null;
+    const v = this.maxValue();
+    if (v === null) return this.values().length - 1;
+    return Math.min(this.values().length - 1, this.nearestIndex(v));
+  });
+
+  /** Thumb position (single mode) as a percentage of track width. */
   thumbPercent = computed<number>(() => {
     const idx = this.activeIndex();
     if (idx === null) return 0;
-    const max = Math.max(this.values().length - 1, 1);
-    return (idx / max) * 100;
+    return this.indexToPercent(idx);
+  });
+
+  minPercent = computed<number>(() => {
+    const idx = this.minIndex();
+    return idx === null ? 0 : this.indexToPercent(idx);
+  });
+
+  maxPercent = computed<number>(() => {
+    const idx = this.maxIndex();
+    return idx === null ? 100 : this.indexToPercent(idx);
   });
 
   activeLabel = computed<string>(() => {
     const idx = this.activeIndex();
     if (idx === null) return '';
-    const labels = this.labels();
-    return labels ? labels[idx] ?? String(this.values()[idx]) : String(this.values()[idx]);
+    return this.labelAt(idx);
   });
 
   onPointerDown(event: PointerEvent): void {
     (event.target as Element).setPointerCapture?.(event.pointerId);
-    this.dragging.set(true);
+    const target = this.range() ? this.pickClosestThumb(event) : 'single';
+    this.dragging.set(target);
+    if (target === 'min' || target === 'max') this.lastActiveThumb.set(target);
     this.updateFromEvent(event);
   }
 
   onPointerMove(event: PointerEvent): void {
-    if (!this.dragging()) return;
+    if (this.dragging() === null) return;
     this.updateFromEvent(event);
   }
 
   onPointerUp(event: PointerEvent): void {
-    if (!this.dragging()) return;
+    if (this.dragging() === null) return;
     (event.target as Element).releasePointerCapture?.(event.pointerId);
-    this.dragging.set(false);
+    this.dragging.set(null);
   }
 
   @HostListener('keydown', ['$event'])
   onKeydown(event: KeyboardEvent): void {
+    if (this.range()) {
+      this.handleRangeKey(event);
+      return;
+    }
     const idx = this.activeIndex();
     if (idx === null) return;
     if (event.key === 'ArrowLeft' && idx > 0) {
@@ -110,11 +145,28 @@ export class SnapSliderComponent {
     }
   }
 
-  /**
-   * Translate a pointer event's x-coordinate into the closest discrete value
-   * and emit the change. Re-emitting the same value is a no-op for the
-   * parent's signal because the input identity stays the same.
-   */
+  private handleRangeKey(event: KeyboardEvent): void {
+    const which = this.lastActiveThumb();
+    const minIdx = this.minIndex();
+    const maxIdx = this.maxIndex();
+    if (minIdx === null || maxIdx === null) return;
+    let nextMin = minIdx;
+    let nextMax = maxIdx;
+    if (event.key === 'ArrowLeft') {
+      if (which === 'min' && minIdx > 0) nextMin = minIdx - 1;
+      else if (which === 'max' && maxIdx > minIdx) nextMax = maxIdx - 1;
+      else return;
+    } else if (event.key === 'ArrowRight') {
+      const last = this.values().length - 1;
+      if (which === 'min' && minIdx < maxIdx) nextMin = minIdx + 1;
+      else if (which === 'max' && maxIdx < last) nextMax = maxIdx + 1;
+      else return;
+    } else return;
+    event.preventDefault();
+    this.emitRange(nextMin, nextMax);
+  }
+
+  /** Translate the pointer's x-coordinate into a discrete value and emit. */
   private updateFromEvent(event: PointerEvent): void {
     const track = this.trackEl?.nativeElement;
     if (!track) return;
@@ -122,7 +174,18 @@ export class SnapSliderComponent {
     const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
     const lastIdx = this.values().length - 1;
     const idx = Math.round(ratio * lastIdx);
-    this.emitIndex(idx);
+    const which = this.dragging();
+    if (which === 'single') {
+      this.emitIndex(idx);
+      return;
+    }
+    const minIdx = this.minIndex() ?? 0;
+    const maxIdx = this.maxIndex() ?? lastIdx;
+    if (which === 'min') {
+      this.emitRange(Math.min(idx, maxIdx), maxIdx);
+    } else if (which === 'max') {
+      this.emitRange(minIdx, Math.max(idx, minIdx));
+    }
   }
 
   private emitIndex(idx: number): void {
@@ -130,6 +193,31 @@ export class SnapSliderComponent {
     if (idx < 0 || idx >= values.length) return;
     if (values[idx] === this.value()) return;
     this.valueChange.emit(values[idx]);
+  }
+
+  private emitRange(minIdx: number, maxIdx: number): void {
+    const values = this.values();
+    const min = values[minIdx];
+    const max = values[maxIdx];
+    if (min === this.minValue() && max === this.maxValue()) return;
+    this.rangeChange.emit({ min, max });
+  }
+
+  /**
+   * In range mode, decide which thumb the pointer is closest to so dragging
+   * naturally picks up the nearer handle. Falls back to "min" on exact ties.
+   */
+  private pickClosestThumb(event: PointerEvent): 'min' | 'max' {
+    const track = this.trackEl?.nativeElement;
+    if (!track) return 'min';
+    const rect = track.getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+    const pointerPct = ratio * 100;
+    const minDist = Math.abs(pointerPct - this.minPercent());
+    const maxDist = Math.abs(pointerPct - this.maxPercent());
+    const choice: 'min' | 'max' = maxDist < minDist ? 'max' : 'min';
+    this.lastActiveThumb.set(choice);
+    return choice;
   }
 
   /** Closest index for a value not directly present in `values`. */
@@ -145,5 +233,15 @@ export class SnapSliderComponent {
       }
     }
     return best;
+  }
+
+  private indexToPercent(idx: number): number {
+    const max = Math.max(this.values().length - 1, 1);
+    return (idx / max) * 100;
+  }
+
+  private labelAt(idx: number): string {
+    const labels = this.labels();
+    return labels ? labels[idx] ?? String(this.values()[idx]) : String(this.values()[idx]);
   }
 }

--- a/src/app/shared/components/snap-slider/snap-slider.component.ts
+++ b/src/app/shared/components/snap-slider/snap-slider.component.ts
@@ -1,0 +1,149 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  HostListener,
+  input,
+  output,
+  signal,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Snap slider — a horizontal slider whose thumb snaps to a fixed list of
+ * discrete values. Built for the task point-value input so users can drag a
+ * thumb instead of clicking individual chips. Works for any monotonic value
+ * set (Fibonacci, T-shirt sizes mapped to numbers, etc).
+ *
+ * The component intentionally exposes the raw selected number (the caller
+ * decides how to render it as a label). When `labels` is provided, that
+ * string is shown above the thumb; otherwise the raw value is used.
+ *
+ * Drag interactions use pointer events so it works on mouse, touch, and pen
+ * without separate code paths. Keyboard support uses ArrowLeft / ArrowRight
+ * so the slider is reachable by users who can't drag.
+ */
+@Component({
+  selector: 'app-snap-slider',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './snap-slider.component.html',
+  styleUrls: ['./snap-slider.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SnapSliderComponent {
+  /** Allowed discrete values, in ascending order. */
+  values = input.required<number[]>();
+  /** Optional display labels parallel to `values` (e.g. ["XS","S",…]). */
+  labels = input<string[] | undefined>(undefined);
+  /** Currently-selected value, or null when nothing is set. */
+  value = input<number | null>(null);
+  /** Accent color used for the active track + thumb glow. */
+  accent = input<string>('#06b6d4');
+  /** ARIA label for assistive tech. */
+  ariaLabel = input<string>('Value');
+
+  valueChange = output<number>();
+
+  @ViewChild('track', { static: true }) trackEl!: ElementRef<HTMLDivElement>;
+
+  private dragging = signal(false);
+
+  /** Index of the active value (0..values.length-1), or null. */
+  activeIndex = computed<number | null>(() => {
+    const v = this.value();
+    if (v === null) return null;
+    const idx = this.values().indexOf(v);
+    return idx === -1 ? this.nearestIndex(v) : idx;
+  });
+
+  /** Thumb position as a percentage of track width. */
+  thumbPercent = computed<number>(() => {
+    const idx = this.activeIndex();
+    if (idx === null) return 0;
+    const max = Math.max(this.values().length - 1, 1);
+    return (idx / max) * 100;
+  });
+
+  activeLabel = computed<string>(() => {
+    const idx = this.activeIndex();
+    if (idx === null) return '';
+    const labels = this.labels();
+    return labels ? labels[idx] ?? String(this.values()[idx]) : String(this.values()[idx]);
+  });
+
+  onPointerDown(event: PointerEvent): void {
+    (event.target as Element).setPointerCapture?.(event.pointerId);
+    this.dragging.set(true);
+    this.updateFromEvent(event);
+  }
+
+  onPointerMove(event: PointerEvent): void {
+    if (!this.dragging()) return;
+    this.updateFromEvent(event);
+  }
+
+  onPointerUp(event: PointerEvent): void {
+    if (!this.dragging()) return;
+    (event.target as Element).releasePointerCapture?.(event.pointerId);
+    this.dragging.set(false);
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(event: KeyboardEvent): void {
+    const idx = this.activeIndex();
+    if (idx === null) return;
+    if (event.key === 'ArrowLeft' && idx > 0) {
+      this.emitIndex(idx - 1);
+      event.preventDefault();
+    } else if (event.key === 'ArrowRight' && idx < this.values().length - 1) {
+      this.emitIndex(idx + 1);
+      event.preventDefault();
+    } else if (event.key === 'Home') {
+      this.emitIndex(0);
+      event.preventDefault();
+    } else if (event.key === 'End') {
+      this.emitIndex(this.values().length - 1);
+      event.preventDefault();
+    }
+  }
+
+  /**
+   * Translate a pointer event's x-coordinate into the closest discrete value
+   * and emit the change. Re-emitting the same value is a no-op for the
+   * parent's signal because the input identity stays the same.
+   */
+  private updateFromEvent(event: PointerEvent): void {
+    const track = this.trackEl?.nativeElement;
+    if (!track) return;
+    const rect = track.getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+    const lastIdx = this.values().length - 1;
+    const idx = Math.round(ratio * lastIdx);
+    this.emitIndex(idx);
+  }
+
+  private emitIndex(idx: number): void {
+    const values = this.values();
+    if (idx < 0 || idx >= values.length) return;
+    if (values[idx] === this.value()) return;
+    this.valueChange.emit(values[idx]);
+  }
+
+  /** Closest index for a value not directly present in `values`. */
+  private nearestIndex(target: number): number {
+    const values = this.values();
+    let best = 0;
+    let bestDist = Math.abs(values[0] - target);
+    for (let i = 1; i < values.length; i++) {
+      const dist = Math.abs(values[i] - target);
+      if (dist < bestDist) {
+        best = i;
+        bestDist = dist;
+      }
+    }
+    return best;
+  }
+}

--- a/src/testing/mock-firestore.ts
+++ b/src/testing/mock-firestore.ts
@@ -87,3 +87,6 @@ export const writeBatch = jasmine.createSpy('writeBatch').and.returnValue({
   delete: jasmine.createSpy('batch.delete'),
   commit: jasmine.createSpy('batch.commit').and.returnValue(Promise.resolve()),
 });
+export const deleteField = jasmine.createSpy('deleteField').and.returnValue({});
+export const or = jasmine.createSpy('or').and.returnValue({});
+export const and = jasmine.createSpy('and').and.returnValue({});


### PR DESCRIPTION
## Summary
Adds six task-effort scales — Numeric (configurable), Time-Based, T-Shirt, Animal, Custom Multi-Factor, and Credit Hours — selectable per project from the settings panel. The three numeric-like scales support an optional PERT toggle that turns the per-task input into Optimistic / Most Likely / Pessimistic estimates with weighted average and standard-deviation roll-ups.

## What changed

**Data model** (`src/app/core/models/domain.model.ts`)
- `PointScaleConfig` discriminated union covering all six scales.
- `PointValue` union covering single values, PERT triples, T-shirt/animal labels, and multi-factor maps.
- `Project.pointScaleConfig` and `Task.pointValue` added (both optional, so existing projects are unaffected).
- Built-in numeric preset templates: Linear 1-5 · Linear 1-10 · Fibonacci · Modified Fibonacci · Powers of 2 · Bucket.

**Utilities** (`src/app/core/utils/point-scale.utils.ts` + spec)
- `getNumericAllowedValues` — generates allowed values for linear / Fibonacci / powers-of-two / custom.
- `computePertEstimate` and `computePertStdDev` — (O+4M+P)/6 and (P-O)/6.
- `pointValueScalar` and `aggregateValues` — total, total SD via summed variances, optional `load_factor` forecast for time scales.
- `formatPointValue` — compact badge string (e.g. `5.2 ± 1.3h`).
- `migrateValue` — nearest-equivalent mapping when project switches scale (numeric ↔ T-shirt ↔ animal, PERT on/off collapse/expand, multi-factor by factor ID).

**Project settings UI** (`point-scale-manager.component.*`)
- Cards for picking a scale (or "No point values").
- Per-scale config forms: numeric presets + min/max/increment/custom values; time unit/precision/preset/load factor; multi-factor add/remove/scale/weight; credit hours total/input mode/weekly target.
- PERT toggle on supported scales.
- Save flow confirms before scale-type changes and migrates existing task values in batched Firestore writes.

**Task input** (`task-point-value-input.*`)
- Renders the right control for the active scale: dropdown / numeric input / segmented size buttons / three PERT fields / per-factor inputs.
- Live PERT summary under the inputs.
- Embedded in both `task-create-modal` and `task-detail-modal` (auto-save on change).

**Task list display** (`task-list-view`)
- New "Points" column shows a cyan badge per task; uses `formatPointValue` for shape-aware formatting.

**Service** (`project.service.ts`)
- `updatePointScaleConfig(projectId, newConfig)` — writes the new config and migrates every task's `pointValue` to the nearest equivalent, batched in chunks of 400.

## Test plan
- [ ] Open a project's settings → "Task Point Values" → pick "Numeric (Points)" → apply the Fibonacci preset → Save.
- [ ] Enable PERT, save, open a task — three O/M/P fields appear with the weighted average summary.
- [ ] Disable PERT, save — the input collapses to a single dropdown showing the previously-computed estimate snapped to the nearest Fibonacci value.
- [ ] Switch the scale to T-Shirt — existing task values are remapped to the nearest size (confirm prompt fires).
- [ ] Open project settings → "No point values" → Save — point-value badges disappear from the list and the field is hidden in task modals.
- [ ] Verify production build (`ng build`) passes — confirmed locally.

## Out of scope
- Project-level aggregation widgets (segmented progress bar, weekly bar chart, forecasted completion). The aggregation helpers (`aggregateValues`, total SD, forecast total) are in place so this is a follow-up.
- Reporting/export integrations.

## Rollback
- `pointScaleConfig` and `pointValue` are optional everywhere. Clearing the config restores prior behavior; old documents without the new fields render unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_012kY4K6LEcTLdTchEBfszg5)_