### PR TITLE
Add CODEOWNERS to auto-assign bkenol as reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically assign @bkenol as reviewer for all PRs
+* @bkenol


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file that assigns `@bkenol` as a required reviewer for all files (`*`)
- Any PR targeting `live` will automatically request a review from `@bkenol`

## Note
For CODEOWNERS enforcement to work, branch protection on `live` must have **"Require review from Code Owners"** enabled. If it isn't already, toggle it in **Settings → Branches → `live` → Branch protection rules → Require pull request reviews → Require review from Code Owners**.

## Test plan
- [ ] Open a test PR against `live` and verify `@bkenol` is automatically requested as a reviewer

https://claude.ai/code/session_01LEwAh1agcGdf34akhvyoX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEwAh1agcGdf34akhvyoX7)_