### PR TITLE
feat(users): per-project admins, ownership transfer, and dashboard settings

### DIFF
--- a/docs/plans/user-management-expansion.md
+++ b/docs/plans/user-management-expansion.md
@@ -1,0 +1,109 @@
+# User Management Expansion — Profiles, Dashboard Settings, Per-Project Roles
+
+> Status: in progress
+> Branch: `claude/ecstatic-mccarthy-wqo878`
+> Author: Claude Code
+
+## Scope
+
+Expand OmniTask's user-management surface in four ways:
+
+1. **Individual profiles** — each user keeps their own profile. Add lightweight
+   profile fields (`jobTitle`, `bio`, `timezone`) on top of the existing
+   display name / avatar / photo, surfaced in **Settings**.
+2. **Dashboard settings & views** — let each user configure how their personal
+   **My Tasks** dashboard opens and looks (default pane, compact density,
+   personal accent color). Persisted on the user profile.
+3. **Per-project admins** — let a project owner grant another member elevated
+   "project admin" rights for that specific project (manage members, edit
+   settings). Backed by a new `adminIds` array on `Project`.
+4. **Ownership transfer** — let an owner hand a project to another current
+   member. The previous owner stays on as a project admin.
+
+Out of scope (noted as future work): a read-only "Viewer" project role,
+finer-grained per-field write restrictions for regular members, and a
+dedicated public profile page.
+
+## Design decisions
+
+- **`memberIds` stays the membership source of truth.** The whole app and the
+  Flutter companion query projects with `where('memberIds','array-contains',uid)`.
+  Rather than reshape membership into `ProjectMember[]` (a risky migration
+  across every query path + rules), per-project admins are an **additive**
+  `adminIds: string[]` subset of `memberIds`. Owner is implicitly the top admin.
+- **Role hierarchy:** `owner` > `admin` > `member`.
+  - *Owner*: everything, including delete, transfer ownership, and grant/revoke
+    project admins.
+  - *Admin*: manage members + edit project settings. Cannot delete, transfer,
+    or change the admin roster.
+  - *Member*: collaborate (create/edit tasks, edit shared project fields) as
+    today.
+- **Server-side enforcement is mandatory.** Client checks are convenience only;
+  the capability is enforced in `firestore.rules` so it cannot be bypassed.
+- **Dashboard settings are user-owned, non-privileged fields.** They write to
+  the user's own doc and need no rules change (existing self-update rule already
+  permits non-role/non-permission field writes).
+
+## Files affected
+
+| File | Change |
+|------|--------|
+| `src/app/core/models/user.model.ts` | `UserDashboardSettings` + defaults + `resolveDashboardSettings()`; add `jobTitle`/`bio`/`timezone`/`dashboardSettings` to `UserProfile` |
+| `src/app/core/models/domain.model.ts` | `adminIds?` on `Project`; `ProjectRole`, `getProjectRole()`, `isProjectManager()` |
+| `src/app/core/services/project.service.ts` | `setProjectAdmin()`, `transferOwnership()`; `removeMember()` also strips `adminIds` |
+| `src/app/core/services/project.service.spec.ts` | Tests for the three above |
+| `src/app/features/projects/components/project-member-manager.component.ts` + `.html` | Role badges + owner/admin controls (make/remove admin, transfer ownership), gating by current user's role |
+| `src/app/features/settings/settings.component.ts` + `.html` | Profile fields (`jobTitle`, `bio`) + new "Dashboard" settings section |
+| `src/app/features/my-tasks/my-tasks.component.ts` + `.css` | Seed default pane from settings; apply compact density + accent color |
+| `firestore.rules` | Project update gating for `ownerId` / `adminIds` / `memberIds` |
+| `docs/plans/user-management-expansion.md` | This plan |
+
+## Implementation steps
+
+1. Models: dashboard settings + profile fields (user.model), `adminIds` + role
+   helpers (domain.model).
+2. Service: admin grant/revoke, ownership transfer, member-removal cleanup.
+3. Firestore rules: owner-only `ownerId`/`adminIds`; project-admin-gated
+   `memberIds`.
+4. Member-manager UI: badges + contextual actions, gated by role.
+5. Settings UI: profile fields + dashboard settings section.
+6. My Tasks: consume dashboard settings (default view, density, accent).
+7. Tests + `ng build` + `ng test` + `ng lint`.
+
+## Firestore rules change (behavior delta)
+
+The project `update` rule is tightened so that:
+
+- changing `ownerId` requires being the **current owner** (or a global
+  admin/super-admin),
+- changing `adminIds` requires being the **current owner**,
+- changing `memberIds` requires being a **project admin** (owner or in
+  `adminIds`) **and** holding the global `canInviteMembers` permission.
+
+Regular members can still edit non-sensitive project fields (sections, tags,
+description, etc.) exactly as before. This intentionally moves member management
+from "any member with `canInviteMembers`" to "project admins" — that is the
+"admin permissions for a specific project" capability being added.
+
+Existing projects have no `adminIds` field; `adminIds is list` guards treat that
+as "owner is the only manager", so behavior is unchanged until an owner appoints
+an admin.
+
+## Test plan
+
+- Unit: `project.service.spec.ts` — admin add/remove (incl. owner + non-member
+  guards), transfer (owner-only, member-only target, swaps owner↔admin),
+  member removal also drops admin.
+- Build: `ng build --configuration production`.
+- Lint/tests: `ng test --watch=false` and `ng lint`.
+- Manual (post-deploy of rules): owner appoints admin → admin can add/remove
+  members but not transfer; owner transfers → new owner gains control, old owner
+  becomes admin.
+
+## Rollback
+
+- Pure additive model/service/UI changes: revert the commit. `adminIds` is
+  optional and ignored by old code.
+- Rules: keep the previous `firestore.rules` revision; re-deploy it. Because the
+  new fields are additive, reverting rules only relaxes the member-management
+  gate back to the prior behavior — no data migration required.

--- a/firestore.rules
+++ b/firestore.rules
@@ -110,12 +110,14 @@ service cloud.firestore {
       }
 
       // The signed-in user can manage the project: the owner, or a member
