### PR TITLE
fix: resolve issues #173-#178 and #91 (a11y, DS, voice, CI)

### DIFF
--- a/docs/runbooks/configure-firebase-smtp-secrets.md
+++ b/docs/runbooks/configure-firebase-smtp-secrets.md
@@ -11,12 +11,13 @@ The `firestore-send-email` extension is wired in `extensions/firestore-send-emai
 
 ## Steps
 
-1. Generate a Google App Password for the `omnitask@omniflexfitness.com` alias via the `bertin.kenol@omniflexfitness.com` account.
+1. Generate a Google App Password for the `omnitask@omniflexfitness.com` alias via a Workspace admin account (currently `bertin.kenol@omniflexfitness.com`).
 2. Open [Secret Manager](https://console.cloud.google.com/security/secret-manager?project=omnitask-475422).
-3. Update `EXT_MAIL_SMTP_CONNECTION_URI` to:
+3. Update `EXT_MAIL_SMTP_CONNECTION_URI` in Secret Manager (not the committed `.env` file) to the account that owns the App Password:
    ```
    smtps://bertin.kenol%40omniflexfitness.com@smtp.gmail.com:465
    ```
+   Keep `DEFAULT_FROM` as `OmniTask <omnitask@omniflexfitness.com>` — the SMTP username is for authentication only.
 4. Update `EXT_MAIL_SMTP_PASSWORD` with the 16-character App Password.
 5. Deploy extensions:
    ```bash

