### PR TITLE
feat(settings): user-level Google Calendar due-date sync

### DIFF
--- a/src/app/core/services/google-calendar-sync.service.spec.ts
+++ b/src/app/core/services/google-calendar-sync.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { GoogleCalendarSyncService } from './google-calendar-sync.service';
+import { Task } from '../models/domain.model';
+import { Firestore } from '@angular/fire/firestore';
+import { GoogleCalendarService } from './google-calendar.service';
+import { AuthService } from '../auth/auth.service';
+
+describe('GoogleCalendarSyncService', () => {
+  let service: GoogleCalendarSyncService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        GoogleCalendarSyncService,
+        { provide: Firestore, useValue: {} },
+        { provide: GoogleCalendarService, useValue: {} },
+        { provide: AuthService, useValue: { currentUserSig: () => null } },
+      ],
+    });
+    service = TestBed.inject(GoogleCalendarSyncService);
+  });
+
+  it('taskToCalendarEvent maps due date to all-day event with exclusive end date', () => {
+    const task: Task = {
+      id: 't1',
+      projectId: 'p1',
+      title: 'Ship feature',
+      description: 'Details',
+      status: 'todo',
+      priority: 'medium',
+      order: 0,
+      dueDate: new Date(2026, 5, 12),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const event = service.taskToCalendarEvent(task);
+    expect(event.summary).toBe('Ship feature');
+    expect(event.start?.date).toBe('2026-06-12');
+    expect(event.end?.date).toBe('2026-06-13');
+    expect(event.extendedProperties?.private?.omniTaskId).toBe('t1');
+  });
+
+  it('calendarEventDueDate reads all-day start date', () => {
+    const due = service.calendarEventDueDate({ start: { date: '2026-06-12' } });
+    expect(due?.getFullYear()).toBe(2026);
+    expect(due?.getMonth()).toBe(5);
+    expect(due?.getDate()).toBe(12);
+  });
+});

--- a/src/app/core/services/google-calendar-sync.service.ts
+++ b/src/app/core/services/google-calendar-sync.service.ts
@@ -1,88 +1,193 @@
 import { Injectable, inject } from '@angular/core';
-import { Firestore, doc, updateDoc, collection } from '@angular/fire/firestore';
+import {
+  Firestore,
+  doc,
+  updateDoc,
+  collection,
+  query,
+  where,
+  getDocs,
+} from '@angular/fire/firestore';
 import { firstValueFrom } from 'rxjs';
 import { GoogleCalendarService, GoogleCalendarEvent } from './google-calendar.service';
+import { AuthService } from '../auth/auth.service';
 import { Task } from '../models/domain.model';
 
