### PR TITLE
chore(security): dependabot batch 2 functions remediations

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,7 +11,7 @@
                 "firebase-functions": "^5.0.0",
                 "googleapis": "^130.0.0",
                 "marked": "^18.0.4",
-                "nodemailer": "^8.0.1"
+                "nodemailer": "^9.0.1"
             },
             "devDependencies": {
                 "@types/nodemailer": "^7.0.11",
@@ -26,7 +26,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
@@ -40,7 +39,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -79,7 +77,6 @@
             "version": "4.4.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -95,14 +92,12 @@
         "node_modules/@babel/core/node_modules/ms": {
             "version": "2.1.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@babel/generator": {
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.28.6",
                 "@babel/types": "^7.28.6",
@@ -118,7 +113,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
@@ -134,7 +128,6 @@
             "version": "7.28.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -143,7 +136,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -156,7 +148,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.28.6",
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -173,7 +164,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -182,7 +172,6 @@
             "version": "7.27.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -191,7 +180,6 @@
             "version": "7.28.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -200,7 +188,6 @@
             "version": "7.27.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -209,7 +196,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -222,7 +208,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.28.6"
             },
@@ -237,7 +222,6 @@
             "version": "7.8.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -249,7 +233,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -261,7 +244,6 @@
             "version": "7.12.13",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -273,7 +255,6 @@
             "version": "7.14.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -288,7 +269,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.28.6"
             },
@@ -303,7 +283,6 @@
             "version": "7.10.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -315,7 +294,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -327,7 +305,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.28.6"
             },
@@ -342,7 +319,6 @@
             "version": "7.10.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -354,7 +330,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -366,7 +341,6 @@
             "version": "7.10.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -378,7 +352,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -390,7 +363,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -402,7 +374,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -414,7 +385,6 @@
             "version": "7.14.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -429,7 +399,6 @@
             "version": "7.14.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -444,7 +413,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.28.6"
             },
@@ -459,7 +427,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/parser": "^7.28.6",
@@ -473,7 +440,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/generator": "^7.28.6",
@@ -491,7 +457,6 @@
             "version": "4.4.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -507,14 +472,12 @@
         "node_modules/@babel/traverse/node_modules/ms": {
             "version": "2.1.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@babel/types": {
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
                 "@babel/helper-validator-identifier": "^7.28.5"
@@ -526,8 +489,41 @@
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
             "license": "MIT",
-            "peer": true
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@fastify/busboy": {
             "version": "3.2.0",
@@ -689,7 +685,9 @@
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.14.3",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
@@ -738,7 +736,6 @@
             "version": "8.0.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "string-width": "^5.1.2",
                 "string-width-cjs": "npm:string-width@^4.2.0",
@@ -755,7 +752,6 @@
             "version": "1.1.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
@@ -771,7 +767,6 @@
             "version": "0.1.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -780,7 +775,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -797,7 +791,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/console": "30.2.0",
                 "@jest/pattern": "30.0.1",
@@ -844,7 +837,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -853,7 +845,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/fake-timers": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -868,7 +859,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "expect": "30.2.0",
                 "jest-snapshot": "30.2.0"
@@ -881,7 +871,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0"
             },
@@ -893,7 +882,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@sinonjs/fake-timers": "^13.0.0",
@@ -910,7 +898,6 @@
             "version": "30.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -919,7 +906,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/expect": "30.2.0",
@@ -934,7 +920,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "jest-regex-util": "30.0.1"
@@ -947,7 +932,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "30.2.0",
@@ -989,7 +973,6 @@
             "version": "30.0.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -1001,7 +984,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "chalk": "^4.1.2",
@@ -1016,7 +998,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "callsites": "^3.1.0",
@@ -1030,7 +1011,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/console": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -1045,7 +1025,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/test-result": "30.2.0",
                 "graceful-fs": "^4.2.11",
@@ -1060,7 +1039,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/types": "30.2.0",
@@ -1086,7 +1064,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -1104,7 +1081,6 @@
             "version": "0.3.13",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1114,7 +1090,6 @@
             "version": "2.3.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1124,7 +1099,6 @@
             "version": "3.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1132,14 +1106,12 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1152,6 +1124,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/js-sdsl"
+            }
+        },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
             }
         },
         "node_modules/@opentelemetry/api": {
@@ -1167,7 +1152,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -1176,7 +1160,6 @@
             "version": "0.2.9",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
             },
