### PR TITLE
feat(tasks): drag-to-nest subtasks in list and board views

### DIFF
--- a/src/app/core/services/task.service.ts
+++ b/src/app/core/services/task.service.ts
@@ -663,6 +663,34 @@ export class TaskService {
   }
 
   /**
+   * Assign or clear a task's parent (drag-to-create subtask). Rejects self-nesting
+   * and parentId cycles using the same BFS guard as deleteTask.
+   */
+  async setTaskParent(childId: string, parentId: string | null): Promise<void> {
+    if (childId === parentId) {
+      throw new Error('A task cannot be its own parent');
+    }
+    if (parentId && (await this.isDescendantOf(childId, parentId))) {
+      throw new Error('Cannot nest: would create a parent cycle');
+    }
+    await this.updateTask(childId, { parentId });
+  }
+
+  /** Walk up parentId from `nodeId`; true if `ancestorId` appears in the chain. */
+  async isDescendantOf(ancestorId: string, nodeId: string): Promise<boolean> {
+    let current: string | null = nodeId;
+    const visited = new Set<string>();
+    while (current) {
+      if (current === ancestorId) return true;
+      if (visited.has(current)) return false;
+      visited.add(current);
+      const doc = await this.getTask(current);
+      current = doc?.parentId ?? null;
+    }
+    return false;
+  }
+
+  /**
    * Delete a task and all of its subtasks using batch deletion.
    * Uses BFS with a visited-set to prevent infinite loops from parentId cycles.
    */

--- a/src/app/features/tasks/task-board-view.component.css
+++ b/src/app/features/tasks/task-board-view.component.css
@@ -217,3 +217,31 @@
         -webkit-box-orient: vertical;
         overflow: hidden;
       }
+
+      .board-nest-drop-zone {
+        position: absolute;
+        inset: 0;
+        z-index: 30;
+        pointer-events: auto;
+        border-radius: 0.5rem;
+      }
+
+      .group\/board-card.nest-drop-active .board-nest-drop-zone {
+        background: rgba(34, 211, 238, 0.1);
+        outline: 2px dashed rgba(34, 211, 238, 0.5);
+        outline-offset: -2px;
+      }
+
+      .group\/board-card.nest-drop-active .board-nest-drop-zone::after {
+        content: 'Drop to make subtask';
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.65rem;
+        font-weight: 500;
+        color: rgba(34, 211, 238, 0.9);
+        pointer-events: none;
+        z-index: 31;
+      }

--- a/src/app/features/tasks/task-board-view.component.html
+++ b/src/app/features/tasks/task-board-view.component.html
@@ -389,9 +389,29 @@
               >
                 @for (task of getFilteredTasksForSection(section.id); track task.id) {
                   <div
+                    class="relative group/board-card"
+                    [class.nest-drop-active]="isDragging() && nestDropTargetId() === task.id"
+                  >
+                    @if (isDragging() && !selectionMode()) {
+                      <div
+                        cdkDropList
+                        [id]="nestDropListId(task.id)"
+                        [cdkDropListData]="nestDropData"
+                        [cdkDropListConnectedTo]="connectedDropLists()"
+                        [cdkDropListSortingDisabled]="true"
+                        (cdkDropListEntered)="onNestEntered(task)"
+                        (cdkDropListExited)="onNestExited(task)"
+                        (cdkDropListDropped)="onNestDrop($event, task)"
+                        class="board-nest-drop-zone"
+                        [attr.aria-label]="'Drop to make subtask of ' + task.title"
+                      ></div>
+                    }
+                  <div
                     cdkDrag
                     [cdkDragData]="task"
                     [cdkDragDisabled]="selectionMode()"
+                    (cdkDragStarted)="onDragStarted()"
+                    (cdkDragEnded)="onDragEnded()"
                     class="ofx-task-card rounded-lg border shadow-sm transition-all cursor-pointer group relative overflow-hidden z-0"
                     [class.p-4]="!getColumnSettings(section.id).compactMode"
                     [class.p-2]="getColumnSettings(section.id).compactMode"
@@ -577,6 +597,7 @@
                         ></app-point-value-badge>
                       }
                     </div>
+                  </div>
                   </div>
                 }
 

--- a/src/app/features/tasks/task-board-view.component.spec.ts
+++ b/src/app/features/tasks/task-board-view.component.spec.ts
@@ -1,10 +1,12 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TaskBoardViewComponent } from './task-board-view.component';
 import { TaskService } from '../../core/services/task.service';
 import { ProjectService } from '../../core/services/project.service';
