### PR TITLE
Fix hyperlink popup clipping in markdown editor

### DIFF
--- a/src/app/shared/components/markdown-editor/markdown-editor.component.html
+++ b/src/app/shared/components/markdown-editor/markdown-editor.component.html
@@ -279,7 +279,7 @@
             <input
               type="url"
               [value]="linkUrl()"
-              (input)="linkUrl.set($any($event.target).value)"
+              (input)="linkUrl.set(linkInput.value)"
               style="padding: 4px 8px; background-color: rgb(15, 23, 42); border: 1px solid rgb(51, 65, 85); border-radius: 4px; font-size: 14px; color: rgb(226, 232, 240); outline: none;"
               placeholder="https://"
               (keydown.enter)="submitLink($event)"

--- a/src/app/shared/components/markdown-editor/markdown-editor.component.html
+++ b/src/app/shared/components/markdown-editor/markdown-editor.component.html
@@ -246,53 +246,56 @@
         </button>
 
         <!-- Link -->
-        <div style="position: relative; display: inline-flex;">
-          <button
-            type="button"
-            tabindex="-1"
-            class="md-btn"
-            title="Link (Ctrl+K)"
-            (click)="insertLink()"
+        <button
+          #linkBtnRef
+          type="button"
+          tabindex="-1"
+          class="md-btn"
+          title="Link (Ctrl+K)"
+          (click)="insertLink()"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="md-svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="md-svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+            />
+          </svg>
+        </button>
+
+        @if (showLinkPrompt()) {
+          <div
+            [style.top.px]="linkPromptPosition().top"
+            [style.left.px]="linkPromptPosition().left"
+            style="position: fixed; padding: 8px; background-color: rgb(30, 41, 59); border: 1px solid rgb(51, 65, 85); border-radius: 4px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); z-index: 1000; display: flex; gap: 8px;"
+          >
+            <input
+              type="url"
+              [value]="linkUrl()"
+              (input)="linkUrl.set($any($event.target).value)"
+              style="padding: 4px 8px; background-color: rgb(15, 23, 42); border: 1px solid rgb(51, 65, 85); border-radius: 4px; font-size: 14px; color: rgb(226, 232, 240); outline: none;"
+              placeholder="https://"
+              (keydown.enter)="submitLink($event)"
+              (keydown.escape)="closeLinkPrompt()"
+              #linkInput
             >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-              />
-            </svg>
-          </button>
-          
-          @if (showLinkPrompt()) {
-            <div style="position: absolute; top: 100%; left: 0; margin-top: 4px; padding: 8px; background-color: rgb(30, 41, 59); border: 1px solid rgb(51, 65, 85); border-radius: 4px; box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); z-index: 10; display: flex; gap: 8px;">
-              <input 
-                type="url" 
-                [value]="linkUrl()" 
-                (input)="linkUrl.set($any($event.target).value)"
-                style="padding: 4px 8px; background-color: rgb(15, 23, 42); border: 1px solid rgb(51, 65, 85); border-radius: 4px; font-size: 14px; color: rgb(226, 232, 240); outline: none;"
-                placeholder="https://"
-                (keydown.enter)="submitLink($event)"
-                (keydown.escape)="closeLinkPrompt()"
-                #linkInput
-              >
-              <button 
-                type="button" 
-                class="md-btn" 
-                style="background-color: rgb(8, 145, 178); color: white;" 
-                (click)="submitLink()"
-              >
-                Add
-              </button>
-            </div>
-          }
-        </div>
+            <button
+              type="button"
+              class="md-btn"
+              style="background-color: rgb(8, 145, 178); color: white;"
+              (click)="submitLink()"
+            >
+              Add
+            </button>
+          </div>
+        }
 
         <!-- Table -->
         <button

--- a/src/app/shared/components/markdown-editor/markdown-editor.component.ts
+++ b/src/app/shared/components/markdown-editor/markdown-editor.component.ts
@@ -215,8 +215,8 @@ export class MarkdownEditorComponent {
         top: rect.bottom + 4,
         left: rect.left,
       });