@@ -1231,14 +1214,12 @@
         "node_modules/@sinclair/typebox": {
             "version": "0.34.47",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
@@ -1247,7 +1228,6 @@
             "version": "13.0.5",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1"
             }
@@ -1260,11 +1240,21 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.20.7",
                 "@babel/types": "^7.20.7",
@@ -1277,7 +1267,6 @@
             "version": "7.27.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
@@ -1286,7 +1275,6 @@
             "version": "7.4.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -1296,7 +1284,6 @@
             "version": "7.28.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.28.2"
             }
@@ -1354,14 +1341,12 @@
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-report": {
             "version": "3.0.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
@@ -1370,7 +1355,6 @@
             "version": "3.0.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
@@ -1455,8 +1439,7 @@
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -1467,7 +1450,6 @@
             "version": "17.0.35",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
@@ -1475,14 +1457,267 @@
         "node_modules/@types/yargs-parser": {
             "version": "21.0.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.0",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
+        },
+        "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-android-arm64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-arm64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-x64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-freebsd-x64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^0.2.11"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
             "version": "1.11.1",
@@ -1494,8 +1729,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -1530,7 +1764,6 @@
             "version": "4.3.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -1545,7 +1778,6 @@
             "version": "6.2.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1571,7 +1803,6 @@
             "version": "3.1.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -1584,7 +1815,6 @@
             "version": "1.0.10",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -1618,7 +1848,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/transform": "30.2.0",
                 "@types/babel__core": "^7.20.5",
@@ -1639,7 +1868,6 @@
             "version": "7.0.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "workspaces": [
                 "test/babel-8"
             ],
@@ -1658,7 +1886,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/babel__core": "^7.20.5"
             },
@@ -1670,7 +1897,6 @@
             "version": "1.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -1696,7 +1922,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "babel-plugin-jest-hoist": "30.2.0",
                 "babel-preset-current-node-syntax": "^1.2.0"
@@ -1711,8 +1936,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -1736,7 +1960,6 @@
             "version": "2.9.14",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
             }
@@ -1774,7 +1997,6 @@
             "version": "2.0.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -1783,7 +2005,6 @@
             "version": "3.0.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -1828,7 +2049,6 @@
             "version": "2.1.1",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
             }
@@ -1840,8 +2060,7 @@
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/bytes": {
             "version": "3.1.2",
@@ -1863,6 +2082,8 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -1879,7 +2100,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1888,7 +2108,6 @@
             "version": "5.3.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1910,14 +2129,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "CC-BY-4.0",
