### PR TITLE
fix(tasks): register nest drop lists before drag starts

### DIFF
--- a/src/app/core/models/domain.model.ts
+++ b/src/app/core/models/domain.model.ts
@@ -293,6 +293,24 @@ export interface Task {
   isGoogleCalendarEvent?: boolean;
 }
 
+/** Sync parent-cycle check using in-memory tasks (e.g. during drag-and-drop). */
+export function wouldCreateTaskParentCycle(
+  ancestorId: string,
+  nodeId: string,
+  tasks: Pick<Task, 'id' | 'parentId'>[],
+): boolean {
+  let current: string | null = nodeId;
+  const visited = new Set<string>();
+  while (current) {
+    if (current === ancestorId) return true;
+    if (visited.has(current)) return false;
+    visited.add(current);
+    const taskDoc = tasks.find((t) => t.id === current);
+    current = taskDoc?.parentId ?? null;
+  }
+  return false;
+}
+
 /**
  * A task that recurs every day at a specific time.
  * Stored in users/{uid}/recurringTasks subcollection.

--- a/src/app/features/tasks/task-board-view.component.css
+++ b/src/app/features/tasks/task-board-view.component.css
@@ -226,6 +226,11 @@
         border-radius: 0.5rem;
       }
 
+      .board-nest-drop-zone--idle {
+        pointer-events: none;
+        z-index: 0;
+      }
+
       .group\/board-card.nest-drop-active .board-nest-drop-zone {
         background: rgba(34, 211, 238, 0.1);
         outline: 2px dashed rgba(34, 211, 238, 0.5);

--- a/src/app/features/tasks/task-board-view.component.html
+++ b/src/app/features/tasks/task-board-view.component.html
@@ -392,7 +392,7 @@
                     class="relative group/board-card"
                     [class.nest-drop-active]="isDragging() && nestDropTargetId() === task.id"
                   >
-                    @if (isDragging() && !selectionMode()) {
+                    @if (!selectionMode()) {
                       <div
                         cdkDropList
                         [id]="nestDropListId(task.id)"
@@ -403,16 +403,18 @@
                         (cdkDropListExited)="onNestExited(task)"
                         (cdkDropListDropped)="onNestDrop($event, task)"
                         class="board-nest-drop-zone"
+                        [class.board-nest-drop-zone--idle]="!isDragging()"
+                        [attr.aria-hidden]="!isDragging()"
                         [attr.aria-label]="'Drop to make subtask of ' + task.title"
                       ></div>
                     }
-                  <div
-                    cdkDrag
-                    [cdkDragData]="task"
-                    [cdkDragDisabled]="selectionMode()"
-                    (cdkDragStarted)="onDragStarted()"
-                    (cdkDragEnded)="onDragEnded()"
-                    class="ofx-task-card rounded-lg border shadow-sm transition-all cursor-pointer group relative overflow-hidden z-0"
+                    <div
+                      cdkDrag
+                      [cdkDragData]="task"
+                      [cdkDragDisabled]="selectionMode()"
+                      (cdkDragStarted)="onDragStarted()"
+                      (cdkDragEnded)="onDragEnded()"
+                      class="ofx-task-card rounded-lg border shadow-sm transition-all cursor-pointer group relative overflow-hidden z-0"
                     [class.p-4]="!getColumnSettings(section.id).compactMode"
                     [class.p-2]="getColumnSettings(section.id).compactMode"
                     [class.bg-slate-800]="task.status !== 'done' && !isSelected(task.id)"
@@ -600,8 +602,6 @@
                   </div>
                   </div>
                 }
-
-                <!-- Add Task Button -->
                 <button
                   class="w-full py-2 rounded-lg border border-dashed border-slate-700 text-slate-500 hover:text-slate-300 hover:border-slate-500 hover:bg-white/5 transition-all text-sm flex items-center justify-center gap-2"
                   (click)="quickAdd.emit(section.id)"

--- a/src/app/features/tasks/task-board-view.component.spec.ts
+++ b/src/app/features/tasks/task-board-view.component.spec.ts
@@ -11,8 +11,8 @@ import { Task } from '../../core/models/domain.model';
 describe('TaskBoardViewComponent', () => {
   let component: TaskBoardViewComponent;
   let fixture: ComponentFixture<TaskBoardViewComponent>;
-  let mockTaskService: any;
-  let mockProjectService: any;
+  let mockTaskService: jasmine.SpyObj<TaskService>;
+  let mockProjectService: jasmine.SpyObj<ProjectService>;
 
   beforeEach(async () => {
     mockTaskService = jasmine.createSpyObj('TaskService', [
@@ -40,7 +40,6 @@ describe('TaskBoardViewComponent', () => {
     fixture = TestBed.createComponent(TaskBoardViewComponent);
     component = fixture.componentInstance;
 
-    // Set required inputs
     fixture.componentRef.setInput('tasks', [
       {
         id: 't1',

--- a/src/app/features/tasks/task-board-view.component.ts
+++ b/src/app/features/tasks/task-board-view.component.ts
@@ -6,7 +6,7 @@ import {
   moveItemInArray,
   transferArrayItem,
 } from '@angular/cdk/drag-drop';
-import { Task, Section, Project } from '../../core/models/domain.model';
+import { Task, Section, Project, wouldCreateTaskParentCycle } from '../../core/models/domain.model';
 import { TaskService } from '../../core/services/task.service';
 import { ProjectService } from '../../core/services/project.service';
 import { hexToRgba, getColorWithOpacity } from '../../core/utils/color.utils';
@@ -65,7 +65,7 @@ export class TaskBoardViewComponent {
   menuTriggerRect = signal<DOMRect | null>(null);
   columnDisplaySettings = signal<Record<string, ColumnDisplaySettings>>({});
 
-  // Computed: Get all section IDs for drag-drop connection (+ per-card nest targets)
+  // Computed: section columns + per-card nest targets while dragging
   connectedDropLists = computed(() => [
     ...this.project().sections.map((s) => s.id),
     ...this.nestDropListIds(),
@@ -226,15 +226,7 @@ export class TaskBoardViewComponent {
     });
   }
 
-  onDrop(event: CdkDragDrop<Task[]>, targetSectionId: string) {
-    if (
-      event.previousContainer !== event.container &&
-      event.container.id.startsWith('board-nest-')
-    ) {
-      // Card nest targets handle this in onNestDrop.
-      return;
-    }
-
+  onDrop(event: CdkDragDrop<Task[]>, targetSectionId: string): void {
     const task = event.item.data as Task;
     this.reorderTask(task, event.currentIndex, targetSectionId, event.container.data);
   }
@@ -244,46 +236,38 @@ export class TaskBoardViewComponent {
   }
 
   wouldCreateParentCycle(ancestorId: string, nodeId: string): boolean {
-    let current: string | null = nodeId;
-    const visited = new Set<string>();
-    const allTasks = this.tasks();
-    while (current) {
-      if (current === ancestorId) return true;
-      if (visited.has(current)) return false;
-      visited.add(current);
-      const doc = allTasks.find((t) => t.id === current);
-      current = doc?.parentId ?? null;
-    }
-    return false;
+    return wouldCreateTaskParentCycle(ancestorId, nodeId, this.tasks());
   }
 
-  onDragStarted() {
+  onDragStarted(): void {
     this.isDragging.set(true);
   }
 
-  onDragEnded() {
+  onDragEnded(): void {
     this.isDragging.set(false);
     this.nestDropTargetId.set(null);
   }
 
-  onNestEntered(parentTask: Task) {
+  onNestEntered(parentTask: Task): void {
     this.nestDropTargetId.set(parentTask.id);
   }
 
-  onNestExited(parentTask: Task) {
+  onNestExited(parentTask: Task): void {
     if (this.nestDropTargetId() === parentTask.id) {
       this.nestDropTargetId.set(null);
     }
   }
 
-  onNestDrop(event: CdkDragDrop<Task[]>, parentTask: Task) {
+  onNestDrop(event: CdkDragDrop<Task[]>, parentTask: Task): void {
     if (event.previousContainer === event.container) return;
 
     const child = event.item.data as Task;
     if (!child?.id || child.id === parentTask.id) return;
     if (this.wouldCreateParentCycle(child.id, parentTask.id)) return;
 
-    void this.taskService.setTaskParent(child.id, parentTask.id);
+    void this.taskService.setTaskParent(child.id, parentTask.id).catch((err) => {
+      console.warn('Failed to nest task:', err);
+    });
     this.onDragEnded();
   }
 

--- a/src/app/features/tasks/task-list-view.component.css
+++ b/src/app/features/tasks/task-list-view.component.css
@@ -54,6 +54,11 @@
         pointer-events: auto;
       }
 
+      .nest-drop-zone--idle {
+        pointer-events: none;
+        z-index: 0;
+      }
+
       .group\/task-row.nest-drop-active .nest-drop-zone {
         background: rgba(34, 211, 238, 0.08);
         outline: 2px dashed rgba(34, 211, 238, 0.45);

--- a/src/app/features/tasks/task-list-view.component.html
+++ b/src/app/features/tasks/task-list-view.component.html
@@ -323,7 +323,8 @@
         cdkDropList
         [id]="mainDropListId"
         [cdkDropListData]="sortedTasks()"
-        [cdkDropListConnectedTo]="nestDropListIds()"
+        [cdkDropListConnectedTo]="connectedDropLists()"
+        [cdkDropListDisabled]="selectionMode()"
         (cdkDropListDropped)="onDrop($event)"
         class="flex-1 divide-y divide-cyan-500/5 pb-8"
       >
@@ -361,32 +362,34 @@
             class="relative group/task-row"
             [class.nest-drop-active]="isDragging() && nestDropTargetId() === task.id"
           >
-            @if (isDragging() && !selectionMode()) {
+            @if (!selectionMode()) {
               <div
                 cdkDropList
                 [id]="nestDropListId(task.id)"
                 [cdkDropListData]="nestDropData"
-                [cdkDropListConnectedTo]="[mainDropListId]"
+                [cdkDropListConnectedTo]="connectedDropLists()"
                 [cdkDropListSortingDisabled]="true"
                 (cdkDropListEntered)="onNestEntered(task)"
                 (cdkDropListExited)="onNestExited(task)"
                 (cdkDropListDropped)="onNestDrop($event, task)"
                 class="nest-drop-zone"
+                [class.nest-drop-zone--idle]="!isDragging()"
+                [attr.aria-hidden]="!isDragging()"
                 [attr.aria-label]="'Drop to make subtask of ' + task.title"
               ></div>
             }
-          <div
-            cdkDrag
-            [cdkDragData]="task"
-            [cdkDragDisabled]="selectionMode()"
-            (cdkDragStarted)="onDragStarted()"
-            (cdkDragEnded)="onDragEnded()"
-            [class.opacity-50]="task.status === 'done'"
-            [class.bg-purple-500/5]="isSelected(task.id)"
-            [class.border-purple-500/30]="isSelected(task.id)"
-            class="group hover:bg-cyan-500/5 transition-all cursor-pointer bg-[#0a0f1e]/80 border-l-2 border-transparent hover:border-cyan-500/50"
-            (click)="selectionMode() ? toggleTaskSelection(task.id) : taskClick.emit(task)"
-          >
+            <div
+              cdkDrag
+              [cdkDragData]="task"
+              [cdkDragDisabled]="selectionMode()"
+              (cdkDragStarted)="onDragStarted()"
+              (cdkDragEnded)="onDragEnded()"
+              [class.opacity-50]="task.status === 'done'"
+              [class.bg-purple-500/5]="isSelected(task.id)"
+              [class.border-purple-500/30]="isSelected(task.id)"
+              class="group hover:bg-cyan-500/5 transition-all cursor-pointer bg-[#0a0f1e]/80 border-l-2 border-transparent hover:border-cyan-500/50"
+              (click)="selectionMode() ? toggleTaskSelection(task.id) : taskClick.emit(task)"
+            >
             <!-- Custom Drag Preview -->
             <div
               *cdkDragPreview
@@ -604,7 +607,7 @@
                 }
               </div>
             }
-          </div>
+            </div>
           </div>
         }
       </div>

--- a/src/app/features/tasks/task-list-view.component.spec.ts
+++ b/src/app/features/tasks/task-list-view.component.spec.ts
@@ -186,7 +186,6 @@ describe('TaskListViewComponent', () => {
       ]);
       fixture.detectChanges();
 
-      // Args: (draggedTaskId, targetParentId) — cycle if target is under dragged.
       expect(component.wouldCreateParentCycle('parent', 'child')).toBeTrue();
       expect(component.wouldCreateParentCycle('parent', 'grandchild')).toBeTrue();
       expect(component.wouldCreateParentCycle('child', 'parent')).toBeFalse();

--- a/src/app/features/tasks/task-list-view.component.ts
+++ b/src/app/features/tasks/task-list-view.component.ts
@@ -9,7 +9,11 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Task, CustomFieldDefinition } from '../../core/models/domain.model';
+import {
+  Task,
+  CustomFieldDefinition,
+  wouldCreateTaskParentCycle,
+} from '../../core/models/domain.model';
 import { TaskService } from '../../core/services/task.service';
 import { ProjectService } from '../../core/services/project.service';
 import { CustomFieldService } from '../../core/services/custom-field.service';
@@ -398,45 +402,35 @@ export class TaskListViewComponent {
     return `task-nest-${taskId}`;
   }
 
-  nestDropListIds = computed(() =>
-    this.sortedTasks().map((t) => this.nestDropListId(t.id)),
-  );
+  nestDropListIds = computed(() => this.sortedTasks().map((t) => this.nestDropListId(t.id)));
+
+  connectedDropLists = computed(() => [this.mainDropListId, ...this.nestDropListIds()]);
 
   /** Sync check using in-memory tasks (no Firestore round-trip during drag). */
   wouldCreateParentCycle(ancestorId: string, nodeId: string): boolean {
-    let current: string | null = nodeId;
-    const visited = new Set<string>();
-    const allTasks = this.tasks();
-    while (current) {
-      if (current === ancestorId) return true;
-      if (visited.has(current)) return false;
-      visited.add(current);
-      const doc = allTasks.find((t) => t.id === current);
-      current = doc?.parentId ?? null;
-    }
-    return false;
+    return wouldCreateTaskParentCycle(ancestorId, nodeId, this.tasks());
   }
 
