### PR TITLE
ci(deploy): provision missing GitHub integration secrets to unblock live deploys

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -122,6 +122,33 @@ jobs:
       - name: Enable Required APIs for Firebase Extensions
         run: gcloud services enable firebaseinstallations.googleapis.com aiplatform.googleapis.com --project ${{ env.PROJECT_ID }}
 
+      - name: Ensure Functions secrets exist
+        # The GitHub Issues integration functions bind these secrets via
+        # defineSecret(). `firebase deploy --non-interactive` aborts the whole
+        # deploy if any bound secret is missing in Secret Manager
+        # ("have no value for the secret: GITHUB_APP_ID"), which blocks every
+        # push to live. Create an empty placeholder for any that don't exist
+        # yet so the deploy proceeds. Set real values later (without code
+        # changes) via: firebase functions:secrets:set <NAME> --project <id>.
+        # Existing secrets are never overwritten — the describe check skips them.
+        run: |
+          for SECRET in \
+            GITHUB_APP_ID \
+            GITHUB_APP_PRIVATE_KEY \
+            GITHUB_CLIENT_ID \
+            GITHUB_CLIENT_SECRET \
+            GITHUB_WEBHOOK_SECRET; do
+            if gcloud secrets describe "$SECRET" --project "${{ env.PROJECT_ID }}" >/dev/null 2>&1; then
+              echo "Secret $SECRET already exists; leaving it untouched."
+            else
+              echo "Creating placeholder for missing secret: $SECRET"
+              printf 'placeholder' | gcloud secrets create "$SECRET" \
+                --data-file=- \
+                --replication-policy=automatic \
+                --project "${{ env.PROJECT_ID }}"
+            fi
+          done
+
       - name: Deploy to Firebase (Hosting, Firestore, Functions)
         run: npx firebase-tools deploy --only hosting,firestore,functions --project ${{ env.PROJECT_ID }} --non-interactive --force
 


### PR DESCRIPTION
## Problem

The deploy to `live` for #185 failed — but **not** because of #185's changes. The Firestore rules compiled fine (`✓ rules file firestore.rules compiled successfully`). The functions deploy aborted:

```
Error: In non-interactive mode but have no value for the secret: GITHUB_APP_ID
```

### Root cause

The GitHub Issues integration from **#179** added Cloud Functions (`functions/src/github/functions.ts`) that bind five secrets via `defineSecret()`:

```
GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, GITHUB_CLIENT_ID,
GITHUB_CLIENT_SECRET, GITHUB_WEBHOOK_SECRET
```

`firebase deploy --only ...,functions --non-interactive` validates every bound secret and **aborts the entire deploy** if any has no value in Secret Manager. These secrets were never provisioned in the prod project, so **every push to `live` has failed at the functions step since #179 merged** — blocking all deploys (hosting, firestore, and functions), not just the GitHub ones. The #185 merge was simply the first `live` deploy since #179, which is why it surfaced now.

## Fix

Add a step in `deploy-cloudrun.yml`, before the Firebase deploy, that creates an **empty placeholder** for any of the five `GITHUB_*` secrets that don't yet exist, so the non-interactive deploy proceeds.

- Existing secrets are **never overwritten** — the `gcloud secrets describe` check skips them.
- The deploy service account already manages Secret Manager (it binds the existing `GOOGLE_*` / `NODEMAILER_*` secrets that deploy fine), so no new IAM is required.
- No functions/app code changes; the diff is the single workflow step.

## Required follow-up (to actually use the GitHub integration)

Placeholders unblock deploys but the GitHub connect flow will return a config error until real values are set. Set them at any time (no redeploy code change needed):

```
firebase functions:secrets:set GITHUB_APP_ID --project <project-id>
# ...repeat for GITHUB_APP_PRIVATE_KEY, GITHUB_CLIENT_ID,
#     GITHUB_CLIENT_SECRET, GITHUB_WEBHOOK_SECRET
```

The next deploy picks up the latest version automatically.

## Alternative considered

Gating the GitHub functions out of the deploy until secrets exist (conditional export). Rejected as more invasive and fragile in TS/Firebase CommonJS, and it would leave the merged feature undeployable. The placeholder approach is minimal, reversible, and self-healing once real values land. Happy to switch to gating if you'd prefer the functions not deploy until configured.

## Test plan

- [x] `deploy-cloudrun.yml` parses as valid YAML; new step ordered between "Enable Required APIs" and the Firebase deploy
- [ ] Merge → `live` deploy reaches and passes the Firebase step (authoritative verification is the deploy run itself)

> Note: this only changes the deploy workflow, which can't run from a PR build — the real confirmation is the next `live` deploy.

https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ)_