--- a/docs/runbooks/configure-firebase-smtp-secrets.md
+++ b/docs/runbooks/configure-firebase-smtp-secrets.md
@@ -1,0 +1,39 @@
+# Configure Firebase SMTP Secrets
+
+Runbook for [issue #91](https://github.com/OmniFlexFitness/OmniTask/issues/91).
+
+The `firestore-send-email` extension is wired in `extensions/firestore-send-email.env`. Extension env files and Secret Manager IAM are already in the repo. The remaining step is injecting live credentials in Google Cloud.
+
+## Prerequisites
+
+- Access to `bertin.kenol@omniflexfitness.com` Google Workspace (App Password generation)
+- Editor access to GCP project `omnitask-475422`
+
+## Steps
+
+1. Generate a Google App Password for the `omnitask@omniflexfitness.com` alias via the `bertin.kenol@omniflexfitness.com` account.
+2. Open [Secret Manager](https://console.cloud.google.com/security/secret-manager?project=omnitask-475422).
+3. Update `EXT_MAIL_SMTP_CONNECTION_URI` to:
+   ```
+   smtps://bertin.kenol%40omniflexfitness.com@smtp.gmail.com:465
+   ```
+4. Update `EXT_MAIL_SMTP_PASSWORD` with the 16-character App Password.
+5. Deploy extensions:
+   ```bash
+   npx firebase-tools deploy --only extensions
+   ```
+   Or trigger the GitHub Actions deploy workflow on `live`.
+
+## Verification
+
+- Add a document to the `mail` collection (or trigger a notification flow) and confirm delivery.
+- Check Cloud Functions logs for the `firestore-send-email` extension if send fails.
+
+## Repo config reference
+
+| Setting | Value |
+|---------|-------|
+| Extension env | `extensions/firestore-send-email.env` |
+| From address | `OmniTask <omnitask@omniflexfitness.com>` |
+| Mail collection | `mail` |
+| Firebase project | `omnitask-475422` |

--- a/extensions/firestore-send-email.env
+++ b/extensions/firestore-send-email.env
@@ -1,6 +1,6 @@
 LOCATION=us-east1
 DATABASE_REGION=nam5
-SMTP_CONNECTION_URI=smtps://bertin.kenol%40omniflexfitness.com@smtp.gmail.com:465
+SMTP_CONNECTION_URI=smtps://omnitask%40omniflexfitness.com@smtp.gmail.com:465
 SMTP_PASSWORD=projects/${PROJECT_NUMBER}/secrets/EXT_MAIL_SMTP_PASSWORD/versions/4
 MAIL_COLLECTION=mail
 DEFAULT_FROM=OmniTask <omnitask@omniflexfitness.com>

--- a/extensions/firestore-send-email.env
+++ b/extensions/firestore-send-email.env
@@ -1,6 +1,6 @@
 LOCATION=us-east1
 DATABASE_REGION=nam5
-SMTP_CONNECTION_URI=smtps://omnitask%40omniflexfitness.com@smtp.gmail.com:465
+SMTP_CONNECTION_URI=smtps://bertin.kenol%40omniflexfitness.com@smtp.gmail.com:465
 SMTP_PASSWORD=projects/${PROJECT_NUMBER}/secrets/EXT_MAIL_SMTP_PASSWORD/versions/4
 MAIL_COLLECTION=mail
 DEFAULT_FROM=OmniTask <omnitask@omniflexfitness.com>

--- a/src/app/core/auth/login.component.css
+++ b/src/app/core/auth/login.component.css
@@ -140,10 +140,9 @@
   align-items: center;
   gap: 0.5rem;
   border: 1px solid rgba(6, 182, 212, 0.4);
-  background: rgba(8, 51, 68, 0.4);
+  background: var(--of-color-bg-surface, rgba(10, 15, 30, 0.92));
   padding: 0.35rem 1rem;
-  border-radius: 9999px;
-  backdrop-filter: blur(12px);
+  border-radius: var(--of-radius-pill, 9999px);
   margin-bottom: 0.6rem;
   box-shadow: 0 0 14px rgba(0, 210, 255, 0.2);
 }
@@ -335,11 +334,10 @@
 
 .card-inner {
   position: relative;
-  background: rgba(10, 15, 30, 0.9);
-  backdrop-filter: blur(24px);
+  background: var(--of-color-bg-surface, rgba(10, 15, 30, 0.92));
   border: 1px solid rgba(6, 182, 212, 0.3);
   padding: 2rem;
-  border-radius: 1rem;
+  border-radius: var(--of-radius-lg, 1rem);
   box-shadow:
     0 0 50px rgba(0, 210, 255, 0.12),
     0 0 100px rgba(224, 64, 251, 0.12);
@@ -377,41 +375,34 @@
   box-shadow: 0 0 10px rgba(224, 64, 251, 0.5);
 }
 
-/* Auth button */
+/* Google Sign-In — white button per Google branding guidelines (WCAG AA) */
 .auth-btn {
   position: relative;
   width: 100%;
   overflow: hidden;
-  background: rgba(139, 44, 234, 0.08);
-  border: 1.5px solid #8B2CEA;
-  color: #8B2CEA;
-  font-weight: 600;
-  padding: 1rem 1.5rem;
-  border-radius: 0.75rem;
+  background: #ffffff;
+  border: 1px solid #dadce0;
+  color: #1f1f1f;
+  font-weight: 500;
+  padding: 0.75rem 1.5rem;
+  min-height: 44px;
+  border-radius: var(--of-radius-md, 0.5rem);
   cursor: pointer;
-  transition: all 0.3s;
-  font-size: 1rem;
+  transition: background-color 0.2s, box-shadow 0.2s;
+  font-size: 0.9375rem;
   display: block;
   margin-bottom: 1.25rem;
-  box-shadow: 0 0 12px rgba(139, 44, 234, 0.25);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
 }
 
 .auth-btn:hover {
-  background: rgba(139, 44, 234, 0.15);
-  border-color: #a855f7;
-  box-shadow: 0 0 20px rgba(139, 44, 234, 0.4);
+  background: #f8f9fa;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-.btn-shine {
-  position: absolute;
-  inset: 0;
-  width: 0;
-  background: rgba(139, 44, 234, 0.1);
-  transition: width 0.5s;
-}
-
-.auth-btn:hover .btn-shine {
-  width: 100%;
+.auth-btn:focus-visible {
+  outline: 2px solid var(--of-color-accent-cyan, #00d2ff);
+  outline-offset: 2px;
 }
 
 .btn-label {
@@ -421,13 +412,13 @@
   align-items: center;
   justify-content: center;
   gap: 0.75rem;
-  color: #8B2CEA;
+  color: #1f1f1f;
 }
 
-.btn-label svg {
+.google-g {
   width: 1.25rem;
   height: 1.25rem;
-  color: #8B2CEA;
+  flex-shrink: 0;
 }
 
 /* Card footer */
@@ -470,19 +461,9 @@
   right: 0;
   z-index: 10;
   text-align: center;
-  font-size: 10px;
-  color: #475569;
-  text-transform: uppercase;
-  letter-spacing: 0.25em;
-  font-family: monospace;
-}
-
-.fc {
-  color: #0891b2;
-}
-
-.fp {
-  color: #7c3aed;
+  font-size: 0.6875rem;
+  color: var(--of-color-text-secondary, #94a3b8);
+  letter-spacing: 0.05em;
 }
 
 /* ── ANIMATIONS ────────────────────────── */

--- a/src/app/core/auth/login.component.html
+++ b/src/app/core/auth/login.component.html
@@ -37,11 +37,11 @@
           </div>
         </div>
         <p class="brand-desc">
-          The next-generation project orchestration node for the
-          <span class="brand-hl">OmniFlex Ecosystem</span>.
-          <br /><span class="brand-sub">Initialize your workspace.</span>
+          OmniTask manages projects and tasks for the
+          <span class="brand-hl">OmniFlex team</span>.
+          <br /><span class="brand-sub">Sign in to continue.</span>
         </p>
-        <div class="terminal-line">
+        <div class="terminal-line" aria-hidden="true">
           <span class="term-gt">&gt;</span>
           <span class="term-txt">AWAITING_AUTHENTICATION</span>
           <span class="term-cursor"></span>
@@ -59,18 +59,18 @@
           <div class="card-inner">
             <div class="card-accent-line"></div>
             <div class="card-head">
-              <h2 data-scramble>Identity Verification</h2>
+              <h2>Sign in</h2>
               <div class="card-bar"></div>
             </div>
-            <button (click)="login()" class="omni-glitch-btn auth-btn" type="button">
-              <span class="btn-shine"></span>
+            <button (click)="login()" class="auth-btn google-sign-in-btn" type="button">
               <span class="btn-label">
-                <svg viewBox="0 0 24 24" fill="currentColor">
-                  <path
-                    d="M12.545,10.239v3.821h5.445c-0.712,2.315-2.647,3.972-5.445,3.972c-3.332,0-6.033-2.701-6.033-6.032s2.701-6.032,6.033-6.032c1.498,0,2.866,0.549,3.921,1.453l2.814-2.814C17.503,2.988,15.139,2,12.545,2C7.021,2,2.543,6.477,2.543,12s4.478,10,10.002,10c8.396,0,10.249-7.85,9.426-11.748L12.545,10.239z"
-                  />
+                <svg class="google-g" viewBox="0 0 24 24" aria-hidden="true">
+                  <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/>
+                  <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                  <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                  <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
                 </svg>
-                Authenticate with Google
+                Continue with Google
               </span>
             </button>
             <div class="card-foot">
@@ -97,8 +97,6 @@
 
   <!-- Footer -->
   <div class="login-foot">
-    <span class="fc">//</span> OmniFlex Corporation
-    <span class="fp">//</span> Authorized Personnel Only
-    <span class="fc">//</span>
+    OmniFlex Fitness · OmniTask v{{ version() }}
   </div>
 </div>

--- a/src/app/core/auth/login.component.ts
+++ b/src/app/core/auth/login.component.ts
@@ -1,6 +1,8 @@
-import { Component, inject , ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal, ChangeDetectionStrategy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AuthService } from './auth.service';
+import { VersionService } from '../services/version.service';
+import { DEFAULT_VERSION } from '../constants';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -13,8 +15,15 @@ import { AuthService } from './auth.service';
   templateUrl: './login.component.html',
   styleUrl: './login.component.css',
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
   authService = inject(AuthService);
+  private readonly versionService = inject(VersionService);
+
+  version = signal<string>(DEFAULT_VERSION);
+
+  ngOnInit() {
+    this.versionService.getVersion().subscribe((v) => this.version.set(v));
+  }
 
   login() {
     this.authService.loginWithGoogle();

--- a/src/app/core/auth/login.component.ts
+++ b/src/app/core/auth/login.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal, ChangeDetectionStrategy, OnInit } from '@angular/core';
+import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { AuthService } from './auth.service';
 import { VersionService } from '../services/version.service';
@@ -15,15 +16,13 @@ import { DEFAULT_VERSION } from '../constants';
   templateUrl: './login.component.html',
   styleUrl: './login.component.css',
 })
-export class LoginComponent implements OnInit {
-  authService = inject(AuthService);
+export class LoginComponent {
+  readonly authService = inject(AuthService);
   private readonly versionService = inject(VersionService);
 
-  version = signal<string>(DEFAULT_VERSION);
-
-  ngOnInit() {
-    this.versionService.getVersion().subscribe((v) => this.version.set(v));
-  }
+  readonly version = toSignal(this.versionService.getVersion(), {
+    initialValue: DEFAULT_VERSION,
+  });
 
   login() {
     this.authService.loginWithGoogle();

--- a/src/app/features/dashboard/components/project-overview.component.css
+++ b/src/app/features/dashboard/components/project-overview.component.css
@@ -6,7 +6,7 @@
 
 /* Small KPI tile used in the hero strip. */
 .kpi {
-  @apply flex flex-col items-start gap-1 px-3 py-2 rounded-lg border border-white/5 bg-slate-950/60 backdrop-blur;
+  @apply flex flex-col items-start gap-1 px-3 py-2 rounded-lg border border-white/5 bg-slate-950/90;
   box-shadow:
     inset 0 0 0 1px rgba(0, 210, 255, 0.04),
     0 6px 20px rgba(0, 0, 0, 0.35);
@@ -47,7 +47,7 @@
 /* Tag chip with neon glow */
 .tag-chip {
   @apply inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold rounded-full border;
-  backdrop-filter: blur(6px);
+  background: var(--of-color-bg-surface, rgba(10, 15, 30, 0.92));
 }
 
 .tag-count {

--- a/src/app/features/projects/components/project-google-tasks-sync.component.spec.ts
+++ b/src/app/features/projects/components/project-google-tasks-sync.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { ProjectGoogleTasksSyncComponent } from './project-google-tasks-sync.component';
 import { ProjectService } from '../../../core/services/project.service';
 import { DialogService } from '../../../core/services/dialog.service';
@@ -20,6 +21,7 @@ describe('ProjectGoogleTasksSyncComponent', () => {
   let mockGoogleTasksService: jasmine.SpyObj<GoogleTasksService>;
   let mockGoogleTasksSyncService: jasmine.SpyObj<GoogleTasksSyncService>;
   let mockAuthService: jasmine.SpyObj<AuthService>;
+  let mockRouter: { url: string };
 
   const mockProject: Project = {
     id: 'proj1',
@@ -74,6 +76,8 @@ describe('ProjectGoogleTasksSyncComponent', () => {
     mockAuthService.requestOfflineAccess.and.returnValue(Promise.resolve(true));
     mockAuthService.logout.and.returnValue(Promise.resolve());
 
+    mockRouter = { url: '/projects/proj1' };
+
     await TestBed.configureTestingModule({
       imports: [ProjectGoogleTasksSyncComponent],
       providers: [
@@ -82,6 +86,7 @@ describe('ProjectGoogleTasksSyncComponent', () => {
         { provide: GoogleTasksService, useValue: mockGoogleTasksService },
         { provide: GoogleTasksSyncService, useValue: mockGoogleTasksSyncService },
         { provide: AuthService, useValue: mockAuthService },
+        { provide: Router, useValue: mockRouter },
       ],
     }).compileComponents();
 
@@ -229,11 +234,12 @@ describe('ProjectGoogleTasksSyncComponent', () => {
   });
 
   describe('enableScheduledSync', () => {
-    it('should request offline access and show success message', async () => {
+    it('should request offline access and start OAuth redirect flow', async () => {
       await component.enableScheduledSync();
 
-      expect(mockAuthService.requestOfflineAccess).toHaveBeenCalled();
-      expect(component.lastSyncResult()?.success).toBeTrue();
+      // Success UI is shown after OAuth callback — not before redirect.
+      expect(mockAuthService.requestOfflineAccess).toHaveBeenCalledWith('/projects/proj1');
+      expect(component.lastSyncResult()).toBeNull();
     });
 
     it('should handle offline access errors', async () => {

--- a/src/app/features/projects/project-form-modal.component.css
+++ b/src/app/features/projects/project-form-modal.component.css
@@ -1,6 +1,7 @@
 .ofx-modal-overlay {
       @apply fixed inset-0 z-50 flex items-center justify-center p-4;
       background: rgba(0, 0, 0, 0.7);
+      /* Modal scrim — backdrop blur allowed per DS rule 2 (not a card surface) */
       backdrop-filter: blur(4px);
       animation: fadeIn 0.2s ease-out;
     }

--- a/src/app/features/projects/project-sidebar.component.css
+++ b/src/app/features/projects/project-sidebar.component.css
@@ -1,7 +1,6 @@
 .ofx-sidebar {
-        background: #050810;
+        background: var(--of-color-bg-primary, #050810);
         border-right: 1px solid rgba(0, 210, 255, 0.15);
-        backdrop-filter: blur(16px);
         position: relative;
       }
 

--- a/src/app/features/tasks/section-settings-modal.component.css
+++ b/src/app/features/tasks/section-settings-modal.component.css
@@ -1,6 +1,7 @@
 .ofx-modal-overlay {
         @apply fixed inset-0 z-50 flex items-center justify-center p-4;
         background: rgba(0, 0, 0, 0.7);
+        /* Modal scrim — backdrop blur allowed per DS rule 2 (not a card surface) */
         backdrop-filter: blur(4px);
         animation: fadeIn 0.2s ease-out;
       }

--- a/src/app/features/tasks/task-timeline-view.component.css
+++ b/src/app/features/tasks/task-timeline-view.component.css
@@ -61,7 +61,6 @@
   font-size: 0.875rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
-  backdrop-filter: blur(4px);
 }
 
 .vis-item.vis-selected {
@@ -111,8 +110,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  background: rgba(15, 15, 15, 0.8);
-  backdrop-filter: blur(12px);
+  background: var(--of-color-bg-surface, rgba(10, 15, 30, 0.92));
   padding: 3rem;
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,18 +10,45 @@
     --font-display: 'Orbitron', 'Rajdhani', sans-serif;
     --font-monospace: 'JetBrains Mono', ui-monospace, SFMono-Regular,
       Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
-    background-color: #050810;
     font-family: var(--default-font);
-    
-    /* Cyberpunk Core Colors - Vibrant Neon */
-    --cyber-blue: #00d2ff;
+
+    /* OmniFlex Design System tokens (--of-*) */
+    --of-color-bg-primary: #050810;
+    --of-color-bg-secondary: #0a0f1e;
+    --of-color-bg-surface: rgba(10, 15, 30, 0.92);
+    --of-color-text-primary: #f0f6ff;
+    --of-color-text-secondary: #94a3b8;
+    --of-color-accent-cyan: #00d2ff;
+    --of-color-accent-blue: #3b82f6;
+    --of-color-accent-purple: #8b5cf6;
+    --of-color-accent-pink: #ff1493;
+    --of-color-accent-magenta: #d500f9;
+    --of-color-border-subtle: rgba(255, 255, 255, 0.1);
+    --of-font-display: 'Orbitron', 'Rajdhani', sans-serif;
+    --of-font-body: 'Rajdhani', ui-sans-serif, system-ui, sans-serif;
+    --of-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+    --of-radius-sm: 0.375rem;
+    --of-radius-md: 0.5rem;
+    --of-radius-lg: 1rem;
+    --of-radius-pill: 9999px;
+    --of-space-1: 0.25rem;
+    --of-space-2: 0.5rem;
+    --of-space-3: 0.75rem;
+    --of-space-4: 1rem;
+    --of-space-5: 1.5rem;
+    --of-space-6: 2rem;
+
+    /* Legacy cyber aliases → --of-* tokens */
+    --cyber-blue: var(--of-color-accent-cyan);
     --cyber-blue-dark: #0073ff;
-    --cyber-purple: #e040fb;      /* Vibrant electric purple from logo */
-    --cyber-magenta: #d500f9;     /* Hot magenta */
-    --cyber-pink: #ff1493;        /* Deep pink/hot pink */
-    --cyber-bg-deep: #050810;
-    --cyber-bg: #0a0f1e;
+    --cyber-purple: #e040fb;
+    --cyber-magenta: var(--of-color-accent-magenta);
+    --cyber-pink: var(--of-color-accent-pink);
+    --cyber-bg-deep: var(--of-color-bg-primary);
+    --cyber-bg: var(--of-color-bg-secondary);
     --cyber-grid: rgba(0, 210, 255, 0.06);
+
+    background-color: var(--of-color-bg-primary);
   }
 
   html {
@@ -40,13 +67,15 @@
     background-attachment: fixed;
   }
 
-  /* Force remove default browser outlines on all interactive elements to prevent white rings */
-  input:focus,
-  textarea:focus,
-  select:focus,
-  button:focus,
-  [tabindex]:focus {
-    outline: none !important;
+  /* Suppress mouse-click focus rings; keyboard focus uses :focus-visible below */
+  :where(input, textarea, select, button, a, [role='button'], [tabindex]:not([tabindex='-1'])):focus {
+    outline: none;
+  }
+
+  :where(input, textarea, select, button, a, [role='button'], [tabindex]:not([tabindex='-1'])):focus-visible {
+    outline: 2px solid var(--of-color-accent-cyan);
+    outline-offset: 2px;
+    border-radius: inherit;
   }
 
   .blur-overlay {


### PR DESCRIPTION
## Summary
- **#173** — Fix `enableScheduledSync` spec to match OAuth redirect flow (no false success assertion)
- **#174** — Add canonical `--of-*` design tokens in `styles.css`; legacy `--cyber-*` aliases preserved
- **#175** — Replace global `outline: none !important` with `:focus-visible` keyboard focus rings
- **#176** — Google sign-in button: white Google-branded style, `Continue with Google`, WCAG AA contrast
- **#177** — Remove `backdrop-filter` from cards/sidebars; modal scrims annotated as allowed
- **#178** — Login copy rewritten to OmniFlex Voice; terminal decoration `aria-hidden`
- **#91** — Update SMTP connection URI + add runbook at `docs/runbooks/configure-firebase-smtp-secrets.md` (App Password still requires manual Secret Manager step)

## Test plan
- [x] `ng test --watch=false --browsers=ChromeHeadless` — 348/348 pass
- [x] `ng build --configuration production` — success
- [ ] Manual Tab through login → dashboard on preview deploy
- [ ] Complete #91 Secret Manager password injection per runbook (ops step)

Closes #173, #174, #175, #176, #177, #178. Partially addresses #91 (repo + runbook; secrets require GCP console).