### PR TITLE
feat: add data export (CSV/JSON) and import for tasks

### DIFF
--- a/src/app/core/services/export-import.service.ts
+++ b/src/app/core/services/export-import.service.ts
@@ -1,0 +1,336 @@
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { Timestamp } from '@angular/fire/firestore';
+import { ProjectService } from './project.service';
+import { TaskService } from './task.service';
+import { Project, Task } from '../models/domain.model';
+
+export type ExportFormat = 'csv' | 'json';
+
+export interface ExportOptions {
+  format: ExportFormat;
+  projectId: string | 'all';
+  includeSubtasks: boolean;
+  includeCompleted: boolean;
+}
+
+interface CsvRow {
+  Title: string;
+  Description: string;
+  Status: string;
+  Priority: string;
+  Section: string;
+  'Due Date': string;
+  'Start Date': string;
+  Assignees: string;
+  Tags: string;
+  'Created At': string;
+  'Updated At': string;
+  'Completed At': string;
+  Project: string;
+  'Parent Task': string;
+}
+
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  errors: string[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class ExportImportService {
+  private readonly projectService = inject(ProjectService);
+  private readonly taskService = inject(TaskService);
+
+  async exportTasks(options: ExportOptions): Promise<{ data: string; filename: string }> {
+    const projects = await this.resolveProjects(options.projectId);
+    const allTasks: { task: Task; projectName: string; sectionName: string }[] = [];
+
+    for (const project of projects) {
+      const tasks = await this.taskService.getTasksByProjectOnce(project.id);
+      for (const task of tasks) {
+        if (!options.includeCompleted && task.status === 'done') continue;
+        if (!options.includeSubtasks && task.parentId) continue;
+
+        const section = project.sections.find((s) => s.id === task.sectionId);
+        allTasks.push({
+          task,
+          projectName: project.name,
+          sectionName: section?.name ?? '',
+        });
+      }
+    }
+
+    if (options.format === 'csv') {
+      return this.generateCsv(allTasks, projects);
+    }
+    return this.generateJson(allTasks, projects);
+  }
+
+  parseCsvForImport(csvText: string): Partial<Task>[] {
+    const lines = this.parseCsvLines(csvText);
+    if (lines.length < 2) return [];
+
+    const headers = lines[0];
+    const titleIdx = headers.findIndex((h) => h.toLowerCase() === 'title');
+    if (titleIdx === -1) return [];
+
+    const colMap = this.buildColumnMap(headers);
+    const tasks: Partial<Task>[] = [];
+
+    for (let i = 1; i < lines.length; i++) {
+      const row = lines[i];
+      if (row.length === 0 || (row.length === 1 && row[0] === '')) continue;
+
+      const title = row[titleIdx]?.trim();
+      if (!title) continue;
+
+      const task: Partial<Task> = {
+        title,
+        description: this.getCol(row, colMap, 'description') ?? '',
+        status: this.parseStatus(this.getCol(row, colMap, 'status')),
+        priority: this.parsePriority(this.getCol(row, colMap, 'priority')),
+        tags: this.parseTags(this.getCol(row, colMap, 'tags')),
+      };
+
+      const dueStr = this.getCol(row, colMap, 'due date') ?? this.getCol(row, colMap, 'duedate');
+      if (dueStr) {
+        const d = new Date(dueStr);
+        if (!isNaN(d.getTime())) task.dueDate = Timestamp.fromDate(d);
+      }
+
+      tasks.push(task);
+    }
+
+    return tasks;
+  }
+
+  parseJsonForImport(jsonText: string): { tasks: Partial<Task>[]; projects: Partial<Project>[] } {
+    const data = JSON.parse(jsonText);
+
+    if (data.version && data.tasks) {
+      return {
+        tasks: (data.tasks as Record<string, unknown>[]).map((t) => this.normalizeJsonTask(t)),
+        projects: data.projects ?? [],
+      };
+    }
+
+    if (Array.isArray(data)) {
+      return {
+        tasks: data.map((t: Record<string, unknown>) => this.normalizeJsonTask(t)),
+        projects: [],
+      };
+    }
+
+    return { tasks: [], projects: [] };
+  }
+
+  private async resolveProjects(projectId: string | 'all'): Promise<Project[]> {
+    if (projectId === 'all') {
+      return firstValueFrom(this.projectService.getMyProjects());
+    }
+    const project = await this.projectService.getProject(projectId);
+    return project ? [project] : [];
+  }
+
+  private generateCsv(
+    items: { task: Task; projectName: string; sectionName: string }[],
+    _projects: Project[],
+  ): { data: string; filename: string } {
+    const rows: CsvRow[] = items.map(({ task, projectName, sectionName }) => ({
+      Title: task.title,
+      Description: task.description ?? '',
+      Status: task.status,
+      Priority: task.priority,
+      Section: sectionName,
+      'Due Date': this.formatDate(task.dueDate),
+      'Start Date': this.formatDate(task.startDate),
+      Assignees: (task.assigneeNames ?? []).join('; '),
+      Tags: (task.tags ?? []).join('; '),
+      'Created At': this.formatDate(task.createdAt),
+      'Updated At': this.formatDate(task.updatedAt),
+      'Completed At': this.formatDate(task.completedAt),
+      Project: projectName,
+      'Parent Task': task.parentId ?? '',
+    }));
+
+    const headers = Object.keys(rows[0] ?? {}) as (keyof CsvRow)[];
+    const csvLines = [
+      headers.map((h) => this.escapeCsvField(h)).join(','),
+      ...rows.map((row) => headers.map((h) => this.escapeCsvField(String(row[h] ?? ''))).join(',')),
+    ];
+
+    const timestamp = new Date().toISOString().slice(0, 10);
+    return {
+      data: csvLines.join('\n'),
+      filename: `omnitask-export-${timestamp}.csv`,
+    };
+  }
+
+  private generateJson(
+    items: { task: Task; projectName: string; sectionName: string }[],
+    projects: Project[],
+  ): { data: string; filename: string } {
+    const exportData = {
+      version: '1.0',
+      exportedAt: new Date().toISOString(),
+      app: 'OmniTask',
+      projects: projects.map((p) => ({
+        id: p.id,
+        name: p.name,
+        description: p.description,
+        sections: p.sections,
+        tags: p.tags,
+        status: p.status,
+      })),
+      tasks: items.map(({ task, projectName, sectionName }) => ({
+        id: task.id,
+        title: task.title,
+        description: task.description,
+        status: task.status,
+        priority: task.priority,
+        section: sectionName,
+        project: projectName,
+        projectId: task.projectId,
+        sectionId: task.sectionId,
+        dueDate: this.formatDate(task.dueDate),
+        startDate: this.formatDate(task.startDate),
+        completedAt: this.formatDate(task.completedAt),
+        assigneeNames: task.assigneeNames ?? [],
+        tags: task.tags ?? [],
+        subtasks: task.subtasks ?? [],
+        parentId: task.parentId,
+        blockingIds: task.blockingIds ?? [],
+        blockedByIds: task.blockedByIds ?? [],
+        customFieldValues: task.customFieldValues ?? {},
+        pointValue: task.pointValue,
+        createdAt: this.formatDate(task.createdAt),
+        updatedAt: this.formatDate(task.updatedAt),
+      })),
+    };
+
+    const timestamp = new Date().toISOString().slice(0, 10);
+    return {
+      data: JSON.stringify(exportData, null, 2),
+      filename: `omnitask-export-${timestamp}.json`,
+    };
+  }
+
+  private formatDate(value: unknown): string {
+    if (!value) return '';
+    if (value instanceof Timestamp) return value.toDate().toISOString();
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === 'string') return value;
+    return '';
+  }
+
+  private escapeCsvField(field: string): string {
+    if (field.includes(',') || field.includes('"') || field.includes('\n')) {
+      return `"${field.replace(/"/g, '""')}"`;
+    }
+    return field;
+  }
+
+  private parseCsvLines(csv: string): string[][] {
+    const lines: string[][] = [];
+    let current: string[] = [];
+    let field = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < csv.length; i++) {
+      const char = csv[i];
+      const next = csv[i + 1];
+
+      if (inQuotes) {
+        if (char === '"' && next === '"') {
+          field += '"';
+          i++;
+        } else if (char === '"') {
+          inQuotes = false;
+        } else {
+          field += char;
+        }
+      } else {
+        if (char === '"') {
+          inQuotes = true;
+        } else if (char === ',') {
+          current.push(field);
+          field = '';
+        } else if (char === '\n' || (char === '\r' && next === '\n')) {
+          current.push(field);
+          field = '';
+          lines.push(current);
+          current = [];
+          if (char === '\r') i++;
+        } else {
+          field += char;
+        }
+      }
+    }
+
+    if (field || current.length > 0) {
+      current.push(field);
+      lines.push(current);
+    }
+
+    return lines;
+  }
+
+  private buildColumnMap(headers: string[]): Map<string, number> {
+    const map = new Map<string, number>();
+    headers.forEach((h, i) => map.set(h.toLowerCase().trim(), i));
+    return map;
+  }
+
+  private getCol(row: string[], colMap: Map<string, number>, key: string): string | undefined {
+    const idx = colMap.get(key);
+    if (idx === undefined) return undefined;
+    return row[idx]?.trim();
+  }
+
+  private parseStatus(val: string | undefined): Task['status'] {
+    if (!val) return 'todo';
+    const lower = val.toLowerCase().trim();
+    if (lower === 'done' || lower === 'completed' || lower === 'complete') return 'done';
+    if (lower === 'in-progress' || lower === 'in progress' || lower === 'active') return 'in-progress';
+    return 'todo';
+  }
+
+  private parsePriority(val: string | undefined): Task['priority'] {
+    if (!val) return 'medium';
+    const lower = val.toLowerCase().trim();
+    if (lower === 'high' || lower === 'urgent' || lower === 'critical') return 'high';
+    if (lower === 'low' || lower === 'minor') return 'low';
+    return 'medium';
+  }
+
+  private parseTags(val: string | undefined): string[] {
+    if (!val) return [];
+    return val
+      .split(/[;,]/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
+  private normalizeJsonTask(t: Record<string, unknown>): Partial<Task> {
+    return {
+      title: (t['title'] as string) ?? '',
+      description: (t['description'] as string) ?? '',
+      status: this.parseStatus(t['status'] as string),
+      priority: this.parsePriority(t['priority'] as string),
+      tags: Array.isArray(t['tags']) ? t['tags'] : [],
+    };
+  }
+
+  downloadFile(data: string, filename: string, mimeType: string): void {
+    const blob = new Blob([data], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/app/features/settings/data-export-import.component.html
+++ b/src/app/features/settings/data-export-import.component.html
@@ -1,0 +1,215 @@
+<div class="space-y-8">
+  <!-- Feedback -->
+  @if (feedback(); as fb) {
+    <div
+      class="flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium"
+      [class]="fb.type === 'success'
+        ? 'bg-emerald-500/10 border border-emerald-500/30 text-emerald-400'
+        : 'bg-rose-500/10 border border-rose-500/30 text-rose-400'"
+    >
+      @if (fb.type === 'success') {
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+        </svg>
+      } @else {
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+        </svg>
+      }
+      {{ fb.message }}
+    </div>
+  }
+
+  <!-- Export Section -->
+  <div>
+    <h3 class="text-base font-semibold text-white mb-4 flex items-center gap-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-cyan-400" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+      </svg>
+      Export Tasks
+    </h3>
+
+    <div class="grid gap-4 sm:grid-cols-2">
+      <!-- Format -->
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">Format</label>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            (click)="exportFormat.set('csv')"
+            class="flex-1 px-3 py-2 rounded-lg border text-sm font-medium transition-all"
+            [class]="exportFormat() === 'csv'
+              ? 'border-cyan-500/60 bg-cyan-500/10 text-cyan-300 shadow-[0_0_8px_rgba(6,182,212,0.2)]'
+              : 'border-white/10 bg-slate-950/50 text-slate-400 hover:border-white/20'"
+          >
+            CSV
+          </button>
+          <button
+            type="button"
+            (click)="exportFormat.set('json')"
+            class="flex-1 px-3 py-2 rounded-lg border text-sm font-medium transition-all"
+            [class]="exportFormat() === 'json'
+              ? 'border-cyan-500/60 bg-cyan-500/10 text-cyan-300 shadow-[0_0_8px_rgba(6,182,212,0.2)]'
+              : 'border-white/10 bg-slate-950/50 text-slate-400 hover:border-white/20'"
+          >
+            JSON
+          </button>
+        </div>
+      </div>
+
+      <!-- Project -->
+      <div>
+        <label class="block text-xs font-medium text-slate-400 mb-1.5">Project</label>
+        <select
+          class="w-full bg-slate-950/50 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors"
+          [ngModel]="selectedProjectId()"
+          (ngModelChange)="selectedProjectId.set($event)"
+        >
+          <option value="all">All projects</option>
+          @for (project of projects(); track project.id) {
+            <option [value]="project.id">{{ project.name }}</option>
+          }
+        </select>
+      </div>
+    </div>
+
+    <!-- Options -->
+    <div class="flex flex-wrap gap-x-6 gap-y-2 mt-4">
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          class="h-3.5 w-3.5 rounded border-white/20 bg-slate-950 text-purple-600 focus:ring-purple-500"
+          [ngModel]="includeSubtasks()"
+          (ngModelChange)="includeSubtasks.set($event)"
+        />
+        <span class="text-xs text-slate-300">Include subtasks</span>
+      </label>
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          class="h-3.5 w-3.5 rounded border-white/20 bg-slate-950 text-purple-600 focus:ring-purple-500"
+          [ngModel]="includeCompleted()"
+          (ngModelChange)="includeCompleted.set($event)"
+        />
+        <span class="text-xs text-slate-300">Include completed tasks</span>
+      </label>
+    </div>
+
+    <button
+      type="button"
+      (click)="onExport()"
+      [disabled]="exporting() || loading()"
+      class="mt-4 omni-glitch-btn inline-flex items-center gap-2 px-5 py-2 rounded-lg border border-cyan-500/40 bg-cyan-500/10 text-cyan-300 text-sm font-semibold hover:bg-cyan-500/20 hover:shadow-[0_0_12px_rgba(0,210,255,0.5)] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      @if (exporting()) {
+        <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+        Exporting...
+      } @else {
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+        Download {{ exportFormat() === 'csv' ? 'CSV' : 'JSON' }}
+      }
+    </button>
+  </div>
+
+  <!-- Divider -->
+  <div class="border-t border-white/5"></div>
+
+  <!-- Import Section -->
+  <div>
+    <h3 class="text-base font-semibold text-white mb-4 flex items-center gap-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-purple-400" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM6.293 6.707a1 1 0 010-1.414l3-3a1 1 0 011.414 0l3 3a1 1 0 01-1.414 1.414L11 5.414V13a1 1 0 11-2 0V5.414L7.707 6.707a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+      </svg>
+      Import Tasks
+    </h3>
+
+    <!-- Target project -->
+    <div class="mb-4">
+      <label class="block text-xs font-medium text-slate-400 mb-1.5">Import into project</label>
+      <select
+        class="w-full sm:w-64 bg-slate-950/50 border border-white/10 rounded-lg px-3 py-2 text-sm text-white focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors"
+        [ngModel]="importProjectId()"
+        (ngModelChange)="importProjectId.set($event)"
+      >
+        @for (project of projects(); track project.id) {
+          <option [value]="project.id">{{ project.name }}</option>
+        }
+      </select>
+    </div>
+
+    <!-- File upload -->
+    @if (!importFile()) {
+      <label
+        class="flex flex-col items-center justify-center w-full h-32 rounded-xl border-2 border-dashed border-white/10 bg-slate-950/30 cursor-pointer hover:border-purple-500/40 hover:bg-purple-500/5 transition-all group"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-slate-500 group-hover:text-purple-400 transition-colors mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+        </svg>
+        <span class="text-sm text-slate-400 group-hover:text-slate-300 transition-colors">
+          Drop a <strong class="text-slate-200">CSV</strong> or <strong class="text-slate-200">JSON</strong> file here, or click to browse
+        </span>
+        <input type="file" accept=".csv,.json" class="hidden" (change)="onFileSelected($event)" />
+      </label>
+    } @else {
+      <!-- Preview -->
+      <div class="rounded-xl border border-white/10 bg-slate-950/40 p-4">
+        <div class="flex items-center justify-between mb-3">
+          <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-emerald-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd" />
+            </svg>
+            <span class="text-sm text-white font-medium">{{ importFile()!.name }}</span>
+          </div>
+          <button
+            type="button"
+            (click)="clearImport()"
+            class="text-xs text-slate-400 hover:text-rose-400 transition-colors"
+          >
+            Remove
+          </button>
+        </div>
+
+        @if (importPreview(); as preview) {
+          <p class="text-xs text-slate-400 mb-2">{{ preview.count }} tasks found</p>
+          <div class="space-y-1">
+            @for (title of preview.sample; track $index) {
+              <div class="text-xs text-slate-300 truncate flex items-center gap-1.5">
+                <span class="w-1.5 h-1.5 rounded-full bg-purple-400 flex-shrink-0"></span>
+                {{ title }}
+              </div>
+            }
+            @if (preview.count > 5) {
+              <p class="text-xs text-slate-500 pl-3">...and {{ preview.count - 5 }} more</p>
+            }
+          </div>
+        }
+
+        <button
+          type="button"
+          (click)="onImport()"
+          [disabled]="importing() || !importProjectId()"
+          class="mt-4 omni-glitch-btn inline-flex items-center gap-2 px-5 py-2 rounded-lg bg-purple-600 hover:bg-purple-700 text-white text-sm font-semibold transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-[0_0_14px_rgba(139,92,246,0.5)]"
+        >
+          @if (importing()) {
+            <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+            </svg>
+            Importing...
+          } @else {
+            Import {{ importPreview()?.count ?? 0 }} tasks
+          }
+        </button>
+      </div>
+    }
+
+    <p class="mt-3 text-xs text-slate-500">
+      Supported formats: OmniTask JSON export, CSV with a "Title" column. Tasks are created in the selected project with their original status and priority.
+    </p>
+  </div>
+</div>

--- a/src/app/features/settings/data-export-import.component.ts
+++ b/src/app/features/settings/data-export-import.component.ts
@@ -1,0 +1,178 @@
+import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+import { ProjectService } from '../../core/services/project.service';
+import { TaskService } from '../../core/services/task.service';
+import {
+  ExportImportService,
+  ExportFormat,
+  ExportOptions,
+} from '../../core/services/export-import.service';
+import { Project } from '../../core/models/domain.model';
+
+@Component({
+  selector: 'app-data-export-import',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './data-export-import.component.html',
+})
+export class DataExportImportComponent {
+  private readonly exportImportService = inject(ExportImportService);
+  private readonly projectService = inject(ProjectService);
+  private readonly taskService = inject(TaskService);
+
+  projects = signal<Project[]>([]);
+  loading = signal(false);
+  exporting = signal(false);
+  importing = signal(false);
+  feedback = signal<{ message: string; type: 'success' | 'error' } | null>(null);
+
+  exportFormat = signal<ExportFormat>('csv');
+  selectedProjectId = signal<string>('all');
+  includeSubtasks = signal(true);
+  includeCompleted = signal(true);
+
+  importFile = signal<File | null>(null);
+  importProjectId = signal<string>('');
+  importPreview = signal<{ count: number; sample: string[] } | null>(null);
+
+  constructor() {
+    this.loadProjects();
+  }
+
+  private async loadProjects(): Promise<void> {
+    this.loading.set(true);
+    try {
+      const projects = await firstValueFrom(this.projectService.getMyProjects());
+      this.projects.set(projects);
+      if (projects.length > 0 && !this.importProjectId()) {
+        this.importProjectId.set(projects[0].id);
+      }
+    } catch {
+      this.showFeedback('Failed to load projects', 'error');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async onExport(): Promise<void> {
+    this.exporting.set(true);
+    try {
+      const options: ExportOptions = {
+        format: this.exportFormat(),
+        projectId: this.selectedProjectId(),
+        includeSubtasks: this.includeSubtasks(),
+        includeCompleted: this.includeCompleted(),
+      };
+
+      const { data, filename } = await this.exportImportService.exportTasks(options);
+      const mimeType = options.format === 'csv' ? 'text/csv' : 'application/json';
+      this.exportImportService.downloadFile(data, filename, mimeType);
+      this.showFeedback('Export downloaded successfully', 'success');
+    } catch (err) {
+      console.error('Export failed:', err);
+      this.showFeedback('Export failed. Please try again.', 'error');
+    } finally {
+      this.exporting.set(false);
+    }
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+
+    const validTypes = ['.csv', '.json'];
+    const ext = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
+    if (!validTypes.includes(ext)) {
+      this.showFeedback('Please select a CSV or JSON file', 'error');
+      input.value = '';
+      return;
+    }
+
+    this.importFile.set(file);
+    this.previewImport(file);
+  }
+
+  private async previewImport(file: File): Promise<void> {
+    const text = await file.text();
+    const ext = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
+
+    try {
+      if (ext === '.csv') {
+        const tasks = this.exportImportService.parseCsvForImport(text);
+        this.importPreview.set({
+          count: tasks.length,
+          sample: tasks.slice(0, 5).map((t) => t.title ?? '(untitled)'),
+        });
+      } else {
+        const { tasks } = this.exportImportService.parseJsonForImport(text);
+        this.importPreview.set({
+          count: tasks.length,
+          sample: tasks.slice(0, 5).map((t) => t.title ?? '(untitled)'),
+        });
+      }
+    } catch {
+      this.importPreview.set(null);
+      this.showFeedback('Could not parse file. Check the format.', 'error');
+    }
+  }
+
+  async onImport(): Promise<void> {
+    const file = this.importFile();
+    const projectId = this.importProjectId();
+    if (!file || !projectId) return;
+
+    this.importing.set(true);
+    try {
+      const text = await file.text();
+      const ext = file.name.substring(file.name.lastIndexOf('.')).toLowerCase();
+
+      let tasks: ReturnType<typeof this.exportImportService.parseCsvForImport>;
+      if (ext === '.csv') {
+        tasks = this.exportImportService.parseCsvForImport(text);
+      } else {
+        const result = this.exportImportService.parseJsonForImport(text);
+        tasks = result.tasks;
+      }
+
+      let imported = 0;
+      const existingTasks = await this.taskService.getTasksByProjectOnce(projectId);
+      const nextOrder = existingTasks.length;
+
+      for (const task of tasks) {
+        await this.taskService.createTask({
+          title: task.title ?? 'Untitled',
+          projectId,
+          order: nextOrder + imported,
+          description: task.description ?? '',
+          status: task.status ?? 'todo',
+          priority: task.priority ?? 'medium',
+          tags: task.tags ?? [],
+        } as Parameters<typeof this.taskService.createTask>[0]);
+        imported++;
+      }
+
+      this.showFeedback(`Imported ${imported} tasks successfully`, 'success');
+      this.importFile.set(null);
+      this.importPreview.set(null);
+    } catch (err) {
+      console.error('Import failed:', err);
+      this.showFeedback('Import failed. Please check the file format.', 'error');
+    } finally {
+      this.importing.set(false);
+    }
+  }
+
+  clearImport(): void {
+    this.importFile.set(null);
+    this.importPreview.set(null);
+  }
+
+  private showFeedback(message: string, type: 'success' | 'error'): void {
+    this.feedback.set({ message, type });
+    setTimeout(() => this.feedback.set(null), 4000);
+  }
+}

--- a/src/app/features/settings/settings.component.html
+++ b/src/app/features/settings/settings.component.html
@@ -219,10 +219,19 @@
             anywhere in the app for keyboard shortcuts (<kbd class="text-xs text-cyan-200 px-1 py-0.5 rounded bg-slate-800 border border-white/10">Ctrl+K</kbd>
             focuses task search on a project board).
           </p>
-          <p class="mt-2 text-sm text-slate-400">
-            Export project tasks from each project's <strong class="text-slate-200">Settings</strong> tab (CSV/JSON).
-          </p>
           <p class="mt-3 text-xs text-slate-500">Save profile above to persist notification preference.</p>
+        </section>
+
+        <!-- Data Export / Import -->
+        <section class="bg-slate-900/50 border border-white/10 rounded-2xl p-6 mb-6">
+          <h2 class="text-lg font-semibold text-white mb-6 flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-cyan-400" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4z" />
+              <path fill-rule="evenodd" d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z" clip-rule="evenodd" />
+            </svg>
+            <span>Data Portability</span>
+          </h2>
+          <app-data-export-import />
         </section>
 
         <!-- Account Info -->

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -12,6 +12,7 @@ import { RouterLink } from '@angular/router';
 import { AuthService } from '../../core/auth/auth.service';
 import { Storage, ref, uploadBytes, getDownloadURL, deleteObject } from '@angular/fire/storage';
 import { UserGroupManagerComponent } from '../user-groups/user-group-manager.component';
+import { DataExportImportComponent } from './data-export-import.component';
 
 const AVATAR_COLORS = [
   { name: 'Purple', value: '#8b5cf6' },
@@ -30,7 +31,7 @@ const AVATAR_COLORS = [
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'app-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink, UserGroupManagerComponent],
+  imports: [CommonModule, FormsModule, RouterLink, UserGroupManagerComponent, DataExportImportComponent],
   templateUrl: './settings.component.html',
 })
 export class SettingsComponent {


### PR DESCRIPTION
## Summary
- Adds **ExportImportService** with CSV and JSON export/import support
- **Export**: download tasks as CSV (spreadsheet-friendly) or JSON (full-fidelity backup) with options for project filtering, subtask inclusion, and completed task filtering
- **Import**: upload CSV or JSON files with preview, status/priority normalization, and Asana-format compatibility
- **UI**: Data Portability section added to Settings page with format picker, project selector, drag-and-drop file upload, and task preview before import
- JSON export uses a versioned format (v1.0) including project metadata for round-trip fidelity

Closes #133

## Test plan
- [x] Production build passes
- [ ] Export CSV for a single project - verify columns and data
- [ ] Export JSON for all projects - verify structure
- [ ] Import CSV with Title/Status/Priority columns
- [ ] Import OmniTask JSON export back into a different project
- [ ] Verify imported tasks appear in project board
