### PR TITLE
fix(test): repair deterministically-failing enableScheduledSync spec (#173)

### DIFF
--- a/src/app/features/projects/components/project-google-tasks-sync.component.spec.ts
+++ b/src/app/features/projects/components/project-google-tasks-sync.component.spec.ts
@@ -229,7 +229,7 @@ describe('ProjectGoogleTasksSyncComponent', () => {
   });
 
   describe('enableScheduledSync', () => {
-    it('should request offline access and not surface a result until the OAuth callback returns', async () => {
+    it('should not surface a result until the OAuth callback returns', async () => {
       // requestOfflineAccess redirects the browser to Google's consent screen;
       // success is only shown after the OAuth callback returns to the app, so the
       // synchronous path must not set lastSyncResult (regression guard for #173).

--- a/src/app/features/projects/components/project-google-tasks-sync.component.spec.ts
+++ b/src/app/features/projects/components/project-google-tasks-sync.component.spec.ts
@@ -229,11 +229,15 @@ describe('ProjectGoogleTasksSyncComponent', () => {
   });
 
   describe('enableScheduledSync', () => {
-    it('should request offline access and show success message', async () => {
+    it('should request offline access and not surface a result until the OAuth callback returns', async () => {
+      // requestOfflineAccess redirects the browser to Google's consent screen;
+      // success is only shown after the OAuth callback returns to the app, so the
+      // synchronous path must not set lastSyncResult (regression guard for #173).
       await component.enableScheduledSync();
 
       expect(mockAuthService.requestOfflineAccess).toHaveBeenCalled();
-      expect(component.lastSyncResult()?.success).toBeTrue();
+      expect(component.lastSyncResult()).toBeNull();
+      expect(component.enablingScheduledSync()).toBeTrue();
     });
 
     it('should handle offline access errors', async () => {


### PR DESCRIPTION
## Summary

Fixes the `Validate PR Build` failure that has shown red on **every** PR against `live` since PR #170 — including unrelated changes. Root cause is a **stale unit test**, not a product bug.

`ProjectGoogleTasksSyncComponent.enableScheduledSync()` was changed in #170 to a **redirect-based** OAuth flow: it calls `authService.requestOfflineAccess(this.router.url)`, which redirects the browser to Google's consent screen. Success is surfaced only **after** the OAuth callback returns to the app, so the synchronous path intentionally does **not** set `lastSyncResult`.

The unit test was never updated and still asserted `component.lastSyncResult()?.success` is `true` on the success path — which is now `undefined`, producing `Expected undefined to be true` on every run. Suite size 348, exactly 1 failing assertion, deterministic — matching #173.

## Fix

Update the test to assert the actual (correct) redirect behavior:
- `requestOfflineAccess` is called
- no premature result is shown (`lastSyncResult()` stays `null`)
- the in-progress flag (`enablingScheduledSync()`) stays set while the redirect is pending

The sibling error-path test already correctly covered the `catch` branch and is unchanged. The revised test now acts as a regression guard so a premature success message can't sneak back in. A follow-up commit shortens the test description to satisfy the repo's 100-char line limit (review feedback).

## Verification

> Note: this PR was prepared in a remote container **without a browser**, so the karma/ChromeHeadless suite cannot be executed locally — `ng test` aborts before running any spec (no Chrome binary). I did **not** run the suite locally; the authoritative confirmation is the **`Validate PR Build`** check on this PR.

What I verified locally (browser-free):
- **Type-check:** `tsc -p tsconfig.spec.json --noEmit` → 0 errors.
- **Lint:** `ng lint` → 0 errors.
- **Logic:** the test's `requestOfflineAccess` mock resolves (no throw), so the `catch` branch is not taken → `lastSyncResult()` stays `null`, `enablingScheduledSync()` stays `true`, and `requestOfflineAccess` is called — all three new assertions hold.

Diff is a single file: `project-google-tasks-sync.component.spec.ts` (no production code touched).

## Out of scope (noted, not changed)

While reading the component I noticed dead/duplicated signals in `project-google-tasks-sync.component.ts` (`enablingScheduledSync2`, `lastSyncResult2`, and a `// wait this doesn't look right` comment) that are unreferenced by the template. Left untouched to keep this PR tightly scoped to the CI fix; worth a separate cleanup.

Closes #173

https://claude.ai/code/session_0123jj7TB5fXGtxAyEuSg4kf