-      // granted project-admin rights via the `adminIds` array.
+      // granted project-admin rights via the `adminIds` array. Use get() with
+      // a default so projects created before `adminIds` existed (field absent)
+      // evaluate cleanly instead of erroring on a missing-field access.
       function isProjectAdmin(resourceData) {
         return isProjectOwner(resourceData) || (
           isAuthenticated() &&
-          resourceData.adminIds is list &&
-          request.auth.uid in resourceData.adminIds
+          resourceData.get('adminIds', []) is list &&
+          request.auth.uid in resourceData.get('adminIds', [])
         );
       }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -104,17 +104,44 @@ service cloud.firestore {
     }
 
     match /projects/{projectId} {
+      // The signed-in user is the project owner.
+      function isProjectOwner(resourceData) {
+        return isAuthenticated() && request.auth.uid == resourceData.ownerId;
+      }
+
+      // The signed-in user can manage the project: the owner, or a member
+      // granted project-admin rights via the `adminIds` array.
+      function isProjectAdmin(resourceData) {
+        return isProjectOwner(resourceData) || (
+          isAuthenticated() &&
+          resourceData.adminIds is list &&
+          request.auth.uid in resourceData.adminIds
+        );
+      }
+
+      // True when the incoming update touches any of the given keys.
+      function projectChanges(keys) {
+        return request.resource.data.diff(resource.data).affectedKeys().hasAny(keys);
+      }
+
       allow create: if isAdmin() || isSuperAdmin() || (
         isAuthenticated() && hasPermission('canCreateProjects')
       );
       allow read: if isMember(resource.data) || isAdmin() || isSuperAdmin();
-      // Members can update project fields freely, but changing `memberIds`
-      // additionally requires the `canInviteMembers` permission so the invite
-      // flag is actually enforced. Admins/super-admins bypass this.
+      // Members can update non-sensitive project fields freely. Sensitive
+      // changes are gated by per-project role:
+      //  - `ownerId` (ownership transfer): current owner only.
+      //  - `adminIds` (grant/revoke project admins): current owner only.
+      //  - `memberIds` (add/remove members): project admin (owner or in
+      //    adminIds) plus the global `canInviteMembers` permission.
+      // Global admins/super-admins bypass all of this.
       allow update: if isAdmin() || isSuperAdmin() || (
-        isMember(resource.data) && (
-          !request.resource.data.diff(resource.data).affectedKeys().hasAny(['memberIds']) ||
-          hasPermission('canInviteMembers')
+        isMember(resource.data) &&
+        (!projectChanges(['ownerId']) || isProjectOwner(resource.data)) &&
+        (!projectChanges(['adminIds']) || isProjectOwner(resource.data)) &&
+        (
+          !projectChanges(['memberIds']) ||
+          (isProjectAdmin(resource.data) && hasPermission('canInviteMembers'))
         )
       );
       allow delete: if isAdmin() || isSuperAdmin() || (

--- a/src/app/core/models/domain.model.ts
+++ b/src/app/core/models/domain.model.ts
@@ -158,6 +158,13 @@ export interface Project {
   coverImage?: string; // Project cover image URL (Firebase Storage)
   ownerId: string;
   memberIds: string[];
+  /**
+   * Members granted elevated "project admin" rights for this project: they can
+   * manage members and edit project settings without being the owner. Always a
+   * subset of `memberIds`. The owner is implicitly an admin and is never listed
+   * here. Absent on projects created before per-project admins existed.
+   */
+  adminIds?: string[];
   sections: Section[]; // Kanban columns
   customFieldIds?: string[]; // References to global CustomFieldDefinitions
   tags?: Tag[]; // Defined tags for this project
@@ -185,6 +192,44 @@ export interface Project {
   sheetSyncStatus?: 'synced' | 'pending' | 'error';
   /** Client-evaluated automation rules for this project. */
   automationRules?: AutomationRule[];
+}
+
+/**
+ * A user's role within a single project. `owner` outranks `admin`, which
+ * outranks `member`. `null` means the user is not part of the project at all.
+ */
+export type ProjectRole = 'owner' | 'admin' | 'member';
+
+/** Fields needed to determine a user's role in a project. */
+type ProjectRoleSource = Pick<Project, 'ownerId' | 'memberIds' | 'adminIds'>;
+
+/**
+ * Resolve a user's role within a project. Owner takes precedence over an
+ * admin grant, which takes precedence over plain membership. Returns `null`
+ * for users who are neither owner, admin, nor member.
+ */
+export function getProjectRole(
+  project: ProjectRoleSource,
+  uid: string | null | undefined,
+): ProjectRole | null {
+  if (!uid) return null;
+  if (project.ownerId === uid) return 'owner';
+  if (project.adminIds?.includes(uid)) return 'admin';
+  if (project.memberIds?.includes(uid)) return 'member';
+  return null;
+}
+
+/**
+ * True when the user can manage a project (owner or project admin): manage
+ * members and edit project settings. Owner-only actions (delete, transfer,
+ * change the admin roster) are checked separately against `getProjectRole`.
+ */
+export function isProjectManager(
+  project: ProjectRoleSource,
+  uid: string | null | undefined,
+): boolean {
+  const role = getProjectRole(project, uid);
+  return role === 'owner' || role === 'admin';
 }
 
 export interface Task {

--- a/src/app/core/models/user.model.ts
+++ b/src/app/core/models/user.model.ts
@@ -32,6 +32,32 @@ export const DEFAULT_USER_PERMISSIONS: UserPermissions = {
   isSuperAdmin: false,
 };
 
+/**
+ * Per-user customization of the personal "My Tasks" dashboard. Distinct from
+ * the per-project `DashboardPreferences` (which an owner/admin sets for a whole
+ * project) — these settings only affect what the signed-in user sees on their
+ * own landing page. Every field is optional in storage; `resolveDashboardSettings`
+ * fills in defaults so consumers always get a fully-populated object.
+ */
+export interface UserDashboardSettings {
+  /** Which My Tasks pane opens by default when the user lands on the dashboard. */
+  defaultMyTasksView: 'overview' | 'list' | 'available';
+  /** Tighten vertical spacing on dashboard lists for denser layouts. */
+  compactMode: boolean;
+  /** Personal accent color (hex) used for dashboard highlights. */
+  accentColor: string;
+}
+
+/**
+ * Defaults applied when a user has not customized their dashboard. Centralized
+ * so the settings form and the dashboard rendering stay in sync.
+ */
+export const DEFAULT_DASHBOARD_SETTINGS: UserDashboardSettings = {
+  defaultMyTasksView: 'overview',
+  compactMode: false,
+  accentColor: '#00d2ff',
+};
+
 export interface UserProfile {
   uid: string;
   email: string;
@@ -44,6 +70,21 @@ export interface UserProfile {
   permissions?: UserPermissions;
   createdAt: Date;
   lastLoginAt: Date;
+
+  // --- Individual profile details (all optional, user-editable) ---
+  /** Short role/title shown on the user's profile and dashboard header. */
+  jobTitle?: string;
+  /** Free-text "about me" blurb. */
+  bio?: string;
+  /** IANA timezone identifier (e.g. "America/New_York"), for future scheduling UX. */
+  timezone?: string;
+
+  /**
+   * Per-user dashboard configuration (default view, density, accent). Stored
+   * as a partial so older documents and forward-compatible additions resolve
+   * through `resolveDashboardSettings`.
+   */
+  dashboardSettings?: Partial<UserDashboardSettings>;
 
   // Google Tasks scheduled sync fields
   hasGoogleTasksOfflineAccess?: boolean;
@@ -91,4 +132,14 @@ export interface UserProfile {
  */
 export function resolvePermissions(user?: UserProfile | null): UserPermissions {
   return { ...DEFAULT_USER_PERMISSIONS, ...(user?.permissions ?? {}) };
+}
+
+/**
+ * Resolve a user's effective dashboard settings, applying defaults for any
+ * unset field. Accepts null/undefined and returns a fully populated object.
+ */
+export function resolveDashboardSettings(
+  user?: UserProfile | null,
+): UserDashboardSettings {
+  return { ...DEFAULT_DASHBOARD_SETTINGS, ...(user?.dashboardSettings ?? {}) };
 }

--- a/src/app/core/services/project.service.spec.ts
+++ b/src/app/core/services/project.service.spec.ts
@@ -333,7 +333,7 @@ describe('ProjectService', () => {
   });
 
   describe('project roles & ownership', () => {
-    let mockProject: any;
+    let mockProject: Partial<Project>;
 
     beforeEach(() => {
       mockProject = {
@@ -342,7 +342,7 @@ describe('ProjectService', () => {
         memberIds: ['user-1', 'member-1', 'member-2'],
         adminIds: ['member-1'],
       };
-      spyOn(service, 'getProject').and.returnValue(Promise.resolve(mockProject));
+      spyOn(service, 'getProject').and.returnValue(Promise.resolve(mockProject as Project));
       spyOn(service, 'updateProject').and.returnValue(Promise.resolve());
       authServiceMock.currentUserSig.set({ uid: 'user-1' } as any);
     });

--- a/src/app/core/services/project.service.spec.ts
+++ b/src/app/core/services/project.service.spec.ts
@@ -331,4 +331,105 @@ describe('ProjectService', () => {
       expect(service.updateProject).toHaveBeenCalled();
     });
   });
+
+  describe('project roles & ownership', () => {
+    let mockProject: any;
+
+    beforeEach(() => {
+      mockProject = {
+        id: 'proj-1',
+        ownerId: 'user-1',
+        memberIds: ['user-1', 'member-1', 'member-2'],
+        adminIds: ['member-1'],
+      };
+      spyOn(service, 'getProject').and.returnValue(Promise.resolve(mockProject));
+      spyOn(service, 'updateProject').and.returnValue(Promise.resolve());
+      authServiceMock.currentUserSig.set({ uid: 'user-1' } as any);
+    });
+
+    // --- setProjectAdmin ---
+    it('should grant project-admin rights to a member', async () => {
+      await service.setProjectAdmin('proj-1', 'member-2', true);
+      const args = (service.updateProject as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1].adminIds).toContain('member-2');
+      expect(args[1].adminIds).toContain('member-1');
+    });
+
+    it('should revoke project-admin rights from an admin', async () => {
+      await service.setProjectAdmin('proj-1', 'member-1', false);
+      const args = (service.updateProject as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1].adminIds).not.toContain('member-1');
+    });
+
+    it('should refuse to make the owner an admin', async () => {
+      await expectAsync(service.setProjectAdmin('proj-1', 'user-1', true)).toBeRejectedWithError(
+        /owner already has/i,
+      );
+      expect(service.updateProject).not.toHaveBeenCalled();
+    });
+
+    it('should refuse to make a non-member an admin', async () => {
+      await expectAsync(service.setProjectAdmin('proj-1', 'stranger', true)).toBeRejectedWithError(
+        /before making them an admin/i,
+      );
+      expect(service.updateProject).not.toHaveBeenCalled();
+    });
+
+    it('should no-op when granting admin to an existing admin', async () => {
+      await service.setProjectAdmin('proj-1', 'member-1', true);
+      expect(service.updateProject).not.toHaveBeenCalled();
+    });
+
+    // --- transferOwnership ---
+    it('should transfer ownership and demote the prior owner to admin', async () => {
+      await service.transferOwnership('proj-1', 'member-2');
+      const args = (service.updateProject as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1].ownerId).toBe('member-2');
+      expect(args[1].adminIds).toContain('user-1');
+      expect(args[1].adminIds).not.toContain('member-2');
+    });
+
+    it('should remove the new owner from the admin list on transfer', async () => {
+      await service.transferOwnership('proj-1', 'member-1');
+      const args = (service.updateProject as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1].ownerId).toBe('member-1');
+      expect(args[1].adminIds).not.toContain('member-1');
+      expect(args[1].adminIds).toContain('user-1');
+    });
+
+    it('should refuse transfer when the current user is not the owner', async () => {
+      authServiceMock.currentUserSig.set({ uid: 'member-1' } as any);
+      await expectAsync(service.transferOwnership('proj-1', 'member-2')).toBeRejectedWithError(
+        /only the project owner/i,
+      );
+      expect(service.updateProject).not.toHaveBeenCalled();
+    });
+
+    it('should refuse transfer to a non-member', async () => {
+      await expectAsync(service.transferOwnership('proj-1', 'stranger')).toBeRejectedWithError(
+        /current project member/i,
+      );
+    });
+
+    it('should refuse transfer to the current owner', async () => {
+      await expectAsync(service.transferOwnership('proj-1', 'user-1')).toBeRejectedWithError(
+        /already owns/i,
+      );
+    });
+
+    // --- removeMember admin cleanup ---
+    it('should drop the admin grant when removing an admin member', async () => {
+      await service.removeMember('proj-1', 'member-1');
+      const args = (service.updateProject as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1].memberIds).not.toContain('member-1');
+      expect(args[1].adminIds).not.toContain('member-1');
+    });
+
+    it('should not touch adminIds when removing a non-admin member', async () => {
+      await service.removeMember('proj-1', 'member-2');
+      const args = (service.updateProject as jasmine.Spy).calls.mostRecent().args;
+      expect(args[1].memberIds).not.toContain('member-2');
+      expect('adminIds' in args[1]).toBe(false);
+    });
+  });
 });

--- a/src/app/core/services/project.service.ts
+++ b/src/app/core/services/project.service.ts
@@ -361,7 +361,9 @@ export class ProjectService {
   }
 
   /**
-   * Remove a member from a project
+   * Remove a member from a project. If the member also held a project-admin
+   * grant, that grant is revoked in the same write so we never leave a
+   * dangling admin id pointing at a non-member.
    */
   async removeMember(projectId: string, userId: string): Promise<void> {
     this.permissions.requirePermission('canInviteMembers');
@@ -374,7 +376,81 @@ export class ProjectService {
     }
 
     const updatedMemberIds = (project.memberIds || []).filter((id) => id !== userId);
-    await this.updateProject(projectId, { memberIds: updatedMemberIds });
+    const patch: Partial<Project> = { memberIds: updatedMemberIds };
+
+    // Only touch adminIds when the removed member actually had the grant —
+    // changing adminIds is owner-restricted by the rules, so we avoid an
+    // unnecessary (and potentially denied) write for a plain member.
+    if ((project.adminIds || []).includes(userId)) {
+      patch.adminIds = (project.adminIds || []).filter((id) => id !== userId);
+    }
+
+    await this.updateProject(projectId, patch);
+  }
+
+  /**
+   * Grant or revoke project-admin rights for a member. Only the project owner
+   * (or a global admin/super-admin) may do this; the Firestore rules enforce
+   * the owner restriction server-side. An admin must already be a project
+   * member, and the owner can't be listed as an admin (they outrank one).
+   */
+  async setProjectAdmin(projectId: string, userId: string, makeAdmin: boolean): Promise<void> {
+    const project = await this.getProject(projectId);
+    if (!project) throw new Error('Project not found');
+
+    if (userId === project.ownerId) {
+      throw new Error('The project owner already has full admin rights.');
+    }
+
+    const admins = new Set(project.adminIds || []);
+    if (makeAdmin) {
+      if (!(project.memberIds || []).includes(userId)) {
+        throw new Error('Add this person to the project before making them an admin.');
+      }
+      if (admins.has(userId)) return; // Already an admin — no-op.
+      admins.add(userId);
+    } else {
+      if (!admins.has(userId)) return; // Not an admin — no-op.
+      admins.delete(userId);
+    }
+
+    await this.updateProject(projectId, { adminIds: Array.from(admins) });
+  }
+
+  /**
+   * Transfer ownership of a project to another current member. The previous
+   * owner stays on as a project admin so they keep elevated access; the new
+   * owner is removed from the admin list (they now sit above it). Only the
+   * current owner (or a global admin/super-admin) may transfer; the rules
+   * enforce this server-side.
+   */
+  async transferOwnership(projectId: string, newOwnerId: string): Promise<void> {
+    const project = await this.getProject(projectId);
+    if (!project) throw new Error('Project not found');
+
+    const currentUser = this.auth.currentUserSig();
+    if (!currentUser) throw new Error('Not authenticated');
+
+    const isGlobalAdmin = this.permissions.currentPermissions().isSuperAdmin;
+    if (project.ownerId !== currentUser.uid && !isGlobalAdmin) {
+      throw new Error('Only the project owner can transfer ownership.');
+    }
+    if (newOwnerId === project.ownerId) {
+      throw new Error('This person already owns the project.');
+    }
+    if (!(project.memberIds || []).includes(newOwnerId)) {
+      throw new Error('You can only transfer ownership to a current project member.');
+    }
+
+    const previousOwnerId = project.ownerId;
+    const admins = new Set(project.adminIds || []);
+    admins.delete(newOwnerId); // New owner outranks the admin list.
+    admins.add(previousOwnerId); // Previous owner keeps elevated access.
+
+    await this.updateProject(projectId, {
+      ownerId: newOwnerId,
+      adminIds: Array.from(admins),
+    });
   }
 
   /**

--- a/src/app/features/my-tasks/my-tasks.component.css
+++ b/src/app/features/my-tasks/my-tasks.component.css
@@ -4,6 +4,16 @@
   height: 100%;
 }
 
+/*
+ * Personal accent color. Defaults to the cyber-blue the dashboard has always
+ * used; overridden per-user via the inline `--ot-accent` custom property set
+ * from the user's dashboard settings.
+ */
+.mytasks-compact,
+:host {
+  --ot-accent: #00d2ff;
+}
+
 /* Top navigation pills that switch between Overview / My Tasks / Available. */
 .mytasks-tab {
   display: inline-flex;
@@ -23,14 +33,14 @@
 
 .mytasks-tab:hover {
   color: rgb(226, 232, 240);
-  border-color: rgba(0, 210, 255, 0.35);
+  border-color: color-mix(in srgb, var(--ot-accent) 35%, transparent);
 }
 
 .mytasks-tab.active {
   color: #e6f8ff;
-  border-color: rgba(0, 210, 255, 0.55);
-  background: rgba(0, 210, 255, 0.1);
-  box-shadow: 0 0 14px rgba(0, 210, 255, 0.25);
+  border-color: color-mix(in srgb, var(--ot-accent) 55%, transparent);
+  background: color-mix(in srgb, var(--ot-accent) 12%, transparent);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--ot-accent) 28%, transparent);
 }
 
 /* Count pill rendered next to the tab label. */
@@ -44,6 +54,21 @@
   border-radius: 9999px;
   font-size: 0.65rem;
   font-weight: 700;
-  background: rgba(0, 210, 255, 0.18);
+  background: color-mix(in srgb, var(--ot-accent) 18%, transparent);
   color: rgb(125, 232, 255);
 }
+
+/*
+ * Compact density: tighten the vertical rhythm of the dashboard so more
+ * content is visible at once. Opt-in via the user's dashboard settings.
+ */
+.mytasks-compact main {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.mytasks-compact .mytasks-tab {
+  padding-top: 0.35rem;
+  padding-bottom: 0.35rem;
+}
+

--- a/src/app/features/my-tasks/my-tasks.component.html
+++ b/src/app/features/my-tasks/my-tasks.component.html
@@ -1,4 +1,8 @@
-<div class="h-screen flex flex-col overflow-hidden bg-[#050810]">
+<div
+  class="h-screen flex flex-col overflow-hidden bg-[#050810]"
+  [class.mytasks-compact]="compactMode()"
+  [style.--ot-accent]="accentColor()"
+>
   <!-- Background grid overlay, cyberpunk theme matching the project dashboard -->
   <div class="absolute inset-0 overflow-hidden pointer-events-none z-0">
     <div class="absolute inset-0 cyber-grid-bg opacity-40"></div>

--- a/src/app/features/my-tasks/my-tasks.component.html
+++ b/src/app/features/my-tasks/my-tasks.component.html
@@ -62,14 +62,14 @@
       <button
         class="mytasks-tab"
         [class.active]="viewMode() === 'overview'"
-        (click)="viewMode.set('overview')"
+        (click)="selectView('overview')"
       >
         Overview
       </button>
       <button
         class="mytasks-tab"
         [class.active]="viewMode() === 'list'"
-        (click)="viewMode.set('list')"
+        (click)="selectView('list')"
       >
         My Tasks
         <span class="mytasks-tab-count">{{ listCount() }}</span>
@@ -77,7 +77,7 @@
       <button
         class="mytasks-tab"
         [class.active]="viewMode() === 'available'"
-        (click)="viewMode.set('available')"
+        (click)="selectView('available')"
       >
         Available
         <span class="mytasks-tab-count">{{ availableCount() }}</span>
@@ -98,7 +98,7 @@
             [pinnedProjectIds]="pinnedProjectIds()"
             (taskClick)="openTaskDetail($event)"
             (createTask)="openCreateForProject($event)"
-            (viewChange)="viewMode.set($event)"
+            (viewChange)="selectView($event)"
             (reportsToChange)="saveReportsTo($event)"
             (togglePin)="togglePinProject($event)"
           ></app-my-tasks-overview>

--- a/src/app/features/my-tasks/my-tasks.component.ts
+++ b/src/app/features/my-tasks/my-tasks.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   computed,
+  effect,
   inject,
   signal,
 } from '@angular/core';
@@ -17,7 +18,7 @@ import { DialogService } from '../../core/services/dialog.service';
 import { MyTasksSheetSyncService } from '../../core/services/my-tasks-sheet-sync.service';
 import { GoogleSheetsService } from '../../core/services/google-sheets.service';
 import { Project, Task } from '../../core/models/domain.model';
-import { UserProfile } from '../../core/models/user.model';
+import { UserProfile, resolveDashboardSettings } from '../../core/models/user.model';
 
 import { TaskDetailModalComponent } from '../tasks/task-detail-modal.component';
 import { TaskCreateModalComponent } from '../tasks/task-create-modal.component';
@@ -68,9 +69,35 @@ export class MyTasksComponent {
     () => this.currentUser()?.pinnedProjectIds ?? [],
   );
 
-  // Active top-level pane. Overview is the default entry because it answers
-  // "what's going on with me?" at a glance.
+  /** The user's resolved dashboard settings (default view, density, accent). */
+  readonly dashboardSettings = computed(() =>
+    resolveDashboardSettings(this.currentUser()),
+  );
+
+  /** Personal accent color, exposed to the template as a CSS custom property. */
+  readonly accentColor = computed(() => this.dashboardSettings().accentColor);
+
+  /** Compact density toggle for dashboard lists. */
+  readonly compactMode = computed(() => this.dashboardSettings().compactMode);
+
+  // Active top-level pane. Defaults to the user's configured landing pane
+  // (seeded once below); Overview is the fallback when unset.
   viewMode = signal<MyTasksViewMode>('overview');
+
+  /** Guards the one-time seed of `viewMode` from the user's saved preference. */
+  private viewSeeded = false;
+
+  constructor() {
+    // Seed the active pane from the user's dashboard settings the first time
+    // their profile resolves. After that, manual tab switches win — we don't
+    // want a later profile refresh to yank the user back to their default.
+    effect(() => {
+      const user = this.currentUser();
+      if (!user || this.viewSeeded) return;
+      this.viewSeeded = true;
+      this.viewMode.set(resolveDashboardSettings(user).defaultMyTasksView);
+    });
+  }
 
   // Modal state — reuse the same detail/create modals the project dashboard uses.
   openTask = signal<Task | null>(null);

--- a/src/app/features/my-tasks/my-tasks.component.ts
+++ b/src/app/features/my-tasks/my-tasks.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   ChangeDetectionStrategy,
   computed,
-  effect,
   inject,
   signal,
 } from '@angular/core';
