### PR TITLE
fix(my-tasks): address PR #158 review feedback on pin toggles

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -11,6 +11,8 @@ import {
   Firestore,
   collection,
   doc,
+  arrayRemove,
+  arrayUnion,
   getDoc,
   getDocs,
   query,
@@ -266,6 +268,29 @@ export class AuthService {
     const userRef = doc(this.firestore, `users/${currentUser.uid}`);
     await updateDoc(userRef, updates as { [k: string]: unknown });
     this.currentUserSig.set({ ...currentUser, ...updates });
+  }
+
+  /**
+   * Atomically pin or unpin a project on the user's profile.
+   *
+   * Uses arrayUnion/arrayRemove to avoid lost updates when multiple pins are
+   * toggled quickly (e.g., pinning multiple projects back-to-back).
+   */
+  async updatePinnedProjectId(projectId: string, pinned: boolean): Promise<void> {
+    const currentUser = this.currentUserSig();
+    if (!currentUser) return;
+
+    const userRef = doc(this.firestore, `users/${currentUser.uid}`);
+    await updateDoc(userRef, {
+      pinnedProjectIds: pinned ? arrayUnion(projectId) : arrayRemove(projectId),
+    });
+
+    const current = currentUser.pinnedProjectIds ?? [];
+    const next = pinned
+      ? Array.from(new Set([...current, projectId]))
+      : current.filter((id) => id !== projectId);
+
+    this.currentUserSig.set({ ...currentUser, pinnedProjectIds: next });
   }
 
   async logout() {

--- a/src/app/features/my-tasks/components/my-tasks-overview.component.css
+++ b/src/app/features/my-tasks/components/my-tasks-overview.component.css
@@ -72,7 +72,7 @@
 /* Pinned panel — retint `.ofx-panel`'s outer glow to pink so it visually
    ties to the pink border / star icon. */
 .mt-panel-pinned {
-  --panel-glow: rgba(255, 20, 147, 0.55);
+  --panel-glow: rgba(139, 92, 246, 0.55);
 }
 
 /* Pin/unpin icon button on each project card. Hover + active states tint

--- a/src/app/features/my-tasks/my-tasks.component.ts
+++ b/src/app/features/my-tasks/my-tasks.component.ts
@@ -226,18 +226,16 @@ export class MyTasksComponent {
    * mirrors the change into `AuthService.currentUserSig` so the UI reacts
    * immediately. Errors surface via the dialog service.
    */
-  async togglePinProject(projectId: string) {
+  async togglePinProject(projectId: string): Promise<void> {
     const user = this.currentUser();
     if (!user) return;
-    const current = user.pinnedProjectIds ?? [];
-    const next = current.includes(projectId)
-      ? current.filter((id) => id !== projectId)
-      : [...current, projectId];
     try {
-      await this.auth.updateProfile({ pinnedProjectIds: next });
+      const current = user.pinnedProjectIds ?? [];
+      const shouldPin = !current.includes(projectId);
+      await this.auth.updatePinnedProjectId(projectId, shouldPin);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Could not update pinned projects';
-      await this.dialogService.alert(message, 'Pin failed');
+      console.error('Failed to toggle project pin:', err);
+      await this.dialogService.alert('Could not update pinned projects', 'Pin failed');
     }
   }
 


### PR DESCRIPTION
## Summary

Addresses unresolved review comments from merged PR #158.

## Changes
- **Error handling**: generic user-facing pin failure message; log details to console
- **Types**: explicit \Promise<void>\ on \	ogglePinProject\
- **Race safety**: \AuthService.updatePinnedProjectId\ uses Firestore \rrayUnion\ / \rrayRemove\
- **Brand**: pinned panel glow uses purple (\#8b5cf6\) instead of pink

## Related
- Closes follow-up for #158


Made with [Cursor](https://cursor.com)