### PR TITLE
chore: cleanup batch — allowSignalWrites, console.log noise, demo stubs

### DIFF
--- a/src/app/core/services/contacts.service.ts
+++ b/src/app/core/services/contacts.service.ts
@@ -101,9 +101,6 @@ export class ContactsService {
       this.contactsCache$ = combineLatest([
         // 1. Cached contacts from Firestore (fast, primary source, user-scoped)
         from(this.fetchCachedContacts()).pipe(
-          tap((contacts) =>
-            console.log('[ContactsService] Firestore cache:', contacts.length, 'contacts'),
-          ),
           catchError((err) => {
             console.warn('Failed to fetch cached contacts:', err);
             return of([]);
@@ -111,9 +108,6 @@ export class ContactsService {
         ),
         // 2. Google Directory people (domain users) - primary source for team contacts
         this.googleContactsService.getDirectoryPeople().pipe(
-          tap((contacts) =>
-            console.log('[ContactsService] Google Directory:', contacts.length, 'contacts'),
-          ),
           map((contacts) => contacts.map((c) => this.mapGoogleContactToContact(c))),
           catchError((err) => {
             console.warn('[ContactsService] Google Directory failed:', err);
@@ -122,17 +116,11 @@ export class ContactsService {
         ),
         // 3. Google Contacts (personal contacts)
         this.googleContactsService.getContacts().pipe(
-          tap((contacts) =>
-            console.log('[ContactsService] Google Contacts:', contacts.length, 'contacts'),
-          ),
           map((contacts) => contacts.map((c) => this.mapGoogleContactToContact(c))),
           catchError(() => of([])),
         ),
         // 4. Other contacts inferred from interactions
         this.googleContactsService.getOtherContacts().pipe(
-          tap((contacts) =>
-            console.log('[ContactsService] Google Other Contacts:', contacts.length, 'contacts'),
-          ),
           map((contacts) => contacts.map((c) => this.mapGoogleContactToContact(c))),
           catchError((err) => {
             console.warn('[ContactsService] Google Other Contacts failed:', err);
@@ -242,7 +230,6 @@ export class ContactsService {
     try {
       const currentUser = this.authService.currentUserSig();
       if (!currentUser?.uid) {
-        console.log('No current user, skipping cached contacts fetch');
         return [];
       }
 
@@ -281,7 +268,6 @@ export class ContactsService {
     try {
       const currentUser = this.authService.currentUserSig();
       if (!currentUser?.uid) {
-        console.log('No current user, skipping contacts sync');
         return;
       }
 
@@ -305,7 +291,6 @@ export class ContactsService {
       }
 
       await batch.commit();
-      console.log(`Synced ${contactsToSync.length} contacts to Firestore (user-scoped)`);
     } catch (e) {
       console.error('Error syncing contacts to Firestore:', e);
       throw e;

--- a/src/app/core/services/google-tasks-sync.service.ts
+++ b/src/app/core/services/google-tasks-sync.service.ts
@@ -316,9 +316,6 @@ export class GoogleTasksSyncService {
       }
     }
 
-    console.log(
-      `Sync result: ${added} added, ${updated} updated, ${pushed} pushed, ${linked} linked by title`,
-    );
     return { added, updated, pushed };
   }
 

--- a/src/app/core/services/seed-data.service.ts
+++ b/src/app/core/services/seed-data.service.ts
@@ -347,6 +347,5 @@ export class SeedDataService {
 
     // Commit all data
     await batch.commit();
-    console.log('✅ Sample data seeded successfully!');
   }
 }

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -77,10 +77,7 @@ export class DashboardComponent {
   private async seedSampleDataIfNeeded() {
     this.seeding.set(true);
     try {
-      const seeded = await this.seedService.seedIfEmpty();
-      if (seeded) {
-        console.log('Sample data created for new user!');
-      }
+      await this.seedService.seedIfEmpty();
     } catch (err) {
       console.error('Failed to seed data:', err);
     } finally {

--- a/src/app/features/demo/board-demo.component.html
+++ b/src/app/features/demo/board-demo.component.html
@@ -1,26 +1,35 @@
 <div class="min-h-screen bg-slate-950 p-8">
-      <div class="max-w-7xl mx-auto">
-        <div class="mb-8 text-center">
-          <h1
-            class="text-4xl font-bold mb-3 [text-shadow:0_0_8px_rgba(224,64,251,0.8),_0_0_16px_rgba(224,64,251,0.6),_0_0_24px_rgba(0,210,255,0.4)]"
-          >
-            Board View - Cyberpunk Enhancement Demo
-          </h1>
-          <p class="text-slate-400 text-lg">
-            Showcasing enhanced column styling, task color accents, and dormant state effects
-          </p>
-        </div>
-
-        <div
-          class="rounded-xl overflow-hidden border border-white/10 bg-slate-900/30 "
-        >
-          <app-task-board-view
-            [tasks]="demoTasks()"
-            [project]="demoProject()"
-            (taskClick)="onTaskClick($event)"
-            (quickAdd)="onQuickAdd($event)"
-            (addSection)="onAddSection()"
-          />
-        </div>
-      </div>
+  <div class="max-w-7xl mx-auto">
+    <div class="mb-8 text-center">
+      <h1
+        class="text-4xl font-bold mb-3 [text-shadow:0_0_8px_rgba(224,64,251,0.8),_0_0_16px_rgba(224,64,251,0.6),_0_0_24px_rgba(0,210,255,0.4)]"
+      >
+        Board View - Cyberpunk Enhancement Demo
+      </h1>
+      <p class="text-slate-400 text-lg">
+        Showcasing enhanced column styling, task color accents, and dormant state effects
+      </p>
     </div>
+
+    <div class="rounded-xl overflow-hidden border border-white/10 bg-slate-900/30">
+      <app-task-board-view
+        [tasks]="demoTasks()"
+        [project]="demoProject()"
+        (taskClick)="onTaskClick($event)"
+        (quickAdd)="onQuickAdd($event)"
+        (addSection)="onAddSection()"
+      />
+    </div>
+  </div>
+
+  @if (toastMessage(); as msg) {
+    <div
+      class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-5 py-3 rounded-lg
+             bg-purple-600/90 text-white text-sm font-medium shadow-lg
+             backdrop-blur-sm border border-purple-400/30
+             animate-[fadeIn_0.2s_ease-out]"
+    >
+      {{ msg }}
+    </div>
+  }
+</div>

--- a/src/app/features/demo/board-demo.component.ts
+++ b/src/app/features/demo/board-demo.component.ts
@@ -11,6 +11,9 @@ import { Task, Project, DEFAULT_SECTIONS } from '../../core/models/domain.model'
   templateUrl: './board-demo.component.html',
 })
 export class BoardDemoComponent {
+  private nextId = 10;
+  toastMessage = signal('');
+
   demoProject = signal<Project>({
     id: 'demo-project',
     name: 'Cyberpunk Enhancement Demo',
@@ -69,14 +72,47 @@ export class BoardDemoComponent {
   ]);
 
   onTaskClick(task: Task) {
-    console.log('Task clicked:', task);
+    this.showToast(`Viewing "${task.title}" (demo — no detail modal)`);
   }
 
   onQuickAdd(sectionId: string) {
-    console.log('Quick add for section:', sectionId);
+    const id = `task-${this.nextId++}`;
+    const section = this.demoProject().sections.find(
+      (s) => s.id === sectionId,
+    );
+    const newTask: Task = {
+      id,
+      projectId: 'demo-project',
+      sectionId,
+      title: `New task ${this.nextId}`,
+      description: '',
+      status: (section?.status as Task['status']) ?? 'todo',
+      priority: 'medium',
+      order: this.demoTasks().length,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.demoTasks.update((tasks) => [...tasks, newTask]);
+    this.showToast('Task added to demo board');
   }
 
   onAddSection() {
-    console.log('Add new section');
+    const idx = this.demoProject().sections.length;
+    const section = {
+      id: `section-${idx}`,
+      name: `Section ${idx + 1}`,
+      order: idx,
+      color: '#8b5cf6',
+    };
+    this.demoProject.update((p) => ({
+      ...p,
+      sections: [...p.sections, section],
+    }));
+    this.showToast(`Section "${section.name}" added`);
+  }
+
+  private showToast(msg: string) {
+    this.toastMessage.set(msg);
+    setTimeout(() => this.toastMessage.set(''), 3000);
   }
 }

--- a/src/app/features/projects/components/project-google-tasks-sync.component.ts
+++ b/src/app/features/projects/components/project-google-tasks-sync.component.ts
@@ -208,8 +208,6 @@ export class ProjectGoogleTasksSyncComponent implements OnInit {
         lastSyncDate,
       );
 
-      console.log(`Sync complete: ${result.added} added, ${result.updated} updated`);
-
       // Mark as synced and show result
       await this.projectService.updateProject(this.project().id, {
         syncStatus: 'synced',

--- a/src/app/features/projects/project-detail.component.ts
+++ b/src/app/features/projects/project-detail.component.ts
@@ -178,7 +178,6 @@ export class ProjectDetailComponent implements OnDestroy {
   // Event Handlers
   onProjectUpdated() {
     // Firestore subscription handles data updates
-    console.log('Project updated');
   }
 
   onProjectDeleted() {

--- a/src/app/features/projects/project-sidebar.component.ts
+++ b/src/app/features/projects/project-sidebar.component.ts
@@ -73,7 +73,6 @@ export class ProjectSidebarComponent {
     this.seeding.set(true);
     try {
       await this.seedService.seedSampleData();
-      console.log('Sample data loaded!');
     } catch (error) {
       console.error('Failed to load sample data:', error);
     } finally {

--- a/src/app/shared/components/custom-date-picker/custom-date-picker.component.ts
+++ b/src/app/shared/components/custom-date-picker/custom-date-picker.component.ts
@@ -180,7 +180,6 @@ export class CustomDatePickerComponent implements ControlValueAccessor {
           this.writeValue(val);
         }
       },
-      { allowSignalWrites: true },
     );
   }
 


### PR DESCRIPTION
## Summary

- **#124**: Remove deprecated \llowSignalWrites\ flag from \custom-date-picker\ (Angular no longer needs it)
- **#122**: Remove 13 \console.log\ debug calls across 7 files (\dashboard\, \project-sidebar\, \project-detail\, \project-google-tasks-sync\, \seed-data.service\, \google-tasks-sync.service\, \contacts.service\). All \console.error\/\console.warn\ in catch blocks kept for production debugging.
- **#118**: Wire demo board event handlers — quick-add creates in-memory tasks, add-section grows the board, task-click shows an inline toast. No more stub \console.log\ only.

## Verification

- [x] \
g build --configuration production\ — passes
- [x] \
g test --no-watch --browsers=ChromeHeadless\ — 340/340 passing

Closes #124
Closes #122
Closes #118

Made with [Cursor](https://cursor.com)