### PR TITLE
chore(email): finalize SMTP secret injection runbook and tooling

### DIFF
--- a/docs/runbooks/configure-firebase-smtp-secrets.md
+++ b/docs/runbooks/configure-firebase-smtp-secrets.md
@@ -40,8 +40,8 @@ This updates `EXT_MAIL_SMTP_CONNECTION_URI`, `EXT_MAIL_SMTP_PASSWORD`, optionall
 
 ```powershell
 cd functions
-$env:GOOGLE_CLOUD_PROJECT = 'omnitask-475422'
-node scripts/send-mail-test.js dijinvestments3@gmail.com
+node test-email.js
+node check-mail.js
 ```
 
 - Expect `delivery.state: SUCCESS` on the new `mail` document within ~15s.

--- a/docs/runbooks/configure-firebase-smtp-secrets.md
+++ b/docs/runbooks/configure-firebase-smtp-secrets.md
@@ -13,33 +13,44 @@ The `firestore-send-email` extension is wired in `extensions/firestore-send-emai
 
 1. Generate a Google App Password for the `omnitask@omniflexfitness.com` alias via a Workspace admin account (currently `bertin.kenol@omniflexfitness.com`).
 
-2. **Automated (recommended)** — requires `gcloud auth login`:
-
-   ```powershell
-   .\scripts\inject-smtp-secrets.ps1
-   # optional: also update NODEMAILER_SMTP_PASSWORD for Cloud Functions nodemailer
-   .\scripts\inject-smtp-secrets.ps1 -IncludeNodemailer
+2. Open [Secret Manager](https://console.cloud.google.com/security/secret-manager?project=omnitask-475422).
+3. Update `EXT_MAIL_SMTP_CONNECTION_URI` in Secret Manager (not the committed `.env` file) to the account that owns the App Password:
    ```
-
-3. **Manual alternative** — [Secret Manager](https://console.cloud.google.com/security/secret-manager?project=omnitask-475422):
-
-   - Update `EXT_MAIL_SMTP_CONNECTION_URI` (not the committed `.env` file) to the account that owns the App Password:
-     ```
-     smtps://bertin.kenol%40omniflexfitness.com@smtp.gmail.com:465
-     ```
-     Keep `DEFAULT_FROM` as `OmniTask <omnitask@omniflexfitness.com>` — the SMTP username is for authentication only.
-   - Update `EXT_MAIL_SMTP_PASSWORD` with the 16-character App Password.
-
-4. Deploy extensions:
+   smtps://bertin.kenol%40omniflexfitness.com@smtp.gmail.com:465
+   ```
+   Keep `DEFAULT_FROM` as `OmniTask <omnitask@omniflexfitness.com>` — the SMTP username is for authentication only.
+4. Update `EXT_MAIL_SMTP_PASSWORD` with the 16-character App Password.
+5. Deploy extensions:
    ```bash
-   npx firebase-tools deploy --only extensions
+   npx firebase-tools deploy --only extensions:firestore-send-email --project omnitask-475422
    ```
    Or trigger the GitHub Actions deploy workflow on `live`.
 
+### CLI shortcut (after installing [Google Cloud SDK](https://cloud.google.com/sdk/docs/install))
+
+From repo root, with `gcloud auth login` completed:
+
+```powershell
+.\scripts\inject-smtp-secrets.ps1 -AppPassword 'YOUR16CHARPASSWORD' -DeployExtension -UpdateNodemailerSecret
+```
+
+This updates `EXT_MAIL_SMTP_CONNECTION_URI`, `EXT_MAIL_SMTP_PASSWORD`, optionally `NODEMAILER_SMTP_PASSWORD`, and redeploys the extension.
+
 ## Verification
 
-- Add a document to the `mail` collection (or trigger a notification flow) and confirm delivery.
-- Check Cloud Functions logs for the `firestore-send-email` extension if send fails.
+```powershell
+cd functions
+$env:GOOGLE_CLOUD_PROJECT = 'omnitask-475422'
+node scripts/send-mail-test.js dijinvestments3@gmail.com
+```
+
+- Expect `delivery.state: SUCCESS` on the new `mail` document within ~15s.
+- Or trigger a task assignment and check the `notifications` collection via `node check-mail.js`.
+- Check Cloud Functions logs for `ext-firestore-send-email-processQueue` if send fails.
+
+## Cloud Functions path (same App Password)
+
+Task assignment and reminder emails use `NODEMAILER_SMTP_PASSWORD` in Cloud Functions (`functions/src/index.ts`), not the Firestore extension. After injecting secrets, also set runtime env `NODEMAILER_SMTP_USER=bertin.kenol@omniflexfitness.com` and redeploy functions if not already configured.
 
 ## Repo config reference
 

--- a/extensions/firestore-send-email.env
+++ b/extensions/firestore-send-email.env
@@ -1,7 +1,8 @@
 LOCATION=us-east1
 DATABASE_REGION=nam5
-SMTP_CONNECTION_URI=smtps://omnitask%40omniflexfitness.com@smtp.gmail.com:465
-SMTP_PASSWORD=projects/${PROJECT_NUMBER}/secrets/EXT_MAIL_SMTP_PASSWORD/versions/4
+# Auth user + host live in Secret Manager (see EXT_MAIL_SMTP_CONNECTION_URI); do not embed passwords here.
+SMTP_CONNECTION_URI=projects/${PROJECT_NUMBER}/secrets/EXT_MAIL_SMTP_CONNECTION_URI/versions/latest
+SMTP_PASSWORD=projects/${PROJECT_NUMBER}/secrets/EXT_MAIL_SMTP_PASSWORD/versions/latest
 MAIL_COLLECTION=mail
 DEFAULT_FROM=OmniTask <omnitask@omniflexfitness.com>
 DEFAULT_REPLY_TO=omnitask@omniflexfitness.com

--- a/scripts/inject-smtp-secrets.ps1
+++ b/scripts/inject-smtp-secrets.ps1
@@ -84,4 +84,4 @@ if ($DeployExtension) {
 
 Write-Host ''
 Write-Host 'Done. Next: run a mail test.' -ForegroundColor Green
-Write-Host '  cd functions && set GOOGLE_CLOUD_PROJECT=omnitask-475422 && node scripts/send-mail-test.js' -ForegroundColor Cyan
+Write-Host '  cd functions && node test-email.js && node check-mail.js' -ForegroundColor Cyan

--- a/scripts/inject-smtp-secrets.ps1
+++ b/scripts/inject-smtp-secrets.ps1
@@ -1,112 +1,87 @@
-#Requires -Version 5.1
-<#
-.SYNOPSIS
-  Add new Secret Manager versions for Firebase SMTP credentials (issue #91).
+# Injects Gmail App Password into Secret Manager for OmniTask (#91).
+# Requires: gcloud CLI authenticated as a user with secretmanager.versions.add on omnitask-475422
+#
+# Usage:
+#   .\scripts\inject-smtp-secrets.ps1 -AppPassword 'xxxxxxxxxxxxxxxx'
+#   .\scripts\inject-smtp-secrets.ps1 -AppPassword 'xxxxxxxxxxxxxxxx' -DeployExtension
+#   .\scripts\inject-smtp-secrets.ps1 -AppPassword 'xxxxxxxxxxxxxxxx' -DeployExtension -UpdateNodemailerSecret
 
-.DESCRIPTION
-  Updates EXT_MAIL_SMTP_CONNECTION_URI and EXT_MAIL_SMTP_PASSWORD in Google Cloud
-  Secret Manager for project omnitask-475422. Optionally updates
-  NODEMAILER_SMTP_PASSWORD for Cloud Functions nodemailer.
-
-  Does not write secrets to disk or echo passwords. Requires:
-    gcloud auth login
-    Secret Manager Secret Accessor (or Editor) on omnitask-475422
-
-.PARAMETER AppPassword
-  16-character Google App Password (no spaces). Prompted securely if omitted.
-
-.PARAMETER SmtpUser
-  SMTP auth username. Default: bertin.kenol@omniflexfitness.com
-
-.PARAMETER ProjectId
-  GCP project id. Default: omnitask-475422
-
-.PARAMETER IncludeNodemailer
-  Also add a NODEMAILER_SMTP_PASSWORD secret version (same App Password).
-
-.EXAMPLE
-  .\scripts\inject-smtp-secrets.ps1
-  .\scripts\inject-smtp-secrets.ps1 -AppPassword 'xxxx xxxx xxxx xxxx' -IncludeNodemailer
-
-.NOTES
-  Runbook: docs/runbooks/configure-firebase-smtp-secrets.md
-#>
-[CmdletBinding()]
 param(
+  [Parameter(Mandatory = $true)]
   [string]$AppPassword,
-  [string]$SmtpUser = 'bertin.kenol@omniflexfitness.com',
+
+  [switch]$DeployExtension,
+  [switch]$UpdateNodemailerSecret,
   [string]$ProjectId = 'omnitask-475422',
-  [switch]$IncludeNodemailer
+  [string]$SmtpUser = 'bertin.kenol@omniflexfitness.com'
 )
 
-Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Assert-Gcloud {
-  if (-not (Get-Command gcloud -ErrorAction SilentlyContinue)) {
-    throw 'gcloud CLI not found. Install Google Cloud SDK and run: gcloud auth login'
+function Ensure-Gcloud {
+  $gcloud = Get-Command gcloud -ErrorAction SilentlyContinue
+  if ($gcloud) {
+    return $gcloud.Source
   }
-  $account = gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>$null | Select-Object -First 1
-  if (-not $account) {
-    throw 'No active gcloud account. Run: gcloud auth login'
-  }
-  Write-Host "Using gcloud account: $account"
+
+  Write-Host 'gcloud not found. Install Google Cloud SDK, then re-run this script.' -ForegroundColor Yellow
+  Write-Host '  winget install Google.CloudSDK' -ForegroundColor Cyan
+  Write-Host '  gcloud auth login' -ForegroundColor Cyan
+  Write-Host '  gcloud config set project omnitask-475422' -ForegroundColor Cyan
+  throw 'gcloud is required to add Secret Manager versions from the CLI.'
 }
 
 function Add-SecretVersion {
   param(
-    [Parameter(Mandatory)][string]$SecretId,
-    [Parameter(Mandatory)][string]$Plaintext
+    [string]$SecretName,
+    [string]$Value
   )
+
   $tempFile = [System.IO.Path]::GetTempFileName()
   try {
-    [System.IO.File]::WriteAllText($tempFile, $Plaintext, [System.Text.UTF8Encoding]::new($false))
-    gcloud secrets versions add $SecretId `
-      --project=$ProjectId `
-      --data-file=$tempFile `
-      --quiet | Out-Null
-    Write-Host "Updated secret: $SecretId (new version)"
+    Set-Content -Path $tempFile -Value $Value -NoNewline -Encoding ascii
+    gcloud secrets versions add $SecretName --project=$ProjectId --data-file=$tempFile | Out-Host
+    Write-Host "Added secret version: $SecretName" -ForegroundColor Green
   }
   finally {
-    if (Test-Path $tempFile) {
-      Remove-Item $tempFile -Force
-    }
+    Remove-Item -Force $tempFile -ErrorAction SilentlyContinue
   }
 }
-
-Assert-Gcloud
 
 $normalizedPassword = ($AppPassword -replace '\s', '')
-if (-not $normalizedPassword) {
-  $secure = Read-Host 'Google App Password (16 chars, input hidden)' -AsSecureString
-  $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
-  try {
-    $normalizedPassword = ($bstr -replace '\s', '')
-  }
-  finally {
-    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR([ref]$bstr)
-  }
-}
-
 if ($normalizedPassword.Length -ne 16) {
-  throw "App Password must be 16 characters after removing spaces (got $($normalizedPassword.Length))."
+  throw 'App Password must be 16 characters after removing spaces.'
 }
 
 $encodedUser = [uri]::EscapeDataString($SmtpUser)
 $connectionUri = "smtps://${encodedUser}@smtp.gmail.com:465"
 
-Write-Host "Project: $ProjectId"
-Write-Host "SMTP user: $SmtpUser"
-Write-Host "Connection URI host: smtp.gmail.com:465 (user URL-encoded in secret)"
+Ensure-Gcloud | Out-Null
+gcloud config set project $ProjectId | Out-Null
 
-Add-SecretVersion -SecretId 'EXT_MAIL_SMTP_CONNECTION_URI' -Plaintext $connectionUri
-Add-SecretVersion -SecretId 'EXT_MAIL_SMTP_PASSWORD' -Plaintext $normalizedPassword
+Write-Host "Updating EXT_MAIL_SMTP_CONNECTION_URI..." -ForegroundColor Cyan
+Add-SecretVersion -SecretName 'EXT_MAIL_SMTP_CONNECTION_URI' -Value $connectionUri
 
-if ($IncludeNodemailer) {
-  Add-SecretVersion -SecretId 'NODEMAILER_SMTP_PASSWORD' -Plaintext $normalizedPassword
+Write-Host "Updating EXT_MAIL_SMTP_PASSWORD..." -ForegroundColor Cyan
+Add-SecretVersion -SecretName 'EXT_MAIL_SMTP_PASSWORD' -Value $normalizedPassword
+
+if ($UpdateNodemailerSecret) {
+  Write-Host "Updating NODEMAILER_SMTP_PASSWORD (Cloud Functions direct nodemailer path)..." -ForegroundColor Cyan
+  Add-SecretVersion -SecretName 'NODEMAILER_SMTP_PASSWORD' -Value $normalizedPassword
+}
+
+if ($DeployExtension) {
+  $repoRoot = Split-Path $PSScriptRoot -Parent
+  Push-Location $repoRoot
+  try {
+    Write-Host 'Deploying firestore-send-email extension...' -ForegroundColor Cyan
+    npx -y firebase-tools@latest deploy --only extensions:firestore-send-email --project $ProjectId
+  }
+  finally {
+    Pop-Location
+  }
 }
 
 Write-Host ''
-Write-Host 'Done. Deploy extensions or re-deploy functions so new secret versions bind:'
-Write-Host '  npx firebase-tools deploy --only extensions'
-Write-Host '  # or trigger the GitHub Actions deploy workflow on live'
+Write-Host 'Done. Next: run a mail test.' -ForegroundColor Green
+Write-Host '  cd functions && set GOOGLE_CLOUD_PROJECT=omnitask-475422 && node scripts/send-mail-test.js' -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- document issue #91 operational steps for SMTP Secret Manager setup
- align extension env to Secret Manager latest-version references
- add script flags for optional extension deploy and nodemailer secret update

## Test plan
- [x] reviewed only scoped paths changed
- [ ] run .\\scripts\\inject-smtp-secrets.ps1 with real App Password in project omnitask-475422
- [ ] run functions/scripts/send-mail-test.js and confirm delivery.state=SUCCESS


Made with [Cursor](https://cursor.com)