@@ -80,24 +79,20 @@ export class MyTasksComponent {
   /** Compact density toggle for dashboard lists. */
   readonly compactMode = computed(() => this.dashboardSettings().compactMode);
 
-  // Active top-level pane. Defaults to the user's configured landing pane
-  // (seeded once below); Overview is the fallback when unset.
-  viewMode = signal<MyTasksViewMode>('overview');
+  /**
+   * The pane the user explicitly picked this session (null until they switch
+   * tabs). Kept separate from the configured default so a manual choice wins
+   * and isn't reset when the user profile re-emits.
+   */
+  private readonly userSelectedView = signal<MyTasksViewMode | null>(null);
 
-  /** Guards the one-time seed of `viewMode` from the user's saved preference. */
-  private viewSeeded = false;
-
-  constructor() {
-    // Seed the active pane from the user's dashboard settings the first time
-    // their profile resolves. After that, manual tab switches win — we don't
-    // want a later profile refresh to yank the user back to their default.
-    effect(() => {
-      const user = this.currentUser();
-      if (!user || this.viewSeeded) return;
-      this.viewSeeded = true;
-      this.viewMode.set(resolveDashboardSettings(user).defaultMyTasksView);
-    });
-  }
+  /**
+   * Active top-level pane: the user's explicit choice when they've made one,
+   * otherwise their configured default landing pane (Overview when unset).
+   */
+  readonly viewMode = computed<MyTasksViewMode>(
+    () => this.userSelectedView() ?? this.dashboardSettings().defaultMyTasksView,
+  );
 
   // Modal state — reuse the same detail/create modals the project dashboard uses.
   openTask = signal<Task | null>(null);
@@ -161,6 +156,11 @@ export class MyTasksComponent {
   listCount = computed(() => this.myTasks().filter((t) => t.status !== 'done').length);
 
   // --------- Actions ---------
+
+  /** Switch the active pane, recording it as an explicit user override. */
+  selectView(view: MyTasksViewMode): void {
+    this.userSelectedView.set(view);
+  }
 
   /**
    * Open the task detail modal for a task in any of the user's projects.

--- a/src/app/features/projects/components/project-member-manager.component.html
+++ b/src/app/features/projects/components/project-member-manager.component.html
@@ -1,220 +1,311 @@
 <div class="space-y-6">
-      <!-- Add Member Section -->
-      <div class="bg-[#0f172a]/50 border border-white/5 rounded-xl p-4">
-        <div class="flex items-center justify-between gap-3 mb-3">
-          <h3 class="text-sm font-bold text-white">Add Team Members</h3>
-          <app-group-picker
-            [label]="'Add from group'"
-            [compact]="true"
-            (applyGroup)="applyGroup($event)"
-          ></app-group-picker>
+  <!-- Add Member Section — visible to project managers (owner/admin) only -->
+  @if (canManageMembers()) {
+    <div class="bg-[#0f172a]/50 border border-white/5 rounded-xl p-4">
+      <div class="flex items-center justify-between gap-3 mb-3">
+        <h3 class="text-sm font-bold text-white">Add Team Members</h3>
+        <app-group-picker
+          [label]="'Add from group'"
+          [compact]="true"
+          (applyGroup)="applyGroup($event)"
+        ></app-group-picker>
+      </div>
+
+      <div class="relative">
+        <div class="flex items-center gap-2">
+          <div class="relative flex-grow">
+            <input
+              type="text"
+              [formControl]="searchControl"
+              placeholder="Search users by name or email..."
+              class="w-full bg-[#050810] border border-white/10 rounded-lg py-2 pl-9 pr-4 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 focus:ring-1 focus:ring-cyan-500/50 transition-all"
+              (focus)="showResults.set(true)"
+            />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          </div>
         </div>
 
-        <div class="relative">
-          <div class="flex items-center gap-2">
-            <div class="relative flex-grow">
-              <input
-                type="text"
-                [formControl]="searchControl"
-                placeholder="Search users by name or email..."
-                class="w-full bg-[#050810] border border-white/10 rounded-lg py-2 pl-9 pr-4 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-cyan-500/50 focus:ring-1 focus:ring-cyan-500/50 transition-all"
-                (focus)="showResults.set(true)"
-              />
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
+        <!-- Helper text -->
+        <p class="mt-2 text-xs text-slate-500">
+          Search for people in your organization to add them to this project.
+        </p>
+
+        <!-- Search Results Dropdown -->
+        @if (showResults() && searchResults().length > 0) {
+          <div
+            class="absolute top-full left-0 right-0 mt-2 bg-[#1e293b] border border-white/10 rounded-lg shadow-xl z-50 overflow-hidden max-h-60 overflow-y-auto"
+          >
+            @for (user of searchResults(); track user.id) {
+              <button
+                (click)="addMember(user)"
+                class="w-full text-left px-4 py-3 hover:bg-white/5 flex items-center gap-3 transition-colors border-b border-white/5 last:border-0"
+                [disabled]="isMember(user.id)"
+                [class.opacity-50]="isMember(user.id)"
+                [class.cursor-not-allowed]="isMember(user.id)"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
+                @if (user.photoURL) {
+                  <img
+                    [src]="user.photoURL"
+                    class="w-8 h-8 rounded-full bg-slate-800 object-cover"
+                    alt=""
+                    #userImg
+                    (error)="userImg.style.display = 'none'; userFallback.style.display = 'flex'"
+                  />
+                  <div
+                    #userFallback
+                    class="w-8 h-8 rounded-full items-center justify-center text-xs font-bold text-white hidden"
+                    [style.background-color]="getAvatarColor(user.email)"
+                  >
+                    {{ getInitials(user.displayName) }}
+                  </div>
+                } @else {
+                  <div
+                    class="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold text-white"
+                    [style.background-color]="getAvatarColor(user.email)"
+                  >
+                    {{ getInitials(user.displayName) }}
+                  </div>
+                }
+                <div>
+                  <div class="text-sm font-medium text-white">
+                    {{ user.displayName }}
+                    @if (isMember(user.id)) {
+                      <span class="ml-2 text-xs text-emerald-400 font-normal"
+                        >(Already a member)</span
+                      >
+                    }
+                  </div>
+                  <div class="text-xs text-slate-400">{{ user.email }}</div>
+                </div>
+              </button>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  }
+
+  <!-- Members List -->
+  <div class="space-y-4">
+    <!-- Owner -->
+    <div>
+      <h3 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Owner</h3>
+      <div class="space-y-2">
+        @for (admin of owner(); track admin.id) {
+          <div
+            class="flex items-center justify-between p-3 bg-[#0f172a]/30 border border-emerald-500/20 rounded-lg group hover:border-emerald-500/40 transition-colors"
+          >
+            <div class="flex items-center gap-3">
+              <div class="relative">
+                @if (admin.photoURL) {
+                  <img
+                    [src]="admin.photoURL"
+                    class="w-10 h-10 rounded-full bg-slate-800 object-cover ring-2 ring-emerald-500/30"
+                    alt=""
+                    #adminImg
+                    (error)="adminImg.style.display = 'none'; adminFallback.style.display = 'flex'"
+                  />
+                  <div
+                    #adminFallback
+                    class="w-10 h-10 rounded-full items-center justify-center text-sm font-bold text-white ring-2 ring-emerald-500/30 hidden"
+                    [style.background-color]="getAvatarColor(admin.email)"
+                  >
+                    {{ getInitials(admin.displayName) }}
+                  </div>
+                } @else {
+                  <div
+                    class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white ring-2 ring-emerald-500/30"
+                    [style.background-color]="getAvatarColor(admin.email)"
+                  >
+                    {{ getInitials(admin.displayName) }}
+                  </div>
+                }
+                <div
+                  class="absolute -bottom-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center border-2 border-[#0f172a]"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-2.5 w-2.5 text-[#050810]"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div>
+                <div class="text-sm font-medium text-white flex items-center gap-2">
+                  {{ admin.displayName }}
+                  <span
+                    class="px-1.5 py-0.5 rounded text-[10px] font-bold bg-emerald-500/20 text-emerald-400 border border-emerald-500/20"
+                    >OWNER</span
+                  >
+                </div>
+                <div class="text-xs text-slate-400">{{ admin.email }}</div>
+              </div>
             </div>
           </div>
+        }
+      </div>
+    </div>
 
-          <!-- Helper text -->
-          <p class="mt-2 text-xs text-slate-500">
-            Search for people in your organization to add them to this project.
-          </p>
-
-          <!-- Search Results Dropdown -->
-          @if (showResults() && searchResults().length > 0) {
+    <!-- Project Admins -->
+    @if (admins().length > 0) {
+      <div>
+        <h3 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">
+          Project Admins
+        </h3>
+        <div class="space-y-2">
+          @for (admin of admins(); track admin.id) {
             <div
-              class="absolute top-full left-0 right-0 mt-2 bg-[#1e293b] border border-white/10 rounded-lg shadow-xl z-50 overflow-hidden max-h-60 overflow-y-auto"
+              class="flex items-center justify-between p-3 bg-[#0f172a]/30 border border-purple-500/20 rounded-lg group hover:border-purple-500/40 transition-colors"
             >
-              @for (user of searchResults(); track user.id) {
-                <button
-                  (click)="addMember(user)"
-                  class="w-full text-left px-4 py-3 hover:bg-white/5 flex items-center gap-3 transition-colors border-b border-white/5 last:border-0"
-                  [disabled]="isMember(user.id)"
-                  [class.opacity-50]="isMember(user.id)"
-                  [class.cursor-not-allowed]="isMember(user.id)"
-                >
-                  @if (user.photoURL) {
-                    <img
-                      [src]="user.photoURL"
-                      class="w-8 h-8 rounded-full bg-slate-800 object-cover"
-                      alt=""
-                      #userImg
-                      (error)="userImg.style.display = 'none'; userFallback.style.display = 'flex'"
-                    />
-                    <div
-                      #userFallback
-                      class="w-8 h-8 rounded-full items-center justify-center text-xs font-bold text-white hidden"
-                      [style.background-color]="getAvatarColor(user.email)"
-                    >
-                      {{ getInitials(user.displayName) }}
-                    </div>
-                  } @else {
-                    <div
-                      class="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold text-white"
-                      [style.background-color]="getAvatarColor(user.email)"
-                    >
-                      {{ getInitials(user.displayName) }}
-                    </div>
-                  }
-                  <div>
-                    <div class="text-sm font-medium text-white">
-                      {{ user.displayName }}
-                      @if (isMember(user.id)) {
-                        <span class="ml-2 text-xs text-emerald-400 font-normal"
-                          >(Already a member)</span
-                        >
-                      }
-                    </div>
-                    <div class="text-xs text-slate-400">{{ user.email }}</div>
+              <div class="flex items-center gap-3">
+                @if (admin.photoURL) {
+                  <img
+                    [src]="admin.photoURL"
+                    class="w-10 h-10 rounded-full bg-slate-800 object-cover ring-2 ring-purple-500/30"
+                    alt=""
+                    #padminImg
+                    (error)="padminImg.style.display = 'none'; padminFallback.style.display = 'flex'"
+                  />
+                  <div
+                    #padminFallback
+                    class="w-10 h-10 rounded-full items-center justify-center text-sm font-bold text-white ring-2 ring-purple-500/30 hidden"
+                    [style.background-color]="getAvatarColor(admin.email)"
+                  >
+                    {{ getInitials(admin.displayName) }}
                   </div>
-                </button>
+                } @else {
+                  <div
+                    class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white ring-2 ring-purple-500/30"
+                    [style.background-color]="getAvatarColor(admin.email)"
+                  >
+                    {{ getInitials(admin.displayName) }}
+                  </div>
+                }
+                <div>
+                  <div class="text-sm font-medium text-white flex items-center gap-2">
+                    {{ admin.displayName }}
+                    <span
+                      class="px-1.5 py-0.5 rounded text-[10px] font-bold bg-purple-500/20 text-purple-300 border border-purple-500/20"
+                      >ADMIN</span
+                    >
+                  </div>
+                  <div class="text-xs text-slate-400">{{ admin.email }}</div>
+                </div>
+              </div>
+
+              <!-- Owner-only admin controls -->
+              @if (isOwner()) {
+                <div class="flex items-center gap-1">
+                  <button
+                    (click)="makeOwner(admin)"
+                    class="px-2 py-1 text-xs font-medium text-emerald-300 hover:text-emerald-200 hover:bg-emerald-500/10 rounded-lg transition-all"
+                    title="Transfer ownership to this admin"
+                  >
+                    Make owner
+                  </button>
+                  <button
+                    (click)="removeAdmin(admin)"
+                    class="px-2 py-1 text-xs font-medium text-slate-400 hover:text-rose-400 hover:bg-rose-500/10 rounded-lg transition-all"
+                    title="Revoke admin rights"
+                  >
+                    Remove admin
+                  </button>
+                </div>
               }
             </div>
           }
         </div>
       </div>
+    }
 
-      <!-- Members List -->
-      <div class="space-y-4">
-        <!-- Admins (Owner) -->
-        <div>
-          <h3 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">
-            Project Admins
-          </h3>
-          <div class="space-y-2">
-            @for (admin of admins(); track admin.id) {
-              <div
-                class="flex items-center justify-between p-3 bg-[#0f172a]/30 border border-emerald-500/20 rounded-lg group hover:border-emerald-500/40 transition-colors"
-              >
-                <div class="flex items-center gap-3">
-                  <div class="relative">
-                    @if (admin.photoURL) {
-                      <img
-                        [src]="admin.photoURL"
-                        class="w-10 h-10 rounded-full bg-slate-800 object-cover ring-2 ring-emerald-500/30"
-                        alt=""
-                        #adminImg
-                        (error)="
-                          adminImg.style.display = 'none'; adminFallback.style.display = 'flex'
-                        "
-                      />
-                      <div
-                        #adminFallback
-                        class="w-10 h-10 rounded-full items-center justify-center text-sm font-bold text-white ring-2 ring-emerald-500/30 hidden"
-                        [style.background-color]="getAvatarColor(admin.email)"
-                      >
-                        {{ getInitials(admin.displayName) }}
-                      </div>
-                    } @else {
-                      <div
-                        class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white ring-2 ring-emerald-500/30"
-                        [style.background-color]="getAvatarColor(admin.email)"
-                      >
-                        {{ getInitials(admin.displayName) }}
-                      </div>
-                    }
-                    <div
-                      class="absolute -bottom-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center border-2 border-[#0f172a]"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-2.5 w-2.5 text-[#050810]"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
-                    </div>
+    <!-- Other Members -->
+    <div>
+      <h3 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">
+        Project Members
+      </h3>
+      @if (members().length === 0) {
+        <div class="text-center py-6 border border-dashed border-slate-800 rounded-lg">
+          <p class="text-sm text-slate-500">No additional members yet.</p>
+        </div>
+      } @else {
+        <div class="space-y-2">
+          @for (member of members(); track member.id) {
+            <div
+              class="flex items-center justify-between p-3 bg-[#0f172a]/30 border border-white/5 rounded-lg group hover:border-white/10 transition-colors"
+            >
+              <div class="flex items-center gap-3">
+                @if (member.photoURL) {
+                  <img
+                    [src]="member.photoURL"
+                    class="w-10 h-10 rounded-full bg-slate-800 object-cover"
+                    alt=""
+                    #memberImg
+                    (error)="
+                      memberImg.style.display = 'none'; memberFallback.style.display = 'flex'
+                    "
+                  />
+                  <div
+                    #memberFallback
+                    class="w-10 h-10 rounded-full items-center justify-center text-sm font-bold text-white hidden"
+                    [style.background-color]="getAvatarColor(member.email)"
+                  >
+                    {{ getInitials(member.displayName) }}
                   </div>
-                  <div>
-                    <div class="text-sm font-medium text-white flex items-center gap-2">
-                      {{ admin.displayName }}
-                      <span
-                        class="px-1.5 py-0.5 rounded text-[10px] font-bold bg-emerald-500/20 text-emerald-400 border border-emerald-500/20"
-                        >OWNER</span
-                      >
-                    </div>
-                    <div class="text-xs text-slate-400">{{ admin.email }}</div>
+                } @else {
+                  <div
+                    class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white"
+                    [style.background-color]="getAvatarColor(member.email)"
+                  >
+                    {{ getInitials(member.displayName) }}
                   </div>
+                }
+                <div>
+                  <div class="text-sm font-medium text-white">{{ member.displayName }}</div>
+                  <div class="text-xs text-slate-400">{{ member.email }}</div>
                 </div>
               </div>
-            }
-          </div>
-        </div>
 
-        <!-- Other Members -->
-        <div>
-          <h3 class="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">
-            Project Members
-          </h3>
-          @if (members().length === 0) {
-            <div class="text-center py-6 border border-dashed border-slate-800 rounded-lg">
-              <p class="text-sm text-slate-500">No additional members yet.</p>
-            </div>
-          } @else {
-            <div class="space-y-2">
-              @for (member of members(); track member.id) {
-                <div
-                  class="flex items-center justify-between p-3 bg-[#0f172a]/30 border border-white/5 rounded-lg group hover:border-white/10 transition-colors"
-                >
-                  <div class="flex items-center gap-3">
-                    @if (member.photoURL) {
-                      <img
-                        [src]="member.photoURL"
-                        class="w-10 h-10 rounded-full bg-slate-800 object-cover"
-                        alt=""
-                        #memberImg
-                        (error)="
-                          memberImg.style.display = 'none'; memberFallback.style.display = 'flex'
-                        "
-                      />
-                      <div
-                        #memberFallback
-                        class="w-10 h-10 rounded-full items-center justify-center text-sm font-bold text-white hidden"
-                        [style.background-color]="getAvatarColor(member.email)"
-                      >
-                        {{ getInitials(member.displayName) }}
-                      </div>
-                    } @else {
-                      <div
-                        class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white"
-                        [style.background-color]="getAvatarColor(member.email)"
-                      >
-                        {{ getInitials(member.displayName) }}
-                      </div>
-                    }
-                    <div>
-                      <div class="text-sm font-medium text-white">{{ member.displayName }}</div>
-                      <div class="text-xs text-slate-400">{{ member.email }}</div>
-                    </div>
-                  </div>
+              <div class="flex items-center gap-1">
+                <!-- Owner-only role controls -->
+                @if (isOwner()) {
+                  <button
+                    (click)="makeAdmin(member)"
+                    class="opacity-0 group-hover:opacity-100 px-2 py-1 text-xs font-medium text-purple-300 hover:text-purple-200 hover:bg-purple-500/10 rounded-lg transition-all"
+                    title="Grant project-admin rights"
+                  >
+                    Make admin
+                  </button>
+                  <button
+                    (click)="makeOwner(member)"
+                    class="opacity-0 group-hover:opacity-100 px-2 py-1 text-xs font-medium text-emerald-300 hover:text-emerald-200 hover:bg-emerald-500/10 rounded-lg transition-all"
+                    title="Transfer ownership to this member"
+                  >
+                    Make owner
+                  </button>
+                }
 
+                <!-- Member removal — any project manager -->
+                @if (canManageMembers()) {
                   <button
                     (click)="removeMember(member.id)"
                     class="opacity-0 group-hover:opacity-100 p-2 text-slate-500 hover:text-rose-400 hover:bg-rose-500/10 rounded-lg transition-all"
@@ -235,10 +326,12 @@
                       />
                     </svg>
                   </button>
-                </div>
-              }
+                }
+              </div>
             </div>
           }
         </div>
-      </div>
+      }
     </div>
+  </div>
+</div>

--- a/src/app/features/projects/components/project-member-manager.component.ts
+++ b/src/app/features/projects/components/project-member-manager.component.ts
@@ -27,8 +27,8 @@ export class ProjectMemberManagerComponent {
   projectService = inject(ProjectService);
   contactsService = inject(ContactsService);
   dialogService = inject(DialogService);
-  private auth = inject(AuthService);
-  private permissions = inject(PermissionsService);
+  private readonly auth = inject(AuthService);
+  private readonly permissions = inject(PermissionsService);
 
   applyingGroup = signal(false);
 
@@ -53,7 +53,9 @@ export class ProjectMemberManagerComponent {
   private readonly currentUserId = computed(() => this.auth.currentUserSig()?.uid ?? null);
 
   /** Global super-admins manage every project regardless of project role. */
-  private readonly isGlobalAdmin = computed(() => this.permissions.currentPermissions().isSuperAdmin);
+  private readonly isGlobalAdmin = computed(
+    () => this.permissions.currentPermissions().isSuperAdmin,
+  );
 
   /** The signed-in user's role in this project ('owner' | 'admin' | 'member' | null). */
   readonly myRole = computed(() => getProjectRole(this.project(), this.currentUserId()));
@@ -202,13 +204,20 @@ export class ProjectMemberManagerComponent {
     }
   }
 
-  /** Surface a friendly message for permission-denied and known errors. */
+  /** Surface a friendly message; never leak raw SDK/internal error text. */
   private friendlyError(err: unknown): string {
     const message = err instanceof Error ? err.message : String(err);
     if (/permission|insufficient|PERMISSION_DENIED/i.test(message)) {
       return 'You do not have permission to perform this action on this project.';
     }
-    return message || 'Something went wrong. Please try again.';
+    // Surface our own validated, user-facing messages (thrown from the service
+    // layer); generic-ize anything that looks like an internal/SDK error so raw
+    // Firestore or network details never reach the user.
+    const isInternal = /firebase|firestore|internal|unavailable|network/i.test(message);
+    if (err instanceof Error && !isInternal) {
+      return message;
+    }
+    return 'Something went wrong. Please try again.';
   }
 
   /**

--- a/src/app/features/projects/components/project-member-manager.component.ts
+++ b/src/app/features/projects/components/project-member-manager.component.ts
@@ -5,10 +5,12 @@ import { ProjectService } from '../../../core/services/project.service';
 import { ContactsService } from '../../../core/services/contacts.service';
 import { Contact } from '../../../core/models/contact.model';
 import { DialogService } from '../../../core/services/dialog.service';
-import { Project } from '../../../core/models/domain.model';
+import { AuthService } from '../../../core/auth/auth.service';
+import { PermissionsService } from '../../../core/services/permissions.service';
+import { Project, getProjectRole, isProjectManager } from '../../../core/models/domain.model';
 import { UserGroupMember } from '../../../core/models/user-group.model';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { debounceTime, distinctUntilChanged, switchMap, map, startWith } from 'rxjs';
+import { debounceTime, switchMap, startWith } from 'rxjs';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { GroupPickerComponent } from '../../../shared/components/group-picker/group-picker.component';
 
@@ -25,6 +27,8 @@ export class ProjectMemberManagerComponent {
   projectService = inject(ProjectService);
   contactsService = inject(ContactsService);
   dialogService = inject(DialogService);
+  private auth = inject(AuthService);
+  private permissions = inject(PermissionsService);
 
   applyingGroup = signal(false);
 
@@ -45,18 +49,43 @@ export class ProjectMemberManagerComponent {
     { initialValue: [] },
   );
 
-  // Computed Lists based on Project Data and All Contacts
-  admins = computed(() => {
+  /** UID of the signed-in user. */
+  private readonly currentUserId = computed(() => this.auth.currentUserSig()?.uid ?? null);
+
+  /** Global super-admins manage every project regardless of project role. */
+  private readonly isGlobalAdmin = computed(() => this.permissions.currentPermissions().isSuperAdmin);
+
+  /** The signed-in user's role in this project ('owner' | 'admin' | 'member' | null). */
+  readonly myRole = computed(() => getProjectRole(this.project(), this.currentUserId()));
+
+  /** Owner-only capabilities: appoint/remove admins, transfer ownership, etc. */
+  readonly isOwner = computed(() => this.myRole() === 'owner' || this.isGlobalAdmin());
+
+  /** Manager capabilities: add/remove members and appear in admin controls. */
+  readonly canManageMembers = computed(
+    () => isProjectManager(this.project(), this.currentUserId()) || this.isGlobalAdmin(),
+  );
+
+  // Owner contact (project creator / current owner).
+  owner = computed(() => {
     const p = this.project();
-    const contacts = this.allContacts();
-    return contacts.filter((c) => c.id === p.ownerId);
+    return this.allContacts().filter((c) => c.id === p.ownerId);
   });
 
+  // Project admins (granted elevated rights) — excludes the owner.
+  admins = computed(() => {
+    const p = this.project();
+    const adminIds = new Set(p.adminIds ?? []);
+    return this.allContacts().filter((c) => c.id !== p.ownerId && adminIds.has(c.id));
+  });
+
+  // Plain members: in memberIds but neither owner nor admin.
   members = computed(() => {
     const p = this.project();
-    const contacts = this.allContacts();
-    // Members are in memberIds but NOT the owner
-    return contacts.filter((c) => p.memberIds.includes(c.id) && c.id !== p.ownerId);
+    const adminIds = new Set(p.adminIds ?? []);
+    return this.allContacts().filter(
+      (c) => p.memberIds.includes(c.id) && c.id !== p.ownerId && !adminIds.has(c.id),
+    );
   });
 
   isMember(userId: string): boolean {
@@ -71,6 +100,7 @@ export class ProjectMemberManagerComponent {
       await this.projectService.addMember(this.project().id, user.id);
     } catch (err) {
       console.error('Failed to add member', err);
+      await this.dialogService.alert(this.friendlyError(err), 'Could not add member');
     }
   }
 
@@ -113,7 +143,72 @@ export class ProjectMemberManagerComponent {
       await this.projectService.removeMember(this.project().id, userId);
     } catch (err) {
       console.error('Failed to remove member', err);
+      await this.dialogService.alert(this.friendlyError(err), 'Could not remove member');
     }
+  }
+
+  /** Grant a member project-admin rights (owner only). */
+  async makeAdmin(member: Contact) {
+    if (
+      !(await this.dialogService.confirm(
+        `Give ${member.displayName || member.email} admin rights on this project? ` +
+          `They will be able to manage members and edit project settings.`,
+        'Make Project Admin',
+      ))
+    )
+      return;
+    try {
+      await this.projectService.setProjectAdmin(this.project().id, member.id, true);
+    } catch (err) {
+      console.error('Failed to grant project admin', err);
+      await this.dialogService.alert(this.friendlyError(err), 'Could not update role');
+    }
+  }
+
+  /** Revoke a member's project-admin rights (owner only). */
+  async removeAdmin(member: Contact) {
+    if (
+      !(await this.dialogService.confirm(
+        `Remove ${member.displayName || member.email}'s admin rights? ` +
+          `They will remain a project member.`,
+        'Remove Admin Rights',
+      ))
+    )
+      return;
+    try {
+      await this.projectService.setProjectAdmin(this.project().id, member.id, false);
+    } catch (err) {
+      console.error('Failed to revoke project admin', err);
+      await this.dialogService.alert(this.friendlyError(err), 'Could not update role');
+    }
+  }
+
+  /** Transfer project ownership to another member (owner only). */
+  async makeOwner(member: Contact) {
+    if (
+      !(await this.dialogService.confirm(
+        `Transfer ownership of this project to ${member.displayName || member.email}? ` +
+          `You will become a project admin and lose owner-only rights ` +
+          `(deleting the project and transferring ownership).`,
+        'Transfer Ownership',
+      ))
+    )
+      return;
+    try {
+      await this.projectService.transferOwnership(this.project().id, member.id);
+    } catch (err) {
+      console.error('Failed to transfer ownership', err);
+      await this.dialogService.alert(this.friendlyError(err), 'Could not transfer ownership');
+    }
+  }
+
+  /** Surface a friendly message for permission-denied and known errors. */
+  private friendlyError(err: unknown): string {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/permission|insufficient|PERMISSION_DENIED/i.test(message)) {
+      return 'You do not have permission to perform this action on this project.';
+    }
+    return message || 'Something went wrong. Please try again.';
   }
 
   /**

--- a/src/app/features/settings/settings.component.html
+++ b/src/app/features/settings/settings.component.html
@@ -136,6 +136,36 @@
             />
           </div>
 
+          <!-- Job Title -->
+          <div class="mb-6">
+            <label class="block text-sm font-medium text-slate-300 mb-2">
+              Job Title
+              <span class="text-slate-500 font-normal ml-2">(Optional)</span>
+            </label>
+            <input
+              type="text"
+              [(ngModel)]="jobTitle"
+              maxlength="80"
+              placeholder="e.g. Product Manager"
+              class="w-full bg-slate-950/50 border border-white/10 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors"
+            />
+          </div>
+
+          <!-- Bio -->
+          <div class="mb-6">
+            <label class="block text-sm font-medium text-slate-300 mb-2">
+              Bio
+              <span class="text-slate-500 font-normal ml-2">(Optional)</span>
+            </label>
+            <textarea
+              [(ngModel)]="bio"
+              rows="3"
+              maxlength="280"
+              placeholder="A short blurb about you and what you work on."
+              class="w-full bg-slate-950/50 border border-white/10 rounded-lg px-4 py-2.5 text-white placeholder-slate-500 focus:border-purple-500 focus:ring-1 focus:ring-purple-500 transition-colors resize-none"
+            ></textarea>
+          </div>
+
           <!-- Save Button -->
           <button
             (click)="saveProfile()"
@@ -189,6 +219,109 @@
           } @else if (saveSuccess() === false) {
             <p class="mt-3 text-sm text-red-400">Failed to save profile. Please try again.</p>
           }
+        </section>
+
+        <!-- Dashboard Settings -->
+        <section class="bg-slate-900/50 border border-white/10 rounded-2xl p-6 mb-6">
+          <h2 class="text-lg font-semibold text-white mb-2 flex items-center gap-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-5 w-5 text-cyan-400"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+              />
+            </svg>
+            <span>Dashboard</span>
+          </h2>
+          <p class="text-sm text-slate-400 mb-6">
+            Customize how your personal My Tasks dashboard opens and looks.
+          </p>
+
+          <!-- Default View -->
+          <div class="mb-6">
+            <label class="block text-sm font-medium text-slate-300 mb-2">Default view</label>
+            <div class="flex flex-wrap gap-2">
+              @for (view of dashboardViews; track view.value) {
+                <button
+                  type="button"
+                  (click)="defaultMyTasksView = view.value"
+                  class="px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors"
+                  [class.bg-cyan-500/15]="defaultMyTasksView === view.value"
+                  [class.border-cyan-500/50]="defaultMyTasksView === view.value"
+                  [class.text-cyan-200]="defaultMyTasksView === view.value"
+                  [class.bg-slate-950/40]="defaultMyTasksView !== view.value"
+                  [class.border-white/10]="defaultMyTasksView !== view.value"
+                  [class.text-slate-400]="defaultMyTasksView !== view.value"
+                >
+                  {{ view.label }}
+                </button>
+              }
+            </div>
+            <p class="mt-2 text-xs text-slate-500">
+              Which pane opens first when you land on My Tasks.
+            </p>
+          </div>
+
+          <!-- Accent Color -->
+          <div class="mb-6">
+            <label class="block text-sm font-medium text-slate-300 mb-3">Accent color</label>
+            <div class="flex flex-wrap gap-3">
+              @for (color of avatarColors; track color.value) {
+                <button
+                  type="button"
+                  (click)="selectAccentColor(color.value)"
+                  class="w-10 h-10 rounded-full transition-all hover:scale-110 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900"
+                  [class.ring-2]="accentColor() === color.value"
+                  [class.ring-white]="accentColor() === color.value"
+                  [class.ring-offset-2]="accentColor() === color.value"
+                  [class.ring-offset-slate-900]="accentColor() === color.value"
+                  [style.background-color]="color.value"
+                  [title]="color.name"
+                >
+                  @if (accentColor() === color.value) {
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="h-5 w-5 text-white mx-auto"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fill-rule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clip-rule="evenodd"
+                      />
+                    </svg>
+                  }
+                </button>
+              }
+            </div>
+            <p class="mt-2 text-xs text-slate-500">
+              Highlights the active tab and accents on your dashboard.
+            </p>
+          </div>
+
+          <!-- Compact Mode -->
+          <label class="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              class="mt-1 h-4 w-4 rounded border-white/20 bg-slate-950 text-cyan-600 focus:ring-cyan-500"
+              [(ngModel)]="compactMode"
+            />
+            <span>
+              <span class="block text-sm font-medium text-slate-200">Compact mode</span>
+              <span class="block text-xs text-slate-400 mt-0.5">
+                Tighten spacing so more fits on screen at once.
+              </span>
+            </span>
+          </label>
+
+          <p class="mt-5 text-xs text-slate-500">
+            Use <span class="text-slate-300 font-medium">Save Changes</span> in the Profile section
+            above to apply dashboard settings.
+          </p>
         </section>
 
         <!-- GitHub Issues integration -->

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -14,6 +14,10 @@ import { Storage, ref, uploadBytes, getDownloadURL, deleteObject } from '@angula
 import { UserGroupManagerComponent } from '../user-groups/user-group-manager.component';
 import { DataExportImportComponent } from './data-export-import.component';
 import { GithubConnectionComponent } from './github-connection.component';
+import {
+  UserDashboardSettings,
+  resolveDashboardSettings,
+} from '../../core/models/user.model';
 
 const AVATAR_COLORS = [
   { name: 'Purple', value: '#8b5cf6' },
@@ -51,9 +55,23 @@ export class SettingsComponent {
 
   selectedColor = signal<string>('#8b5cf6');
   displayName = '';
+  jobTitle = '';
+  bio = '';
   emailNotificationsEnabled = true;
   saving = signal(false);
   saveSuccess = signal<boolean | null>(null);
+
+  // --- Dashboard settings (per-user My Tasks customization) ---
+  /** Available default-view options for the My Tasks dashboard. */
+  readonly dashboardViews: { value: UserDashboardSettings['defaultMyTasksView']; label: string }[] =
+    [
+      { value: 'overview', label: 'Overview' },
+      { value: 'list', label: 'My Tasks list' },
+      { value: 'available', label: 'Available to pick up' },
+    ];
+  defaultMyTasksView: UserDashboardSettings['defaultMyTasksView'] = 'overview';
+  compactMode = false;
+  accentColor = signal<string>('#00d2ff');
 
   // Profile photo upload state
   uploadingPhoto = signal(false);