-/**
- * Mirrors task due dates to Google Calendar events. Scaffold only — wire into
- * TaskService once users re-consent with the calendar.events scope.
- */
+const OMNITASK_ID_KEY = 'omniTaskId';
+
+/** Format a local date as YYYY-MM-DD for all-day Calendar events. */
+function toDateOnlyString(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function firestoreDueDate(value: Task['dueDate']): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'object' && 'toDate' in value) {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  return null;
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class GoogleCalendarSyncService {
   private readonly firestore = inject(Firestore);
   private readonly calendarService = inject(GoogleCalendarService);
+  private readonly authService = inject(AuthService);
   private readonly tasksCollection = collection(this.firestore, 'tasks');
 
-  /** Default calendar id when none is configured on the task/project. */
-  private static readonly PRIMARY_CALENDAR = 'primary';
-
-  toCalendarEvent(task: Partial<Task>): GoogleCalendarEvent {
+  /** Map a task due date to an all-day Calendar event (exclusive end date +1 day). */
+  taskToCalendarEvent(task: Task): GoogleCalendarEvent {
     const event: GoogleCalendarEvent = {
-      summary: task.title ?? 'Untitled task',
+      summary: task.title,
       description: task.description ?? '',
+      extendedProperties: {
+        private: { [OMNITASK_ID_KEY]: task.id },
+      },
     };
 
-    if (task.dueDate) {
-      const due =
-        task.dueDate instanceof Date
-          ? task.dueDate
-          : typeof task.dueDate === 'object' && 'toDate' in task.dueDate
-            ? (task.dueDate as { toDate: () => Date }).toDate()
-            : null;
-      if (due) {
-        event.start = { dateTime: due.toISOString() };
-        const end = new Date(due.getTime() + 30 * 60 * 1000);
-        event.end = { dateTime: end.toISOString() };
-      }
+    const due = firestoreDueDate(task.dueDate);
+    if (due) {
+      const start = toDateOnlyString(due);
+      const endDate = new Date(due);
+      endDate.setDate(endDate.getDate() + 1);
+      event.start = { date: start };
+      event.end = { date: toDateOnlyString(endDate) };
     }
 
     return event;
   }
 
-  async pushTaskToCalendar(
-    task: Task,
-    calendarId?: string,
-  ): Promise<{ calendarId: string; eventId: string } | null> {
-    if (!this.calendarService.isAuthenticated()) return null;
-    if (!task.dueDate) return null;
-
-    const targetCalendarId = calendarId ?? task.googleCalendarId ?? GoogleCalendarSyncService.PRIMARY_CALENDAR;
-    const payload = this.toCalendarEvent(task);
-
-    if (task.googleCalendarEventId) {
-      const updated = await firstValueFrom(
-        this.calendarService.updateEvent(targetCalendarId, task.googleCalendarEventId, payload),
-      );
-      return updated.id ? { calendarId: targetCalendarId, eventId: updated.id } : null;
-    }
-
-    const created = await firstValueFrom(
-      this.calendarService.createEvent(targetCalendarId, payload),
-    );
-    if (!created.id) return null;
-
-    await updateDoc(doc(this.tasksCollection, task.id), {
-      googleCalendarId: targetCalendarId,
-      googleCalendarEventId: created.id,
-      isGoogleCalendarEvent: true,
-    });
-
-    return { calendarId: targetCalendarId, eventId: created.id };
+  calendarEventDueDate(event: Pick<GoogleCalendarEvent, 'start'>): Date | null {
+    const dateStr = event.start?.date;
+    if (!dateStr) return null;
+    const [y, m, d] = dateStr.split('-').map(Number);
+    if (!y || !m || !d) return null;
+    return new Date(y, m - 1, d);
   }
 
-  async deleteCalendarEvent(task: Task, calendarId?: string): Promise<void> {
-    if (!this.calendarService.isAuthenticated()) return;
-    if (!task.googleCalendarEventId) return;
+  private resolveCalendarId(preferred?: string | null): string {
+    const user = this.authService.currentUserSig();
+    return preferred ?? user?.googleCalendarId ?? 'primary';
+  }
 
-    const targetCalendarId =
-      calendarId ?? task.googleCalendarId ?? GoogleCalendarSyncService.PRIMARY_CALENDAR;
+  private isSyncEnabled(): boolean {
+    return !!this.authService.currentUserSig()?.googleCalendarSyncEnabled;
+  }
+
+  async syncTaskOutbound(task: Task): Promise<void> {
+    if (!this.isSyncEnabled() || !this.calendarService.isAuthenticated()) return;
+
+    const due = firestoreDueDate(task.dueDate);
+    if (!due) {
+      await this.deleteTaskFromCalendar(task);
+      return;
+    }
+
+    const calendarId = this.resolveCalendarId(task.googleCalendarId);
+    const payload = this.taskToCalendarEvent(task);
+
+    try {
+      if (task.googleCalendarEventId) {
+        await firstValueFrom(
+          this.calendarService.updateEvent(calendarId, task.googleCalendarEventId, payload),
+        );
+        return;
+      }
+
+      const created = await firstValueFrom(
+        this.calendarService.createEvent(calendarId, payload),
+      );
+      if (!created.id) return;
+
+      await updateDoc(doc(this.tasksCollection, task.id), {
+        googleCalendarId: calendarId,
+        googleCalendarEventId: created.id,
+        isGoogleCalendarEvent: true,
+      });
+    } catch (err) {
+      console.warn('Google Calendar outbound sync failed:', err);
+    }
+  }
+
+  async pushAllDue Tasks(): Promise<{ pushed: number }> {
+    if (!this.isSyncEnabled() || !this.calendarService.isAuthenticated()) {
+      return { pushed: 0 };
+    }
+
+    const uid = this.authService.currentUserSig()?.uid;
+    if (!uid) return { pushed: 0 };
+
+    const snap = await getDocs(
+      query(this.tasksCollection, where('assigneeIds', 'array-contains', uid)),
+    );
+    let pushed = 0;
+    for (const docSnap of snap.docs) {
+      const task = { id: docSnap.id, ...docSnap.data() } as Task;
+      if (!firestoreDueDate(task.dueDate)) continue;
+      await this.syncTaskOutbound(task);
+      pushed++;
+    }
+
+    await this.authService.updateProfile({
+      lastCalendarSyncAt: new Date(),
+      calendarSyncStatus: 'synced',
+    });
+
+    return { pushed };
+  }
+
+  async pullFromCalendar(): Promise<{ updated: number }> {
+    if (!this.isSyncEnabled() || !this.calendarService.isAuthenticated()) {
+      return { updated: 0 };
+    }
+
+    const calendarId = this.resolveCalendarId();
+    const response = await firstValueFrom(this.calendarService.listEvents(calendarId));
+    let updated = 0;
+
+    for (const event of response.items ?? []) {
+      const taskId = event.extendedProperties?.private?.[OMNITASK_ID_KEY];
+      if (!taskId || event.status === 'cancelled') continue;
+
+      const due = this.calendarEventDueDate(event);
+      if (!due) continue;
+
+      await updateDoc(doc(this.tasksCollection, taskId), {
+        dueDate: due,
+        googleCalendarId: calendarId,
+        googleCalendarEventId: event.id ?? null,
+        isGoogleCalendarEvent: true,
+        updatedAt: new Date(),
+      });
+      updated++;
+    }
+
+    await this.authService.updateProfile({
+      lastCalendarSyncAt: new Date(),
+      calendarSyncStatus: 'synced',
+    });
+
+    return { updated };
+  }
+
+  async deleteTaskFromCalendar(task: Task): Promise<void> {
+    if (!this.calendarService.isAuthenticated() || !task.googleCalendarEventId) return;
+
+    const calendarId = this.resolveCalendarId(task.googleCalendarId);
     try {
       await firstValueFrom(
-        this.calendarService.deleteEvent(targetCalendarId, task.googleCalendarEventId),
+        this.calendarService.deleteEvent(calendarId, task.googleCalendarEventId),
       );
+      await updateDoc(doc(this.tasksCollection, task.id), {
+        googleCalendarEventId: null,
+        isGoogleCalendarEvent: false,
+      });
     } catch (err) {
       console.warn('Google Calendar delete failed:', err);
     }

--- a/src/app/core/services/google-calendar.service.ts
+++ b/src/app/core/services/google-calendar.service.ts
@@ -1,17 +1,25 @@
 import { Injectable, inject, computed } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
-import { AuthService } from '../auth/auth.service';
+import { AuthService } from '../../core/auth/auth.service';
 
 /** Google Calendar API event (subset). */
 export interface GoogleCalendarEvent {
   id?: string;
   summary?: string;
   description?: string;
+  status?: 'confirmed' | 'tentative' | 'cancelled' | string;
   start?: { dateTime?: string; date?: string; timeZone?: string };
   end?: { dateTime?: string; date?: string; timeZone?: string };
-  status?: 'confirmed' | 'tentative' | 'cancelled';
   updated?: string;
+  extendedProperties?: {
+    private?: Record<string, string>;
+  };
+}
+
+export interface GoogleCalendarEventsResponse {
+  items?: GoogleCalendarEvent[];
+  nextPageToken?: string;
 }
 
 export interface GoogleCalendarListEntry {
@@ -33,10 +41,10 @@ export class GoogleCalendarService {
   private readonly API_BASE_URL = 'https://www.googleapis.com/calendar/v3';
 
   /** Reuses the shared Google OAuth access token (same as Tasks/Sheets). */
-  isAuthenticated = computed(() => !!this.authService.googleTasksAccessToken());
+  isAuthenticated = computed(() => !!this.authService.googleTaskAccessToken());
 
   private getAuthHeaders(): HttpHeaders {
-    const token = this.authService.googleTasksAccessToken();
+    const token = this.authService.googleTaskAccessToken();
     if (!token) {
       throw new Error('Google Calendar not authenticated. Reconnect Google to grant calendar access.');
     }
@@ -59,7 +67,7 @@ export class GoogleCalendarService {
     if (!this.isAuthenticated()) {
       return throwError(() => new Error('Google Calendar not authenticated'));
     }
-    const encodedCalendar = encodeURIComponent(calendarId);
+    const embeddedCalendar = encodeURIComponent(calendarId);
     return this.http.get<GoogleCalendarEvent>(
       `${this.API_BASE_URL}/calendars/${encodedCalendar}/events/${eventId}`,
       { headers: this.getAuthHeaders() },
@@ -70,7 +78,7 @@ export class GoogleCalendarService {
     if (!this.isAuthenticated()) {
       return throwError(() => new Error('Google Calendar not authenticated'));
     }
-    const encodedCalendar = encodeURIComponent(calendarId);
+    const embeddedCalendar = encodeURIComponent(calendarId);
     return this.http.post<GoogleCalendarEvent>(
       `${this.API_BASE_URL}/calendars/${encodedCalendar}/events`,
       event,
@@ -86,7 +94,7 @@ export class GoogleCalendarService {
     if (!this.isAuthenticated()) {
       return throwError(() => new Error('Google Calendar not authenticated'));
     }
-    const encodedCalendar = encodeURIComponent(calendarId);
+    const embeddedCalendar = encodeURIComponent(calendarId);
     return this.http.patch<GoogleCalendarEvent>(
       `${this.API_BASE_URL}/calendars/${encodedCalendar}/events/${eventId}`,
       event,
@@ -98,10 +106,29 @@ export class GoogleCalendarService {
     if (!this.isAuthenticated()) {
       return throwError(() => new Error('Google Calendar not authenticated'));
     }
-    const encodedCalendar = encodeURIComponent(calendarId);
+    const embeddedCalendar = encodeURIComponent(calendarId);
     return this.http.delete<void>(
       `${this.API_BASE_URL}/calendars/${encodedCalendar}/events/${eventId}`,
       { headers: this.getAuthHeaders() },
+    );
+  }
+
+  /** List events carrying OmniTask extended property (for inbound due-date sync). */
+  listEvents(calendarId: string): Observable<GoogleCalendarEventsResponse> {
+    if (!this.isAuthenticated()) {
+      return throwError(() => new Error('Google Calendar not authenticated'));
+    }
+    const embeddedCalendar = encodeURIComponent(calendarId);
+    return this.http.get<GoogleCalendarEventsResponse>(
+      `${this.API_BASE_URL}/calendars/${encodedCalendar}/events`,
+      {
+        headers: this.getAuthHeaders(),
+        params: {
+          privateExtendedProperty: 'omniTaskId',
+          showDeleted: 'true',
+          maxResults: '250',
+        },
+      },
     );
   }
 }

--- a/src/app/core/services/task.service.ts
+++ b/src/app/core/services/task.service.ts
@@ -23,6 +23,7 @@ import { map } from 'rxjs/operators';
 import { AuthService } from '../auth/auth.service';
 import { GoogleTasksService, GoogleTask } from './google-tasks.service';
 import { GoogleTasksSyncService } from './google-tasks-sync.service';
+import { GoogleCalendarSyncService } from './google-calendar-sync.service';
 import { GoogleSheetsSyncService } from './google-sheets-sync.service';
 import { ProjectService } from './project.service';
 import { PermissionsService } from './permissions.service';
@@ -37,6 +38,7 @@ export class TaskService {
   private auth = inject(AuthService);
   private googleTasksService = inject(GoogleTasksService);
   private googleTasksSyncService = inject(GoogleTasksSyncService);
+  private googleCalendarSyncService = inject(GoogleCalendarSyncService);
   private googleSheetsSyncService = inject(GoogleSheetsSyncService);
   private projectService = inject(ProjectService);
   private permissions = inject(PermissionsService);
@@ -543,6 +545,9 @@ export class TaskService {
       // Optional Google Sheets push — never blocks the create
       void this.pushTaskToSheet(result.id);
 
+      const createdTask = { ...reconciled, id: result.id } as Task;
+      void this.googleCalendarSyncService.syncTaskOutbound(createdTask);
+
       // Auto-add assignees to project members
       if (task.assigneeIds?.length) {
         for (const uid of task.assigneeIds) {
@@ -616,6 +621,11 @@ export class TaskService {
 
       // Optional Google Sheets push — never blocks the update
       void this.pushTaskToSheet(id);
+
+      if (taskDoc) {
+        const updatedTask = { ...taskDoc, ...reconciled, id } as Task;
+        void this.googleCalendarSyncService.syncTaskOutbound(updatedTask);
+      }
 
       if (taskDoc && this.sideEffectsDepth === 0) {
         const updatedTask = { ...taskDoc, ...reconciled } as Task;
@@ -736,6 +746,7 @@ export class TaskService {
             console.warn('Google Tasks sync failed for task', task.id, err);
           }
         }
+        void this.googleCalendarSyncService.deleteTaskFromCalendar(task);
       }
 
       // Best-effort Google Sheets cleanup — clear each task's row in its project's sheet

--- a/src/app/features/settings/settings-google-calendar-sync.component.html
+++ b/src/app/features/settings/settings-google-calendar-sync.component.html
@@ -1,0 +1,118 @@
+<section class="bg-slate-900/50 border border-white/10 rounded-2xl p-6 mb-6">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-lg font-semibold text-white flex items-center gap-2">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-400" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M19 4h-1V2h-2v2H8V2H6v2H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V6a2 2 0 00-2-2zm0 16H5V10h14v10zM5 8V6h14v2H5zm2 4h10v2H7v-2z" />
+      </svg>
+      Google Calendar Sync
+    </h2>
+    @if (calendarAuthenticated()) {
+      <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/15 text-emerald-400 border border-emerald-500/30">
+        <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+        Connected
+      </span>
+    } @else {
+      <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-500/15 text-amber-400 border border-amber-500/30">
+        <span class="h-2 w-2 rounded-full bg-amber-400"></span>
+        Not connected
+      </span>
+    }
+  </div>
+
+  <p class="text-sm text-slate-400 mb-5">
+    Sync task due dates with your Google Calendar. Changes in OmniTask push to Calendar; use Pull to import Calendar edits.
+  </p>
+
+  @if (!calendarAuthenticated()) {
+    <div class="p-5 rounded-xl border border-blue-500/20 bg-slate-950/60 text-center">
+      <p class="text-sm text-slate-400 mb-4">Sign in with Google to grant Calendar access (includes existing Tasks/Sheets scopes).</p>
+      <button type="button" class="omni-glitch-btn px-4 py-2 rounded-lg bg-blue-600/80 text-white text-sm font-medium" (click)="reconnectGoogle()">
+        Sign in with Google
+      </button>
+    </div>
+  } @else {
+    <div class="space-y-4">
+      <label class="flex items-center justify-between gap-4 p-4 rounded-xl border border-white/10 bg-slate-950/40 cursor-pointer">
+        <div>
+          <p class="text-sm font-medium text-white">Enable calendar sync</p>
+          <p class="text-xs text-slate-500 mt-1">Create/update events when task due dates change</p>
+        </div>
+        <input
+          type="checkbox"
+          class="h-5 w-5 rounded border-slate-600 text-cyan-500 focus:ring-cyan-500"
+          [checked]="syncEnabled()"
+          (change)="toggleSyncEnabled()"
+        />
+      </label>
+
+      @if (syncEnabled()) {
+        <div class="p-4 rounded-xl border border-white/10 bg-slate-950/40 space-y-3">
+          <p class="text-xs uppercase tracking-wider text-slate-500">Target calendar</p>
+          @if (loadingCalendars()) {
+            <p class="text-sm text-slate-400">Loading calendars…</p>
+          } @else {
+            <select
+              class="w-full bg-slate-900 border border-white/10 rounded-lg px-3 py-2 text-sm text-white"
+              [value]="selectedCalendarId()"
+              (change)="selectCalendar($any($event.target).value)"
+            >
+              @for (cal of calendars(); track cal.id) {
+                <option [value]="cal.id">{{ cal.summary }}{{ cal.primary ? ' (Primary)' : '' }}</option>
+              }
+              @if (calendars().length === 0) {
+                <option value="primary">Primary calendar</option>
+              }
+            </select>
+          }
+
+          <p class="text-xs text-slate-500">
+            Last sync: {{ formatSyncDate(currentUser()?.lastCalendarSyncAt) }}
+          </p>
+
+          <div class="flex flex-wrap gap-2 pt-1">
+            <button
+              type="button"
+              class="omni-glitch-btn px-3 py-1.5 rounded-lg border border-cyan-500/40 bg-cyan-500/10 text-cyan-200 text-xs font-semibold disabled:opacity-50"
+              [disabled]="syncing()"
+              (click)="triggerPushSync()"
+            >
+              Push due tasks
+            </button>
+            <button
+              type="button"
+              class="omni-glitch-btn px-3 py-1.5 rounded-lg border border-violet-500/40 bg-violet-500/10 text-violet-200 text-xs font-semibold disabled:opacity-50"
+              [disabled]="syncing()"
+              (click)="triggerPullSync()"
+            >
+              {{ syncing() ? 'Syncing…' : 'Pull from Calendar' }}
+            </button>
+          </div>
+
+          @if (lastSyncResult()) {
+            <p class="text-xs" [class.text-emerald-400]="lastSyncResult()!.success" [class.text-rose-400]="!lastSyncResult()!.success">
+              {{ lastSyncResult()!.message }}
+            </p>
+          }
+        </div>
+
+        <div class="p-4 rounded-xl border border-white/5 bg-slate-950/30">
+          <p class="text-xs text-slate-400 mb-2">Background sync (token refresh for long-lived access)</p>
+          @if (hasOfflineAccess()) {
+            <button type="button" class="text-xs text-slate-400 hover:text-rose-400" (click)="disableOfflineAccess()">
+              Revoke offline access
+            </button>
+          } @else {
+            <button
+              type="button"
+              class="text-xs text-cyan-400 hover:text-cyan-300 disabled:opacity-50"
+              [disabled]="enablingOffline()"
+              (click)="enableOfflineAccess()"
+            >
+              Enable offline access
+            </button>
+          }
+        </div>
+      }
+    </div>
+  }
+</section>

--- a/src/app/features/settings/settings-google-calendar-sync.component.ts
+++ b/src/app/features/settings/settings-google-calendar-sync.component.ts
@@ -1,0 +1,168 @@
+import {
+  Component,
+  inject,
+  signal,
+  computed,
+  ChangeDetectionStrategy,
+  OnInit,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { AuthService } from '../../../core/auth/auth.service';
+import { DialogService } from '../../../core/services/dialog.service';
+import {
+  GoogleCalendarService,
+  GoogleCalendarListEntry,
+} from '../../../core/services/google-calendar.service';
+import { GoogleCalendarSyncService } from '../../../core/services/google-calendar-sync.service';
+
+@Component({
+  selector: 'app-settings-google-calendar-sync',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './settings-google-calendar-sync.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SettingsGoogleCalendarSyncComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly dialogService = inject(DialogService);
+  private readonly calendarService = inject(GoogleCalendarService);
+  private readonly calendarSyncService = inject(GoogleCalendarSyncService);
+  private readonly router = inject(Router);
+
+  currentUser = this.authService.currentUserSig;
+
+  calendarAuthenticated = computed(() => this.calendarService.isAuthenticated());
+  syncEnabled = computed(() => !!this.currentUser()?.googleCalendarSyncEnabled);
+  selectedCalendarId = computed(() => this.currentUser()?.googleCalendarId || 'primary');
+
+  calendars = signal<GoogleCalendarListEntry[]>([]);
+  loadingCalendars = signal(false);
+  syncing = signal(false);
+  lastSyncResult = signal<{ success: boolean; message: string } | null>(null);
+  enablingOffline = signal(false);
+
+  hasOfflineAccess = computed(() => this.authService.hasOfflineAccess());
+
+  ngOnInit(): void {
+    if (this.calendarAuthenticated()) {
+      void this.loadCalendars();
+    }
+  }
+
+  async loadCalendars(): Promise<void> {
+    if (!this.calendarAuthenticated()) return;
+    this.loadingCalendars.set(true);
+    try {
+      const response = await firstValueFrom(this.calendarService.listCalendars());
+      this.calendars.set(response.items ?? []);
+    } catch (err) {
+      console.error('Failed to load calendars:', err);
+      this.calendars.set([]);
+    } finally {
+      this.loadingCalendars.set(false);
+    }
+  }
+
+  async toggleSyncEnabled(): Promise<void> {
+    const next = !this.syncEnabled();
+    try {
+      await this.authService.updateProfile({
+        googleCalendarSyncEnabled: next,
+        calendarSyncStatus: next ? 'pending' : undefined,
+      });
+      if (next && this.calendarAuthenticated()) {
+        await this.loadCalendars();
+      }
+    } catch (err) {
+      console.error('Failed to toggle calendar sync:', err);
+    }
+  }
+
+  async selectCalendar(calendarId: string): Promise<void> {
+    try {
+      await this.authService.updateProfile({
+        googleCalendarId: calendarId,
+        calendarSyncStatus: 'pending',
+      });
+    } catch (err) {
+      console.error('Failed to select calendar:', err);
+    }
+  }
+
+  async triggerPullSync(): Promise<void> {
+    this.syncing.set(true);
+    try {
+      const result = await this.calendarSyncService.pullFromCalendar();
+      this.lastSyncResult.set({
+        success: true,
+        message: `Pulled ${result.updated} due date update(s) from Google Calendar`,
+      });
+    } catch (err) {
+      console.error('Calendar pull failed:', err);
+      await this.authService.updateProfile({ calendarSyncStatus: 'error' });
+      this.lastSyncResult.set({
+        success: false,
+        message: 'Calendar sync failed. Reconnect Google and try again.',
+      });
+    } finally {
+      this.syncing.set(false);
+      setTimeout(() => this.lastSyncResult.set(null), 6000);
+    }
+  }
+
+  async triggerPushSync(): Promise<void> {
+    this.syncing.set(true);
+    try {
+      const result = await this.calendarSyncService.pushAllDueTasks();
+      this.lastSyncResult.set({
+        success: true,
+        message: `Pushed ${result.pushed} task(s) to Google Calendar`,
+      });
+    } catch (err) {
+      console.error('Calendar push failed:', err);
+      this.lastSyncResult.set({
+        success: false,
+        message: 'Failed to push tasks to Google Calendar.',
+      });
+    } finally {
+      this.syncing.set(false);
+      setTimeout(() => this.lastSyncResult.set(null), 6000);
+    }
+  }
+
+  formatSyncDate(date: Date | { toDate: () => Date } | null | undefined): string {
+    if (!date) return 'Never';
+    const d = date instanceof Date ? date : date.toDate?.() ?? new Date();
+    return d.toLocaleString();
+  }
+
+  async reconnectGoogle(): Promise<void> {
+    await this.authService.logout();
+  }
+
+  async enableOfflineAccess(): Promise<void> {
+    this.enablingOffline.set(true);
+    try {
+      await this.authService.requestOfflineAccess(this.router.url);
+    } catch (err) {
+      console.error('Failed to request offline access:', err);
+      this.enablingOffline.set(false);
+    }
+  }
+
+  async disableOfflineAccess(): Promise<void> {
+    const confirmed = await this.dialogService.confirm(
+      'Disable background Google access? Scheduled sync and token refresh will stop until you reconnect.',
+      'Disable offline access',
+    );
+    if (!confirmed) return;
+    try {
+      await this.authService.revokeOfflineAccess();
+      this.lastSyncResult.set({ success: true, message: 'Offline Google access revoked.' });
+    } catch (err) {
+      console.error('Failed to revoke offline access:', err);
+    }
+  }
+}

--- a/src/app/features/settings/settings.component.html
+++ b/src/app/features/settings/settings.component.html
@@ -327,6 +327,9 @@
         <!-- GitHub Issues integration -->
         <app-github-connection />
 
+        <!-- Google Calendar Sync -->
+        <app-settings-google-calendar-sync />
+
         <!-- User Groups -->
         <section class="bg-slate-900/50 border border-white/10 rounded-2xl p-6 mb-6">
           <app-user-group-manager></app-user-group-manager>

--- a/src/app/features/settings/settings.component.ts
+++ b/src/app/features/settings/settings.component.ts
@@ -14,6 +14,7 @@ import { Storage, ref, uploadBytes, getDownloadURL, deleteObject } from '@angula
 import { UserGroupManagerComponent } from '../user-groups/user-group-manager.component';
 import { DataExportImportComponent } from './data-export-import.component';
 import { GithubConnectionComponent } from './github-connection.component';
+import { SettingsGoogleCalendarSyncComponent } from './settings-google-calendar-sync.component';
 import {
   UserDashboardSettings,
   resolveDashboardSettings,
@@ -43,6 +44,7 @@ const AVATAR_COLORS = [
     UserGroupManagerComponent,
     DataExportImportComponent,
     GithubConnectionComponent,
+    SettingsGoogleCalendarSyncComponent,
   ],
   templateUrl: './settings.component.html',
 })


### PR DESCRIPTION
## Summary
- Settings page: Google Calendar Sync (enable, calendar picker, Push/Pull)
- TaskService hooks: sync due dates on create/update/delete when enabled
- GoogleCalendarSyncService: all-day events with omniTaskId extended property

## Test plan
- [ ] Sign in with Google on production after merge
- [ ] Settings → enable sync → Push due tasks → verify Calendar events
- [ ] Pull from Calendar after editing an event due date