### PR TITLE
ci(deploy): retry firebase deploy to absorb gen2 cold-start flakiness

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -150,7 +150,32 @@ jobs:
           done
 
       - name: Deploy to Firebase (Hosting, Firestore, Functions)
-        run: npx firebase-tools deploy --only hosting,firestore,functions --project ${{ env.PROJECT_ID }} --non-interactive --force
+        # Creating ~28 gen2 functions at once intermittently trips Cloud Run
+        # container startup healthchecks ("failed to start and listen on
+        # PORT=8080 within timeout") on a shifting subset of functions. Firebase
+        # skips unchanged functions on a re-run, so a retry re-attempts only the
+        # ones that didn't land — with far less concurrent cold-start load —
+        # which converges to a clean deploy. Retry up to 4 times with backoff.
+        run: |
+          set +e
+          attempts=4
+          for i in $(seq 1 $attempts); do
+            echo "::group::Firebase deploy attempt $i/$attempts"
+            npx firebase-tools deploy --only hosting,firestore,functions \
+              --project ${{ env.PROJECT_ID }} --non-interactive --force
+            code=$?
+            echo "::endgroup::"
+            if [ $code -eq 0 ]; then
+              echo "Firebase deploy succeeded on attempt $i."
+              exit 0
+            fi
+            if [ $i -lt $attempts ]; then
+              echo "Attempt $i failed (exit $code). Retrying in 30s..."
+              sleep 30
+            fi
+          done
+          echo "Firebase deploy failed after $attempts attempts." >&2
+          exit 1
 
       - name: Create Release Tag
         run: |


### PR DESCRIPTION
## Problem

Even after every function was bumped to 256 MiB (#188, preserved by #190), the `live` deploy still fails at the Firebase functions step:

```
Could not create or update Cloud Run service <fn>, Container Healthcheck failed.
The user-provided container failed to start and listen on PORT=8080 within timeout.
```

## Why it's flakiness, not a bug

The failing set **shifts every run** and the same function succeeds on other runs:

| Run | Failed (all 256 MiB by #190) |
|-----|------|
| #188 deploy | (functions step failed) |
| #190 deploy | disconnectGithub, getGithubConnection, getGithubOAuthConfig, updateGithubConnectionSettings |

`getGithubConnection` failed in one run and succeeded in another; the failing functions are identical in shape to ones that deploy fine. The memory bump fixed the worst offenders (the Google callables now deploy reliably), but the residual is **concurrent-deploy pressure**: Firebase creates ~28 gen2 functions at once, and some Cloud Run container startup healthchecks time out under that load. #190 (GitHub Phases 2–4) added more functions, making it more frequent.

## Fix

Wrap the Firebase deploy in a retry loop (up to 4 attempts, 30s backoff). Firebase **skips unchanged functions on a re-run**, so each retry re-attempts only the functions that didn't land — with far less concurrent cold-start pressure — converging to a clean deploy. Idempotent; hosting/firestore are no-ops on retries.

This is also a prerequisite for the upcoming **us-east1 migration**, which recreates *all* functions at once (max concurrency) and would otherwise hit this flakiness hard.

## Test plan

- [x] `deploy-cloudrun.yml` parses as valid YAML; deploy step retains the same flags inside the retry loop
- [ ] Merge → `live` deploy converges to success across attempts (authoritative verification is the deploy run)

> Workflow-only change; can't be exercised by a PR build.

https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrPQPGT1PgwFEyDXaDF8mZ)_