@@ -79,7 +97,15 @@ export class SettingsComponent {
 
       this.seededUid = user.uid;
       this.displayName = user.displayName || '';
+      this.jobTitle = user.jobTitle || '';
+      this.bio = user.bio || '';
       this.emailNotificationsEnabled = user.emailNotificationsEnabled !== false;
+
+      const dashboard = resolveDashboardSettings(user);
+      this.defaultMyTasksView = dashboard.defaultMyTasksView;
+      this.compactMode = dashboard.compactMode;
+      this.accentColor.set(dashboard.accentColor);
+
       if (user.avatarColor) {
         this.selectedColor.set(user.avatarColor);
       } else {
@@ -94,6 +120,10 @@ export class SettingsComponent {
 
   selectColor(color: string): void {
     this.selectedColor.set(color);
+  }
+
+  selectAccentColor(color: string): void {
+    this.accentColor.set(color);
   }
 
   /**
@@ -179,10 +209,18 @@ export class SettingsComponent {
     this.saving.set(true);
     this.saveSuccess.set(null);
     try {
+      const dashboardSettings: UserDashboardSettings = {
+        defaultMyTasksView: this.defaultMyTasksView,
+        compactMode: this.compactMode,
+        accentColor: this.accentColor(),
+      };
       await this.authService.updateProfile({
         displayName: this.displayName,
+        jobTitle: this.jobTitle.trim(),
+        bio: this.bio.trim(),
         avatarColor: this.selectedColor(),
         emailNotificationsEnabled: this.emailNotificationsEnabled,
+        dashboardSettings,
       });
       this.saveSuccess.set(true);
       setTimeout(() => this.saveSuccess.set(null), 3000);

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -63,12 +63,14 @@ export class SettingsComponent {
 
   // --- Dashboard settings (per-user My Tasks customization) ---
   /** Available default-view options for the My Tasks dashboard. */
-  readonly dashboardViews: { value: UserDashboardSettings['defaultMyTasksView']; label: string }[] =
-    [
-      { value: 'overview', label: 'Overview' },
-      { value: 'list', label: 'My Tasks list' },
-      { value: 'available', label: 'Available to pick up' },
-    ];
+  readonly dashboardViews: {
+    value: UserDashboardSettings['defaultMyTasksView'];
+    label: string;
+  }[] = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'list', label: 'My Tasks list' },
+    { value: 'available', label: 'Available to pick up' },
+  ];
   defaultMyTasksView: UserDashboardSettings['defaultMyTasksView'] = 'overview';
   compactMode = false;
   accentColor = signal<string>('#00d2ff');


### PR DESCRIPTION
## What this is

Expands OmniTask's user-management surface in four ways, per the request to
strengthen individual profiles, per-user dashboard configuration, per-project
admin rights, and project ownership transfer.

Plan: `docs/plans/user-management-expansion.md`.

## Changes

### 1. Per-project admins (new)
- `Project.adminIds?: string[]` — members granted elevated "project admin"
  rights for **that** project. Always a subset of `memberIds`; the owner is
  implicitly the top admin and is never listed.
- Role helpers `getProjectRole()` / `isProjectManager()` in `domain.model.ts`
  (`owner` > `admin` > `member`).
- `ProjectService.setProjectAdmin(projectId, userId, makeAdmin)` (owner-only).
- **Design choice:** `memberIds` stays the membership source of truth, so the
  app-wide `where('memberIds','array-contains', uid)` queries and the Flutter
  companion are untouched. This is additive — no membership migration.

### 2. Ownership transfer (new)
- `ProjectService.transferOwnership(projectId, newOwnerId)` — owner hands the
  project to a current member; the prior owner stays on as a project admin, and
  the new owner is removed from the admin list (they now sit above it).
- `removeMember()` also drops a stale admin grant when removing an admin member.

### 3. Per-user dashboard settings (new)
- `UserDashboardSettings` on `UserProfile` (`defaultMyTasksView`, `compactMode`,
  `accentColor`) with `resolveDashboardSettings()` defaults.
- Consumed by the **My Tasks** dashboard: seeds the default pane, applies a
  compact density class, and themes the active-tab accent via a CSS custom
  property.

### 4. Individual profile fields
- Optional `jobTitle`, `bio`, `timezone` on `UserProfile`, editable from
  **Settings** (job title + bio inputs; new "Dashboard" settings section).

### UI
- `project-member-manager` now renders **Owner / Project Admins / Members** with
  role badges and contextual controls — *Make admin*, *Remove admin*, and
  *Make owner* (transfer) — gated by the viewer's project role. Add/remove
  member controls are limited to project managers (owner/admin).

## ⚠️ Firestore rules change (security-sensitive — please review the diff)

`firestore.rules` project `update` is tightened (server-side enforcement so the
client checks can't be bypassed):

- changing `ownerId` (transfer) → **current owner only**;
- changing `adminIds` (grant/revoke admin) → **current owner only**;
- changing `memberIds` (add/remove members) → **project admin** (owner or in
  `adminIds`) **and** the global `canInviteMembers` permission.

Regular members keep editing non-sensitive fields (sections, tags, description,
etc.) exactly as before. Global admins/super-admins still bypass. Existing
projects have no `adminIds`; the `adminIds is list` guard treats that as
"owner is the only manager", so **behavior is unchanged until an owner appoints
an admin**.

> Behavior delta worth calling out: member management moves from "any member
> with `canInviteMembers`" to "project admins". That is the per-project admin
> capability being added.

Out of scope (noted as future work): a read-only **Viewer** role, finer-grained
per-field write restrictions for regular members, and a public profile page.

## Test plan

- [x] `ng build --configuration production` — succeeds (pre-existing bundle-budget
      warnings only)
- [x] `ng test --watch=false --browsers=ChromeHeadless` — **366/366 pass**
      (incl. new `project.service` role/ownership tests)
- [x] `ng lint` — **0 errors**
- [ ] Manual (after rules deploy): owner appoints admin → admin manages members
      but cannot transfer or change the admin roster; owner transfers → new owner
      gains control, old owner becomes admin

## Rollback

Additive model/service/UI changes — revert the commit; `adminIds` and
`dashboardSettings` are optional and ignored by old code. For rules, re-deploy
the prior revision (only relaxes the member-management gate; no data migration).

https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ)_