-  onDragStarted() {
+  onDragStarted(): void {
     this.isDragging.set(true);
   }
 
-  onDragEnded() {
+  onDragEnded(): void {
     this.isDragging.set(false);
     this.nestDropTargetId.set(null);
   }
 
-  onNestEntered(parentTask: Task) {
+  onNestEntered(parentTask: Task): void {
     this.nestDropTargetId.set(parentTask.id);
   }
 
-  onNestExited(parentTask: Task) {
+  onNestExited(parentTask: Task): void {
     if (this.nestDropTargetId() === parentTask.id) {
       this.nestDropTargetId.set(null);
     }
   }
 
-  onNestDrop(event: CdkDragDrop<Task[]>, parentTask: Task) {
+  onNestDrop(event: CdkDragDrop<TaskListViewNode[]>, parentTask: Task): void {
     if (event.previousContainer === event.container) return;
 
     const child = event.item.data as Task;
@@ -449,16 +443,13 @@ export class TaskListViewComponent {
         next.add(parentTask.id);
         return next;
       });
+    }).catch((err) => {
+      console.warn('Failed to nest task:', err);
     });
     this.onDragEnded();
   }
 
-  onDrop(event: CdkDragDrop<TaskListViewNode[]>) {
-    if (event.previousContainer !== event.container) {
-      // Handled by onNestDrop on the row-level nest target.
-      return;
-    }
-
+  onDrop(event: CdkDragDrop<TaskListViewNode[]>): void {
     const visible = event.container.data ?? this.sortedTasks();
     const prevIndex = event.previousIndex;
     const newIndex = event.currentIndex;


### PR DESCRIPTION
## Summary
- Fixes P1 from PR #189 review: nest `cdkDropList` targets must exist before drag starts
- Keep drop zones in DOM; hide with `--idle` CSS until dragging
- Extract `wouldCreateTaskParentCycle` helper; remove dead `onDrop` guards

## Test plan
- [x] Unit tests for task-list-view and task-board-view
- [ ] Manual: drag task onto another in list/board; verify nest + cycle rejection