+      this.showLinkPrompt.set(true);
     }
-    this.showLinkPrompt.set(true);
   }
 
   submitLink(event?: Event): void {

--- a/src/app/shared/components/markdown-editor/markdown-editor.component.ts
+++ b/src/app/shared/components/markdown-editor/markdown-editor.component.ts
@@ -95,6 +95,29 @@ export class MarkdownEditorComponent {
         }
       }
     });
+
+    // Keep the link prompt anchored to the trigger button while open.
+    effect((onCleanup) => {
+      if (!this.showLinkPrompt()) return;
+      const update = () => this.updateLinkPromptPosition();
+      window.addEventListener('scroll', update, true);
+      window.addEventListener('resize', update);
+      onCleanup(() => {
+        window.removeEventListener('scroll', update, true);
+        window.removeEventListener('resize', update);
+      });
+    });
+  }
+
+  private updateLinkPromptPosition(): boolean {
+    const btn = this.linkBtnRef()?.nativeElement;
+    if (!btn) return false;
+    const rect = btn.getBoundingClientRect();
+    this.linkPromptPosition.set({
+      top: rect.bottom + 4,
+      left: rect.left,
+    });
+    return true;
   }
 
   onInput(): void {
@@ -208,13 +231,7 @@ export class MarkdownEditorComponent {
       this.savedRange = sel.getRangeAt(0);
     }
     this.linkUrl.set('');
-    const btn = this.linkBtnRef()?.nativeElement;
-    if (btn) {
-      const rect = btn.getBoundingClientRect();
-      this.linkPromptPosition.set({
-        top: rect.bottom + 4,
-        left: rect.left,
-      });
+    if (this.updateLinkPromptPosition()) {
       this.showLinkPrompt.set(true);
     }
   }

--- a/src/app/shared/components/markdown-editor/markdown-editor.component.ts
+++ b/src/app/shared/components/markdown-editor/markdown-editor.component.ts
@@ -52,6 +52,8 @@ export class MarkdownEditorComponent {
   // Link Prompt State
   showLinkPrompt = signal(false);
   linkUrl = signal('');
+  linkPromptPosition = signal<{ top: number; left: number }>({ top: 0, left: 0 });
+  linkBtnRef = viewChild<ElementRef<HTMLButtonElement>>('linkBtnRef');
   private savedRange: Range | null = null;
 
   private turndownService: TurndownService;
@@ -206,6 +208,14 @@ export class MarkdownEditorComponent {
       this.savedRange = sel.getRangeAt(0);
     }
     this.linkUrl.set('');
+    const btn = this.linkBtnRef()?.nativeElement;
+    if (btn) {
+      const rect = btn.getBoundingClientRect();
+      this.linkPromptPosition.set({
+        top: rect.bottom + 4,
+        left: rect.left,
+      });
+    }
     this.showLinkPrompt.set(true);
   }
 


### PR DESCRIPTION
## Summary
- The link prompt in the markdown editor was absolutely positioned inside the toolbar wrapper, which sits inside `.md-editor` (`overflow: hidden`). When opened near the right edge of the description box, the input + Add button got visually clipped by the editor container.
- Switched the popup to `position: fixed` with `top`/`left` computed from the link button's `getBoundingClientRect()` at open time, so it floats above the editor regardless of any ancestor's overflow.
- Added a `linkBtnRef` viewChild for measuring the trigger button.

## Test plan
- [ ] Open a project, click + Add Task, type some text in Description, select it, click the link icon, and confirm the URL prompt appears below the link button and is not clipped by the description box edges.
- [ ] Repeat with the link button near the right edge of a narrower modal to confirm the popup is no longer cut off.
- [ ] Confirm Esc closes the popup, Enter submits the URL, and the resulting link is inserted into the text.
- [ ] Verify the popup still opens via the Ctrl+K shortcut.

https://claude.ai/code/session_01M1JUJw3A91vY585fC3nVbs

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1JUJw3A91vY585fC3nVbs)_