-import { DragDropModule } from '@angular/cdk/drag-drop';
+import { DragDropModule, CdkDragDrop } from '@angular/cdk/drag-drop';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { generateMockTask } from '../../../testing/mock-data';
+import { Task } from '../../core/models/domain.model';
 
 describe('TaskBoardViewComponent', () => {
   let component: TaskBoardViewComponent;
@@ -13,8 +15,15 @@ describe('TaskBoardViewComponent', () => {
   let mockProjectService: any;
 
   beforeEach(async () => {
-    mockTaskService = jasmine.createSpyObj('TaskService', ['updateTask', 'deleteTask']);
+    mockTaskService = jasmine.createSpyObj('TaskService', [
+      'updateTask',
+      'deleteTask',
+      'setTaskParent',
+      'reorderTasks',
+    ]);
     mockTaskService.updateTask.and.returnValue(Promise.resolve());
+    mockTaskService.setTaskParent.and.returnValue(Promise.resolve());
+    mockTaskService.reorderTasks.and.returnValue(undefined);
 
     mockProjectService = jasmine.createSpyObj('ProjectService', ['updateProject']);
     mockProjectService.updateProject.and.returnValue(Promise.resolve());
@@ -61,5 +70,68 @@ describe('TaskBoardViewComponent', () => {
 
     component.toggleTaskSelection('t1');
     expect(component.selectedTaskIds().has('t1')).toBeTrue();
+  });
+
+  describe('drag-to-nest subtask', () => {
+    it('wouldCreateParentCycle detects direct and transitive cycles', () => {
+      fixture.componentRef.setInput('tasks', [
+        generateMockTask({ id: 'parent', parentId: null, sectionId: 's1' }),
+        generateMockTask({ id: 'child', parentId: 'parent', sectionId: 's1' }),
+        generateMockTask({ id: 'grandchild', parentId: 'child', sectionId: 's1' }),
+      ]);
+      fixture.detectChanges();
+
+      expect(component.wouldCreateParentCycle('parent', 'child')).toBeTrue();
+      expect(component.wouldCreateParentCycle('parent', 'grandchild')).toBeTrue();
+      expect(component.wouldCreateParentCycle('child', 'parent')).toBeFalse();
+    });
+
+    it('onNestDrop calls setTaskParent and clears drag state', fakeAsync(() => {
+      const parent = generateMockTask({ id: 'p1', title: 'Parent', sectionId: 's1' });
+      const child = generateMockTask({ id: 'c1', title: 'Child', parentId: null, sectionId: 's1' });
+      fixture.componentRef.setInput('tasks', [parent, child]);
+      fixture.detectChanges();
+
+      component.onDragStarted();
+      expect(component.isDragging()).toBeTrue();
+
+      const event = {
+        previousContainer: { id: 's1' },
+        container: { id: 'board-nest-p1' },
+        item: { data: child },
+      } as unknown as CdkDragDrop<Task[]>;
+
+      component.onNestDrop(event, parent);
+      tick();
+
+      expect(mockTaskService.setTaskParent).toHaveBeenCalledWith('c1', 'p1');
+      expect(component.isDragging()).toBeFalse();
+      expect(component.nestDropTargetId()).toBeNull();
+    }));
+
+    it('onNestDrop rejects self-nest and cycles', () => {
+      const parent = generateMockTask({ id: 'parent', parentId: null, sectionId: 's1' });
+      const child = generateMockTask({ id: 'child', parentId: 'parent', sectionId: 's1' });
+      fixture.componentRef.setInput('tasks', [parent, child]);
+      fixture.detectChanges();
+
+      const selfEvent = {
+        previousContainer: { id: 's1' },
+        container: { id: 'board-nest-parent' },
+        item: { data: parent },
+      } as unknown as CdkDragDrop<Task[]>;
+
+      component.onNestDrop(selfEvent, parent);
+      expect(mockTaskService.setTaskParent).not.toHaveBeenCalled();
+
+      const cycleEvent = {
+        previousContainer: { id: 's1' },
+        container: { id: 'board-nest-child' },
+        item: { data: parent },
+      } as unknown as CdkDragDrop<Task[]>;
+
+      component.onNestDrop(cycleEvent, child);
+      expect(mockTaskService.setTaskParent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/features/tasks/task-board-view.component.ts
+++ b/src/app/features/tasks/task-board-view.component.ts
@@ -65,8 +65,17 @@ export class TaskBoardViewComponent {
   menuTriggerRect = signal<DOMRect | null>(null);
   columnDisplaySettings = signal<Record<string, ColumnDisplaySettings>>({});
 
-  // Computed: Get all section IDs for drag-drop connection
-  connectedDropLists = computed(() => this.project().sections.map((s) => s.id));
+  // Computed: Get all section IDs for drag-drop connection (+ per-card nest targets)
+  connectedDropLists = computed(() => [
+    ...this.project().sections.map((s) => s.id),
+    ...this.nestDropListIds(),
+  ]);
+
+  nestDropListIds = computed(() => this.tasks().map((t) => this.nestDropListId(t.id)));
+
+  isDragging = signal(false);
+  nestDropTargetId = signal<string | null>(null);
+  readonly nestDropData: Task[] = [];
 
   projectSections = computed(() => this.project().sections.sort((a, b) => a.order - b.order));
 
@@ -218,9 +227,64 @@ export class TaskBoardViewComponent {
   }
 
   onDrop(event: CdkDragDrop<Task[]>, targetSectionId: string) {
-    // For both same-column and cross-column drops, logic is identical!
+    if (
+      event.previousContainer !== event.container &&
+      event.container.id.startsWith('board-nest-')
+    ) {
+      // Card nest targets handle this in onNestDrop.
+      return;
+    }
+
     const task = event.item.data as Task;
     this.reorderTask(task, event.currentIndex, targetSectionId, event.container.data);
+  }
+
+  nestDropListId(taskId: string): string {
+    return `board-nest-${taskId}`;
+  }
+
+  wouldCreateParentCycle(ancestorId: string, nodeId: string): boolean {
+    let current: string | null = nodeId;
+    const visited = new Set<string>();
+    const allTasks = this.tasks();
+    while (current) {
+      if (current === ancestorId) return true;
+      if (visited.has(current)) return false;
+      visited.add(current);
+      const doc = allTasks.find((t) => t.id === current);
+      current = doc?.parentId ?? null;
+    }
+    return false;
+  }
+
+  onDragStarted() {
+    this.isDragging.set(true);
+  }
+
+  onDragEnded() {
+    this.isDragging.set(false);
+    this.nestDropTargetId.set(null);
+  }
+
+  onNestEntered(parentTask: Task) {
+    this.nestDropTargetId.set(parentTask.id);
+  }
+
+  onNestExited(parentTask: Task) {
+    if (this.nestDropTargetId() === parentTask.id) {
+      this.nestDropTargetId.set(null);
+    }
+  }
+
+  onNestDrop(event: CdkDragDrop<Task[]>, parentTask: Task) {
+    if (event.previousContainer === event.container) return;
+
+    const child = event.item.data as Task;
+    if (!child?.id || child.id === parentTask.id) return;
+    if (this.wouldCreateParentCycle(child.id, parentTask.id)) return;
+
+    void this.taskService.setTaskParent(child.id, parentTask.id);
+    this.onDragEnded();
   }
 
   private reorderTask(movedTask: Task, newIndex: number, sectionId: string, siblingTasks: Task[]) {

--- a/src/app/features/tasks/task-list-view.component.css
+++ b/src/app/features/tasks/task-list-view.component.css
@@ -46,3 +46,29 @@
         padding: 0.35rem 0.5rem;
         margin: 0.25rem 0;
       }
+
+      .nest-drop-zone {
+        position: absolute;
+        inset: 0;
+        z-index: 20;
+        pointer-events: auto;
+      }
+
+      .group\/task-row.nest-drop-active .nest-drop-zone {
+        background: rgba(34, 211, 238, 0.08);
+        outline: 2px dashed rgba(34, 211, 238, 0.45);
+        outline-offset: -2px;
+      }
+
+      .group\/task-row.nest-drop-active .nest-drop-zone::after {
+        content: 'Drop to make subtask';
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.7rem;
+        font-weight: 500;
+        color: rgba(34, 211, 238, 0.85);
+        pointer-events: none;
+      }

--- a/src/app/features/tasks/task-list-view.component.html
+++ b/src/app/features/tasks/task-list-view.component.html
@@ -321,7 +321,9 @@
       <!-- Task List -->
       <div
         cdkDropList
+        [id]="mainDropListId"
         [cdkDropListData]="sortedTasks()"
+        [cdkDropListConnectedTo]="nestDropListIds()"
         (cdkDropListDropped)="onDrop($event)"
         class="flex-1 divide-y divide-cyan-500/5 pb-8"
       >
@@ -356,9 +358,29 @@
 
         @for (task of sortedTasks(); track task.id) {
           <div
+            class="relative group/task-row"
+            [class.nest-drop-active]="isDragging() && nestDropTargetId() === task.id"
+          >
+            @if (isDragging() && !selectionMode()) {
+              <div
+                cdkDropList
+                [id]="nestDropListId(task.id)"
+                [cdkDropListData]="nestDropData"
+                [cdkDropListConnectedTo]="[mainDropListId]"
+                [cdkDropListSortingDisabled]="true"
+                (cdkDropListEntered)="onNestEntered(task)"
+                (cdkDropListExited)="onNestExited(task)"
+                (cdkDropListDropped)="onNestDrop($event, task)"
+                class="nest-drop-zone"
+                [attr.aria-label]="'Drop to make subtask of ' + task.title"
+              ></div>
+            }
+          <div
             cdkDrag
             [cdkDragData]="task"
             [cdkDragDisabled]="selectionMode()"
+            (cdkDragStarted)="onDragStarted()"
+            (cdkDragEnded)="onDragEnded()"
             [class.opacity-50]="task.status === 'done'"
             [class.bg-purple-500/5]="isSelected(task.id)"
             [class.border-purple-500/30]="isSelected(task.id)"
@@ -582,6 +604,7 @@
                 }
               </div>
             }
+          </div>
           </div>
         }
       </div>

--- a/src/app/features/tasks/task-list-view.component.spec.ts
+++ b/src/app/features/tasks/task-list-view.component.spec.ts
@@ -6,6 +6,8 @@ import { ComponentRef } from '@angular/core';
 import { ProjectService } from '../../core/services/project.service';
 import { CustomFieldService } from '../../core/services/custom-field.service';
 import { of } from 'rxjs';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { Task } from '../../core/models/domain.model';
 
 describe('TaskListViewComponent', () => {
   let component: TaskListViewComponent;
@@ -20,7 +22,9 @@ describe('TaskListViewComponent', () => {
       'bulkUpdateTasks',
       'completeTask',
       'reopenTask',
+      'setTaskParent',
     ]);
+    mockTaskService.setTaskParent.and.returnValue(Promise.resolve());
 
     mockProjectService = jasmine.createSpyObj('ProjectService', ['getProject$']);
     mockProjectService.getProject$.and.returnValue(of({ id: 'p1', customFieldIds: [] }));
@@ -171,6 +175,66 @@ describe('TaskListViewComponent', () => {
       expect(args[1].completedAt).toBeNull();
       expect(component.selectedTaskIds().size).toBe(0);
     }));
+  });
+
+  describe('drag-to-nest subtask', () => {
+    it('wouldCreateParentCycle detects direct and transitive cycles', () => {
+      componentRef.setInput('tasks', [
+        generateMockTask({ id: 'parent', parentId: null }),
+        generateMockTask({ id: 'child', parentId: 'parent' }),
+        generateMockTask({ id: 'grandchild', parentId: 'child' }),
+      ]);
+      fixture.detectChanges();
+
+      // Args: (draggedTaskId, targetParentId) — cycle if target is under dragged.
+      expect(component.wouldCreateParentCycle('parent', 'child')).toBeTrue();
+      expect(component.wouldCreateParentCycle('parent', 'grandchild')).toBeTrue();
+      expect(component.wouldCreateParentCycle('child', 'parent')).toBeFalse();
+    });
+
+    it('onNestDrop calls setTaskParent and expands parent', fakeAsync(() => {
+      const parent = generateMockTask({ id: 'p1', title: 'Parent' });
+      const child = generateMockTask({ id: 'c1', title: 'Child', parentId: null });
+      componentRef.setInput('tasks', [parent, child]);
+      fixture.detectChanges();
+
+      const event = {
+        previousContainer: { id: 'task-list-main' },
+        container: { id: 'task-nest-p1' },
+        item: { data: child },
+      } as unknown as CdkDragDrop<Task[]>;
+
+      component.onNestDrop(event, parent);
+      tick();
+
+      expect(mockTaskService.setTaskParent).toHaveBeenCalledWith('c1', 'p1');
+      expect(component.expandedTaskIds().has('p1')).toBeTrue();
+    }));
+
+    it('onNestDrop rejects self-nest and cycles', () => {
+      const parent = generateMockTask({ id: 'parent', parentId: null });
+      const child = generateMockTask({ id: 'child', parentId: 'parent' });
+      componentRef.setInput('tasks', [parent, child]);
+      fixture.detectChanges();
+
+      const selfEvent = {
+        previousContainer: { id: 'task-list-main' },
+        container: { id: 'task-nest-parent' },
+        item: { data: parent },
+      } as unknown as CdkDragDrop<Task[]>;
+
+      component.onNestDrop(selfEvent, parent);
+      expect(mockTaskService.setTaskParent).not.toHaveBeenCalled();
+
+      const cycleEvent = {
+        previousContainer: { id: 'task-list-main' },
+        container: { id: 'task-nest-child' },
+        item: { data: parent },
+      } as unknown as CdkDragDrop<Task[]>;
+
+      component.onNestDrop(cycleEvent, child);
+      expect(mockTaskService.setTaskParent).not.toHaveBeenCalled();
+    });
   });
 
   describe('single actions', () => {

--- a/src/app/features/tasks/task-list-view.component.ts
+++ b/src/app/features/tasks/task-list-view.component.ts
@@ -66,6 +66,16 @@ export class TaskListViewComponent {
   // Expanding/collapsing tree nodes
   expandedTaskIds = signal<Set<string>>(new Set());
 
+  /** True while any task row is being dragged (shows nest drop targets). */
+  isDragging = signal(false);
+
+  /** Row highlighted as the current nest drop target. */
+  nestDropTargetId = signal<string | null>(null);
+
+  readonly mainDropListId = 'task-list-main';
+  /** Empty placeholder list data for per-row nest drop zones. */
+  readonly nestDropData: Task[] = [];
+
   project = toSignal(
     toObservable(this.projectId).pipe(
       switchMap((id) => (id ? this.projectService.getProject$(id) : of(null))),
@@ -384,7 +394,71 @@ export class TaskListViewComponent {
     }
   }
 
+  nestDropListId(taskId: string): string {
+    return `task-nest-${taskId}`;
+  }
+
+  nestDropListIds = computed(() =>
+    this.sortedTasks().map((t) => this.nestDropListId(t.id)),
+  );
+
+  /** Sync check using in-memory tasks (no Firestore round-trip during drag). */
+  wouldCreateParentCycle(ancestorId: string, nodeId: string): boolean {
+    let current: string | null = nodeId;
+    const visited = new Set<string>();
+    const allTasks = this.tasks();
+    while (current) {
+      if (current === ancestorId) return true;
+      if (visited.has(current)) return false;
+      visited.add(current);
+      const doc = allTasks.find((t) => t.id === current);
+      current = doc?.parentId ?? null;
+    }
+    return false;
+  }
+
+  onDragStarted() {
+    this.isDragging.set(true);
+  }
+
+  onDragEnded() {
+    this.isDragging.set(false);
+    this.nestDropTargetId.set(null);
+  }
+
+  onNestEntered(parentTask: Task) {
+    this.nestDropTargetId.set(parentTask.id);
+  }
+
+  onNestExited(parentTask: Task) {
+    if (this.nestDropTargetId() === parentTask.id) {
+      this.nestDropTargetId.set(null);
+    }
+  }
+
+  onNestDrop(event: CdkDragDrop<Task[]>, parentTask: Task) {
+    if (event.previousContainer === event.container) return;
+
+    const child = event.item.data as Task;
+    if (!child?.id || child.id === parentTask.id) return;
+    if (this.wouldCreateParentCycle(child.id, parentTask.id)) return;
+
+    void this.taskService.setTaskParent(child.id, parentTask.id).then(() => {
+      this.expandedTaskIds.update((set) => {
+        const next = new Set(set);
+        next.add(parentTask.id);
+        return next;
+      });
+    });
+    this.onDragEnded();
+  }
+
   onDrop(event: CdkDragDrop<TaskListViewNode[]>) {
+    if (event.previousContainer !== event.container) {
+      // Handled by onNestDrop on the row-level nest target.
+      return;
+    }
+
     const visible = event.container.data ?? this.sortedTasks();
     const prevIndex = event.previousIndex;
     const newIndex = event.currentIndex;
@@ -400,5 +474,6 @@ export class TaskListViewComponent {
     }));
 
     void this.taskService.reorderTasks(updates);
+    this.onDragEnded();
   }
 }


### PR DESCRIPTION
## Summary
- Add nest drop targets on list and board views while dragging a task
- Dropping onto another task calls TaskService.setTaskParent and auto-expands the new parent in list view
- Reject self-nesting and parent cycles in the UI (sync) and service (async Firestore walk)

## Test plan
- [x] ng test for task-list-view and task-board-view specs (20/20)
- [x] Manual: drag a task onto another in list view and confirm it nests under the parent
- [x] Manual: drag on board view and confirm parentId updates (cards stay in column)
- [ ] Manual: verify self-nest and cycle drops are rejected

Made with [Cursor](https://cursor.com)