### PR TITLE
fix(auth): reconcile pinned-project local state after atomic Firestore updates

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -280,17 +280,31 @@ export class AuthService {
     const currentUser = this.currentUserSig();
     if (!currentUser) return;
 
-    const userRef = doc(this.firestore, `users/${currentUser.uid}`);
-    await updateDoc(userRef, {
-      pinnedProjectIds: pinned ? arrayUnion(projectId) : arrayRemove(projectId),
-    });
+    const previous = currentUser.pinnedProjectIds ?? [];
+    const optimistic = pinned
+      ? Array.from(new Set([...previous, projectId]))
+      : previous.filter((id) => id !== projectId);
 
-    const current = currentUser.pinnedProjectIds ?? [];
-    const next = pinned
-      ? Array.from(new Set([...current, projectId]))
-      : current.filter((id) => id !== projectId);
+    this.currentUserSig.set({ ...currentUser, pinnedProjectIds: optimistic });
 
-    this.currentUserSig.set({ ...currentUser, pinnedProjectIds: next });
+    const userRef = doc(this.firestore, 'users', currentUser.uid);
+    try {
+      await updateDoc(userRef, {
+        pinnedProjectIds: pinned ? arrayUnion(projectId) : arrayRemove(projectId),
+      });
+    } catch (err) {
+      this.currentUserSig.set({ ...currentUser, pinnedProjectIds: previous });
+      throw err;
+    }
+
+    const latestUser = this.currentUserSig();
+    if (!latestUser) return;
+    const latest = latestUser.pinnedProjectIds ?? [];
+    const reconciled = pinned
+      ? Array.from(new Set([...latest, projectId]))
+      : latest.filter((id) => id !== projectId);
+
+    this.currentUserSig.set({ ...latestUser, pinnedProjectIds: reconciled });
   }
 
   async logout() {

--- a/src/app/features/my-tasks/components/my-tasks-overview.component.css
+++ b/src/app/features/my-tasks/components/my-tasks-overview.component.css
@@ -69,8 +69,8 @@
   overflow: visible;
 }
 
-/* Pinned panel — retint `.ofx-panel`'s outer glow to pink so it visually
-   ties to the pink border / star icon. */
+/* Pinned panel — retint `.ofx-panel`'s outer glow to brand purple so it
+   visually ties to the pinned section accent. */
 .mt-panel-pinned {
   --panel-glow: rgba(139, 92, 246, 0.55);
 }


### PR DESCRIPTION
## Summary

Follow-up hotfix for merged PR #160 review feedback.

## Changes
- **Local state race**: `updatePinnedProjectId` now applies an optimistic `currentUserSig` update, rolls back on Firestore failure, and reconciles from the latest signal after `await`
- **Firestore path style**: use `doc(firestore, 'users', uid)` in the new method
- **CSS comment**: update pinned panel comment to reflect purple brand glow (was still describing pink)

## Addresses
- omnigemini / gemini-code-assist: stale local state after async `updateDoc`
- omnigemini / gemini-code-assist: Firestore path string concatenation
- omnigemini: outdated pink CSS comment
- chatgpt-codex-connector P1: concurrent pin toggles overwriting local signal

## Test plan
- [x] `ng build --configuration production` passes
- [ ] Manual: pin two projects quickly, unpin one, refresh — pins match Firestore
