### PR TITLE
fix(functions): raise tiny callables to 256MiB to fix deploy healthcheck flakiness

### DIFF
--- a/functions/src/github/functions.ts
+++ b/functions/src/github/functions.ts
@@ -117,7 +117,7 @@ function mapConnectionError(err: unknown): never {
 // --- Connection callables ---
 
 export const getGithubOAuthConfig = onCall<void>(
-  { secrets: [githubClientId], memory: '128MiB' },
+  { secrets: [githubClientId], memory: '256MiB' },
   async (request) => {
     requireAuth(request.auth?.uid);
     const clientId = githubClientId.value();
@@ -175,7 +175,7 @@ export const completeGithubAuth = onCall<{ code: string; redirectUri: string }>(
   },
 );
 
-export const getGithubConnection = onCall<void>({ memory: '128MiB' }, async (request) => {
+export const getGithubConnection = onCall<void>({ memory: '256MiB' }, async (request) => {
   requireAuth(request.auth?.uid);
   const connection = await getConnection(request.auth.uid);
   if (!connection) return { connected: false };
@@ -188,7 +188,7 @@ export const getGithubConnection = onCall<void>({ memory: '128MiB' }, async (req
   };
 });
 
-export const disconnectGithub = onCall<void>({ memory: '128MiB' }, async (request) => {
+export const disconnectGithub = onCall<void>({ memory: '256MiB' }, async (request) => {
   requireAuth(request.auth?.uid);
   await deleteUserToken(request.auth.uid);
   await deleteConnection(request.auth.uid);
@@ -325,7 +325,7 @@ async function linkCreate(uid: string, token: string, data: LinkInput) {
 }
 
 export const unlinkTaskFromGithub = onCall<{ taskId: string }>(
-  { memory: '128MiB' },
+  { memory: '256MiB' },
   async (request) => {
     requireAuth(request.auth?.uid);
     const taskId = request.data?.taskId;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -586,7 +586,7 @@ async function storeRefreshToken(uid: string, refreshToken: string): Promise<voi
 export const getGoogleOAuthConfig = onCall<void>(
   {
     secrets: [googleClientId],
-    memory: '128MiB',
+    memory: '256MiB',
   },
   async (request) => {
     if (!request.auth) {
@@ -686,7 +686,7 @@ export const refreshGoogleAccessToken = onCall<void>(
  */
 export const revokeGoogleOfflineAccess = onCall<void>(
   {
-    memory: '128MiB',
+    memory: '256MiB',
   },
   async (request) => {
     if (!request.auth) {


### PR DESCRIPTION
## Problem

After #186 fixed the secret blocker, the `live` deploy still failed at the Firebase functions step with:

```
Could not create or update Cloud Run service <fn>, Container Healthcheck failed.
The user-provided container failed to start and listen on PORT=8080 within timeout.
```

## This is flakiness, not a code bug

The failing set **shifted between runs**:

| Run | Failed functions |
|-----|------------------|
| #186 (`4bc543c5`) | getGithubOAuthConfig, getGithubConnection, disconnectGithub, unlinkTaskFromGithub, getGoogleOAuthConfig |
| #187 (`3f80f41`) | disconnectGithub, getGithubOAuthConfig, **revokeGoogleOfflineAccess** |

Functions that failed in one run succeeded in the other. The one invariant: **every function that ever failed was declared at `128MiB`; all 18 functions at `256MiB` succeeded every time.** (An auto-generated "Explain error" suggested these functions need to `listen()` on port 8080 — that's incorrect for Firebase Functions v2, which owns the HTTP server; the same functions deploy fine on other runs.)

128 MiB allocates the least cold-start CPU, so those containers intermittently miss the startup healthcheck under the concurrent function-create load of a full deploy.

## Fix

Bump the six `128MiB` callables to `256MiB`:
`getGoogleOAuthConfig`, `revokeGoogleOfflineAccess`, `getGithubOAuthConfig`, `getGithubConnection`, `disconnectGithub`, `unlinkTaskFromGithub`.

They're low-traffic config/connection callables, so the memory increase is negligible. All functions are now uniformly `256MiB`.

## Test plan

- [x] `cd functions && npm run build` — clean
- [x] `cd functions && npm test` — 18/18 pass
- [ ] Merge → `live` deploy completes the Firebase functions step (the real verification)

## Note (separate from this PR)

Functions currently deploy to **us-central1** (Firebase default) while Cloud Run runs in **us-east1**. Moving functions to us-east1 is a breaking migration (recreates all functions, changes the `githubWebhook` URL, and requires pointing the Angular client's `getFunctions()` at us-east1) — best done deliberately after the pipeline is stable, not bundled with this fix.

https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ)_