### PR TITLE
Fix project icon upload failing with storage/unauthorized (403)

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -2,12 +2,18 @@ rules_version = '2';
 
 // Firebase Storage security rules for OmniTask.
 //
-// Writable paths require an authenticated caller plus image content-type and
-// size validation; the user folder additionally requires the caller to own it.
-// Reads are kept open to any signed-in user so download URLs work across the
-// app (icons, avatars, attachments are surfaced to anyone who can already see
-// the parent document anyway, and Firestore rules gate the documents
-// themselves).
+// We scope every writable path to the authenticated caller (their own user
+// folder) or to projects they belong to. Reads are kept open to any signed-in
+// user so download URLs work across the app (icons, avatars, attachments are
+// surfaced to anyone who can already see the parent document anyway, and
+// Firestore rules gate the documents themselves).
+//
+// NOTE: `isProjectMember` performs a cross-service Firestore read. This
+// requires the Firebase Storage Service Agent
+// (`service-{PROJECT_NUMBER}@gcp-sa-firebasestorage.iam.gserviceaccount.com`)
+// to hold `roles/datastore.viewer` on the project. Without that IAM grant
+// every project-scoped write/delete fails as `storage/unauthorized` (403)
+// even for the project owner.
 service firebase.storage {
   match /b/{bucket}/o {
 
@@ -24,6 +30,21 @@ service firebase.storage {
       return request.resource.size < 4 * 1024 * 1024;
     }
 
+    // Membership of a project is authoritative in Firestore — only members
+    // (or the owner) may read/write that project's storage tree.
+    function isProjectMember(projectId) {
+      return isSignedIn() &&
+        firestore.exists(/databases/(default)/documents/projects/$(projectId)) &&
+        (
+          request.auth.uid == firestore.get(
+            /databases/(default)/documents/projects/$(projectId)
+          ).data.ownerId ||
+          request.auth.uid in firestore.get(
+            /databases/(default)/documents/projects/$(projectId)
+          ).data.memberIds
+        );
+    }
+
     // User-owned uploads (avatars, personal attachments).
     match /users/{userId}/{allPaths=**} {
       allow read: if isSignedIn();
@@ -34,24 +55,11 @@ service firebase.storage {
       allow delete: if isSignedIn() && request.auth.uid == userId;
     }
 
-    // Project icons and cover images.
-    //
-    // We intentionally authorize on `isSignedIn()` alone (plus image + size
-    // validation) rather than doing a cross-service firestore.get() into the
-    // project document to check ownerId/memberIds. Cross-service Storage ->
-    // Firestore rule reads were the cause of icon uploads failing with
-    // `storage/unauthorized` (403) even for the project owner — see the
-    // regression where this path was the only one using a cross-service read
-    // and the only one failing. Reads here are already open to every signed-in
-    // user, and the project documents themselves remain gated by Firestore
-    // rules, so this matches the app's existing access posture for an internal
-    // team tool. If membership-scoped writes are needed later, enforce them
-    // server-side (callable Function / signed upload token), not via a
-    // cross-service rule.
+    // Project icons and cover images, scoped to project membership.
     match /projects/{projectId}/{allPaths=**} {
       allow read: if isSignedIn();
-      allow write: if isSignedIn() && isImage() && withinSizeLimit();
-      allow delete: if isSignedIn();
+      allow write: if isProjectMember(projectId) && isImage() && withinSizeLimit();
+      allow delete: if isProjectMember(projectId);
     }
 
     // Default deny — anything outside the namespaces above is rejected.

--- a/storage.rules
+++ b/storage.rules
@@ -2,11 +2,12 @@ rules_version = '2';
 
 // Firebase Storage security rules for OmniTask.
 //
-// We scope every writable path to the authenticated caller (their own user
-// folder) or to projects they belong to. Reads are kept open to any signed-in
-// user so download URLs work across the app (icons, avatars, attachments are
-// surfaced to anyone who can already see the parent document anyway, and
-// Firestore rules gate the documents themselves).
+// Writable paths require an authenticated caller plus image content-type and
+// size validation; the user folder additionally requires the caller to own it.
+// Reads are kept open to any signed-in user so download URLs work across the
+// app (icons, avatars, attachments are surfaced to anyone who can already see
+// the parent document anyway, and Firestore rules gate the documents
+// themselves).
 service firebase.storage {
   match /b/{bucket}/o {
 
@@ -23,21 +24,6 @@ service firebase.storage {
       return request.resource.size < 4 * 1024 * 1024;
     }
 
-    // Membership of a project is authoritative in Firestore — only members
-    // (or the owner) may read/write that project's storage tree.
-    function isProjectMember(projectId) {
-      return isSignedIn() &&
-        firestore.exists(/databases/(default)/documents/projects/$(projectId)) &&
-        (
-          request.auth.uid == firestore.get(
-            /databases/(default)/documents/projects/$(projectId)
-          ).data.ownerId ||
-          request.auth.uid in firestore.get(
-            /databases/(default)/documents/projects/$(projectId)
-          ).data.memberIds
-        );
-    }
-
     // User-owned uploads (avatars, personal attachments).
     match /users/{userId}/{allPaths=**} {
       allow read: if isSignedIn();
@@ -48,11 +34,24 @@ service firebase.storage {
       allow delete: if isSignedIn() && request.auth.uid == userId;
     }
 
-    // Project icons and cover images, scoped to project membership.
+    // Project icons and cover images.
+    //
+    // We intentionally authorize on `isSignedIn()` alone (plus image + size
+    // validation) rather than doing a cross-service firestore.get() into the
+    // project document to check ownerId/memberIds. Cross-service Storage ->
+    // Firestore rule reads were the cause of icon uploads failing with
+    // `storage/unauthorized` (403) even for the project owner — see the
+    // regression where this path was the only one using a cross-service read
+    // and the only one failing. Reads here are already open to every signed-in
+    // user, and the project documents themselves remain gated by Firestore
+    // rules, so this matches the app's existing access posture for an internal
+    // team tool. If membership-scoped writes are needed later, enforce them
+    // server-side (callable Function / signed upload token), not via a
+    // cross-service rule.
     match /projects/{projectId}/{allPaths=**} {
       allow read: if isSignedIn();
-      allow write: if isProjectMember(projectId) && isImage() && withinSizeLimit();
-      allow delete: if isProjectMember(projectId);
+      allow write: if isSignedIn() && isImage() && withinSizeLimit();
+      allow delete: if isSignedIn();
     }
 
     // Default deny — anything outside the namespaces above is rejected.


### PR DESCRIPTION
## What

Fixes project icon uploads failing with `storage/unauthorized` (403) in the Create/Edit Project modal.

Closes #171.

## Root cause

The Firebase Storage Service Agent
(`service-172130002005@gcp-sa-firebasestorage.iam.gserviceaccount.com`) was missing
`roles/datastore.viewer`. Without that role, the cross-service `firestore.get()` /
`firestore.exists()` calls inside `isProjectMember` fail server-side and surface to
the client as `storage/unauthorized` (403) -- even for the project owner.

Confirmed via `gcloud projects get-iam-policy omnitask-475422` filtering on the
storage service agent: only `roles/firebasestorage.serviceAgent` was bound; no
Firestore read access.

This is the documented fragile point of cross-service Storage -> Firestore rules,
and matches the failure pattern Gemini and omnigemini flagged in review.

## Change

`storage.rules`: restored `isProjectMember` and the membership-scoped writes/
deletes on `projects/{projectId}/**`. Added a NOTE in the header comment block
documenting the IAM grant the rule depends on, so this can't silently regress.

The previous revision of this PR relaxed writes to `isSignedIn()` only, which
three reviewers (Gemini critical, omnigemini high, Codex P2) correctly flagged
as IDOR / Broken Object Level Authorization. That approach is abandoned.

## Required deploy steps (do both, in order)

1. Grant the service agent Firestore read access (one-time IAM change):
   ```
   gcloud projects add-iam-policy-binding omnitask-475422 \
     --member="serviceAccount:service-172130002005@gcp-sa-firebasestorage.iam.gserviceaccount.com" \
     --role="roles/datastore.viewer"
   ```
2. Deploy the rules:
   ```
   firebase deploy --only storage
   ```

Without step 1, step 2 will re-reproduce the 403. Without step 2, the rules in
the repo are not live.

## Notes on CI

The currently failing `Validate PR Build` check is a flake in
`project-google-tasks-sync.component.spec.ts` (`enableScheduledSync should
request offline access and show success message`). It is unrelated to this
rules-only change and predates this PR. Tracking separately.