-            "peer": true
+            "license": "CC-BY-4.0"
         },
         "node_modules/chalk": {
             "version": "4.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1933,7 +2150,6 @@
             "version": "1.0.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1948,7 +2164,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1956,8 +2171,7 @@
         "node_modules/cjs-module-lexer": {
             "version": "2.2.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -2029,7 +2243,6 @@
             "version": "4.6.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
@@ -2038,8 +2251,7 @@
         "node_modules/collect-v8-coverage": {
             "version": "1.0.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -2071,8 +2283,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/content-disposition": {
             "version": "0.5.4",
@@ -2094,8 +2305,7 @@
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -2123,7 +2333,6 @@
             "version": "7.0.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2144,7 +2353,6 @@
             "version": "1.7.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "babel-plugin-macros": "^3.1.0"
             },
@@ -2158,7 +2366,6 @@
             "version": "4.3.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2190,7 +2397,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2221,8 +2427,7 @@
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
@@ -2238,14 +2443,12 @@
         "node_modules/electron-to-chromium": {
             "version": "1.5.267",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/emittery": {
             "version": "0.13.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2256,8 +2459,7 @@
         "node_modules/emoji-regex": {
             "version": "9.2.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
@@ -2278,7 +2480,6 @@
             "version": "1.3.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2337,7 +2538,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2346,7 +2546,6 @@
             "version": "4.0.1",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -2374,7 +2573,6 @@
             "version": "5.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -2396,14 +2594,12 @@
         "node_modules/execa/node_modules/signal-exit": {
             "version": "3.0.7",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/exit-x": {
             "version": "0.2.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -2412,7 +2608,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/expect-utils": "30.2.0",
                 "@jest/get-type": "30.1.0",
@@ -2488,8 +2683,7 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-xml-parser": {
             "version": "4.5.3",
@@ -2522,7 +2716,6 @@
             "version": "2.0.2",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "bser": "2.1.1"
             }
@@ -2531,7 +2724,6 @@
             "version": "7.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -2559,7 +2751,6 @@
             "version": "4.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -2571,6 +2762,7 @@
         "node_modules/firebase-admin": {
             "version": "12.7.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@fastify/busboy": "^3.0.0",
                 "@firebase/database-compat": "1.0.8",
@@ -2593,6 +2785,7 @@
         "node_modules/firebase-functions": {
             "version": "5.1.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/cors": "^2.8.5",
                 "@types/express": "4.17.3",
@@ -2632,7 +2825,6 @@
             "version": "3.3.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.6",
                 "signal-exit": "^4.0.1"
@@ -2645,19 +2837,20 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.5.5",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.35",
-                "safe-buffer": "^5.2.1"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
-                "node": ">= 0.12"
+                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {
@@ -2677,8 +2870,22 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -2733,7 +2940,6 @@
             "version": "1.0.0-beta.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2772,7 +2978,6 @@
             "version": "0.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -2792,7 +2997,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2804,7 +3008,6 @@
             "version": "10.5.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -2926,8 +3129,7 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/gtoken": {
             "version": "7.1.0",
@@ -2944,7 +3146,6 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2974,7 +3175,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3001,8 +3204,7 @@
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/http-errors": {
             "version": "2.0.1",
@@ -3105,7 +3307,6 @@
             "version": "2.1.0",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=10.17.0"
             }
@@ -3124,7 +3325,6 @@
             "version": "3.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pkg-dir": "^4.2.0",
                 "resolve-cwd": "^3.0.0"
@@ -3143,7 +3343,6 @@
             "version": "0.1.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -3152,7 +3351,6 @@
             "version": "1.0.6",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -3172,8 +3370,7 @@
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -3187,7 +3384,6 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3196,7 +3392,6 @@
             "version": "7.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -3214,14 +3409,12 @@
         "node_modules/isexe": {
             "version": "2.0.0",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3230,7 +3423,6 @@
             "version": "6.0.3",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.23.9",
                 "@babel/parser": "^7.23.9",
@@ -3246,7 +3438,6 @@
             "version": "7.7.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -3258,7 +3449,6 @@
             "version": "3.0.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
                 "make-dir": "^4.0.0",
@@ -3272,7 +3462,6 @@
             "version": "5.0.6",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.23",
                 "debug": "^4.1.1",
@@ -3286,7 +3475,6 @@
             "version": "4.4.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -3302,14 +3490,12 @@
         "node_modules/istanbul-lib-source-maps/node_modules/ms": {
             "version": "2.1.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/istanbul-reports": {
             "version": "3.2.0",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
@@ -3322,7 +3508,6 @@
             "version": "3.4.3",
             "dev": true,
             "license": "BlueOak-1.0.0",
-            "peer": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -3363,7 +3548,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "execa": "^5.1.1",
                 "jest-util": "30.2.0",
@@ -3377,7 +3561,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/expect": "30.2.0",
@@ -3408,7 +3591,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/test-result": "30.2.0",
@@ -3440,7 +3622,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/get-type": "30.1.0",
@@ -3491,7 +3672,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/diff-sequences": "30.0.1",
                 "@jest/get-type": "30.1.0",
@@ -3506,7 +3686,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "detect-newline": "^3.1.0"
             },
@@ -3518,7 +3697,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "@jest/types": "30.2.0",
@@ -3534,7 +3712,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/fake-timers": "30.2.0",
@@ -3552,7 +3729,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -3576,7 +3752,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "pretty-format": "30.2.0"
@@ -3589,7 +3764,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
@@ -3604,7 +3778,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.2.0",
@@ -3624,7 +3797,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -3638,7 +3810,6 @@
             "version": "1.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -3655,7 +3826,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -3664,7 +3834,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
@@ -3683,7 +3852,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "jest-regex-util": "30.0.1",
                 "jest-snapshot": "30.2.0"
@@ -3696,7 +3864,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/console": "30.2.0",
                 "@jest/environment": "30.2.0",
@@ -3729,7 +3896,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/fake-timers": "30.2.0",
@@ -3762,7 +3928,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@babel/generator": "^7.27.5",
@@ -3794,7 +3959,6 @@
             "version": "7.7.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -3806,7 +3970,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -3819,23 +3982,10 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-util/node_modules/picomatch": {
-            "version": "4.0.3",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/jest-validate": {
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "@jest/types": "30.2.0",
@@ -3852,7 +4002,6 @@
             "version": "6.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3864,7 +4013,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/test-result": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -3883,7 +4031,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "@ungap/structured-clone": "^1.3.0",
@@ -3899,7 +4046,6 @@
             "version": "8.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3920,14 +4066,12 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "3.14.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -3940,7 +4084,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -3958,14 +4101,12 @@
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -4099,7 +4240,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4110,14 +4250,12 @@
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -4126,7 +4264,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -4175,7 +4315,6 @@
             "version": "5.1.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -4206,7 +4345,6 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "semver": "^7.5.3"
             },
@@ -4221,7 +4359,6 @@
             "version": "7.7.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4233,7 +4370,6 @@
             "version": "1.0.12",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "tmpl": "1.0.5"
             }
@@ -4274,8 +4410,7 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -4288,7 +4423,6 @@
             "version": "4.0.8",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -4329,18 +4463,18 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -4353,7 +4487,6 @@
             "version": "7.1.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -4366,7 +4499,6 @@
             "version": "0.3.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "napi-postinstall": "lib/cli.js"
             },
@@ -4380,8 +4512,7 @@
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/negotiator": {
             "version": "0.6.3",
@@ -4409,7 +4540,9 @@
             }
         },
         "node_modules/node-forge": {
-            "version": "1.3.3",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
             "license": "(BSD-3-Clause OR GPL-2.0)",
             "engines": {
                 "node": ">= 6.13.0"
@@ -4418,19 +4551,17 @@
         "node_modules/node-int64": {
             "version": "0.4.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/node-releases": {
             "version": "2.0.27",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/nodemailer": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
-            "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+            "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
@@ -4440,7 +4571,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4449,7 +4579,6 @@
             "version": "4.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -4474,6 +4603,8 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -4504,7 +4635,6 @@
             "version": "5.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -4533,7 +4663,6 @@
             "version": "4.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -4545,7 +4674,6 @@
             "version": "2.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -4560,7 +4688,6 @@
             "version": "2.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4568,14 +4695,12 @@
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "dev": true,
-            "license": "BlueOak-1.0.0",
-            "peer": true
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -4600,7 +4725,6 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4609,7 +4733,6 @@
             "version": "1.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4618,7 +4741,6 @@
             "version": "3.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4627,7 +4749,6 @@
             "version": "1.11.1",
             "dev": true,
             "license": "BlueOak-1.0.0",
-            "peer": true,
             "dependencies": {
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -4642,26 +4763,27 @@
         "node_modules/path-scurry/node_modules/lru-cache": {
             "version": "10.4.3",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -4671,7 +4793,6 @@
             "version": "4.0.7",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -4680,7 +4801,6 @@
             "version": "4.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "find-up": "^4.0.0"
             },
@@ -4692,7 +4812,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -4706,7 +4825,6 @@
             "version": "5.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4771,14 +4889,16 @@
                     "url": "https://opencollective.com/fast-check"
                 }
             ],
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.1",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -4810,8 +4930,7 @@
         "node_modules/react-is": {
             "version": "18.3.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
@@ -4838,7 +4957,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -4850,7 +4968,6 @@
             "version": "5.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4902,7 +5019,6 @@
             "version": "6.3.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -4964,7 +5080,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -4976,18 +5091,19 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -4999,11 +5115,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5014,6 +5132,8 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -5030,6 +5150,8 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -5049,7 +5171,6 @@
             "version": "4.1.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -5061,7 +5182,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5070,7 +5190,6 @@
             "version": "0.6.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5079,7 +5198,6 @@
             "version": "0.5.13",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -5088,14 +5206,12 @@
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
             },
@@ -5135,7 +5251,6 @@
             "version": "4.0.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "char-regex": "^1.0.2",
                 "strip-ansi": "^6.0.0"
@@ -5148,7 +5263,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5157,7 +5271,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5169,7 +5282,6 @@
             "version": "5.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -5187,7 +5299,6 @@
             "version": "4.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -5201,7 +5312,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5209,14 +5319,12 @@
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5228,7 +5336,6 @@
             "version": "7.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -5244,7 +5351,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5256,7 +5362,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5265,7 +5370,6 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5274,7 +5378,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5283,7 +5386,6 @@
             "version": "3.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -5311,7 +5413,6 @@
             "version": "7.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -5323,7 +5424,6 @@
             "version": "0.11.12",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@pkgr/core": "^0.2.9"
             },
@@ -5409,7 +5509,6 @@
             "version": "6.0.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
@@ -5423,7 +5522,6 @@
             "version": "1.1.12",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5433,7 +5531,6 @@
             "version": "7.2.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5450,10 +5547,11 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5464,14 +5562,12 @@
         "node_modules/tmpl": {
             "version": "1.0.5",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -5503,7 +5599,6 @@
             "version": "4.0.8",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5512,7 +5607,6 @@
             "version": "0.21.3",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5559,7 +5653,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },
@@ -5606,7 +5699,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -5649,7 +5741,6 @@
             "version": "9.3.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -5670,7 +5761,6 @@
             "version": "1.0.8",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "makeerror": "1.0.12"
             }
@@ -5710,7 +5800,6 @@
             "version": "2.0.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -5725,7 +5814,6 @@
             "version": "8.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.1.0",
                 "string-width": "^5.0.1",
@@ -5743,7 +5831,6 @@
             "version": "7.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -5760,7 +5847,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5768,14 +5854,12 @@
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -5789,7 +5873,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5801,7 +5884,6 @@
             "version": "6.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5818,7 +5900,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^4.0.1"
@@ -5838,8 +5919,7 @@
         "node_modules/yallist": {
             "version": "3.1.1",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,12 +20,23 @@
         "firebase-functions": "^5.0.0",
         "googleapis": "^130.0.0",
         "marked": "^18.0.4",
-        "nodemailer": "^8.0.1"
+        "nodemailer": "^9.0.1"
     },
     "devDependencies": {
         "@types/nodemailer": "^7.0.11",
         "firebase-functions-test": "^3.3.0",
         "typescript": "~5.4.0"
+    },
+    "overrides": {
+        "@grpc/grpc-js": "^1.14.4",
+        "node-forge": "^1.4.0",
+        "form-data": "^4.0.6",
+        "path-to-regexp": "^0.1.13",
+        "minimatch@^3": "^3.1.3",
+        "minimatch@^9": "^9.0.7",
+        "lodash": "^4.18.0",
+        "qs": "^6.15.2",
+        "picomatch": "^4.0.4"
     },
     "private": true
 }


### PR DESCRIPTION
## Summary
- bump unctions direct dependency 
odemailer to a patched major
- add npm overrides for @grpc/grpc-js, 
ode-forge, orm-data, path-to-regexp, minimatch, lodash, qs, and picomatch
- regenerate unctions/package-lock.json

## Validation
- cd functions && npm install
- cd functions && npm run build
- cd functions && npm test (27/27 passing)


Made with [Cursor](https://cursor.com)