### PR TITLE
chore(security): dependabot batch 1 critical remediations (v2)

### DIFF
--- a/docs/security/dependabot-triage.md
+++ b/docs/security/dependabot-triage.md
@@ -1,0 +1,84 @@
+# Dependabot Triage Plan (Bulk Execution)
+
+Last refreshed: 2026-07-02 via `gh api repos/OmniFlexFitness/OmniTask/dependabot/alerts`.
+
+## Snapshot
+
+- Open alerts: `101`
+- Severity mix: `critical: 3`, `high: 36`, `medium: 50`, `low: 12`
+- By manifest:
+  - `yarn.lock`: `56`
+  - `functions/package-lock.json`: `44`
+  - `functions/package.json`: `1`
+
+Most frequent packages currently flagged: `protobufjs (12)`, `dompurify (12)`, `nodemailer (7)`, `undici (7)`, `fast-xml-parser (6)`, `hono (5)`.
+
+## Batch Map
+
+### Batch 1 (critical-first)
+
+- App: bump direct `vitest` to `^3.2.6`
+- Functions: add npm `overrides` for:
+  - `protobufjs` -> `^7.6.3`
+  - `fast-xml-parser` -> `^5.7.0`
+
+Target: clear criticals tied to vitest/protobufjs/fast-xml-parser and establish an overrides mechanism for functions.
+
+### Batch 2 (functions high-risk cluster)
+
+- Functions direct dep:
+  - `nodemailer` -> patched line (`>=9.0.1`)
+- Functions overrides:
+  - `@grpc/grpc-js`, `node-forge`, `form-data`, `path-to-regexp`, `minimatch`, `lodash`, `qs`, `picomatch`
+
+Target: collapse the large high-severity backlog in `functions/package-lock.json`.
+
+### Batch 3 (app runtime-risk cluster)
+
+- Angular runtime packages (`@angular/common`, `@angular/core`, `@angular/compiler`) to latest safe `21.2.x`
+- App deps/resolutions:
+  - `dompurify`, `undici`, `vite`, `form-data`, `tar`
+
+Target: remove browser/runtime-relevant app advisories before lower-risk toolchain packages.
+
+### Batch 4 (dev/build toolchain advisories)
+
+- App resolutions for tooling-only packages:
+  - `hono`, `piscina`, `sigstore`, `@sigstore/verify`, `@sigstore/core`
+  - `launch-editor`, `webpack-dev-server`, `http-proxy-middleware`
+  - `esbuild`, `postcss`, `ip-address`, `ajv`, `uuid`, `@babel/core`
+
+Target: reduce remaining backlog while isolating potential CI/tooling regressions.
+
+### Batch 5 (no-fix / disputed / platform-limited)
+
+Document and dismiss only when all are true:
+- no patched version currently published, or
+- advisory applies only to local dev flows not used in CI/prod, or
+- upstream advisory is duplicated by a newer tracked advisory.
+
+Current likely candidates:
+- `dompurify` advisories with `first_patched_version: none`
+- Windows-only local dev server path/UNC advisories when not exposed in prod
+
+## Verification Gate Per Batch
+
+### App gate
+
+1. `corepack yarn install`
+2. `yarn lint`
+3. `yarn build`
+4. `yarn test`
+
+### Functions gate
+
+1. `cd functions`
+2. `npm install`
+3. `npm run build`
+4. `npm test`
+
+### Alert gate
+
+- Re-check open alerts:
+  - `gh api repos/OmniFlexFitness/OmniTask/dependabot/alerts --paginate`
+- Confirm targeted package alerts for that batch are reduced or resolved before opening next batch.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -26,7 +26,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
@@ -40,7 +39,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -79,7 +77,6 @@
             "version": "4.4.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -95,14 +92,12 @@
         "node_modules/@babel/core/node_modules/ms": {
             "version": "2.1.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@babel/generator": {
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.28.6",
                 "@babel/types": "^7.28.6",
@@ -118,7 +113,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
@@ -134,7 +128,6 @@
             "version": "7.28.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -143,7 +136,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -156,7 +148,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.28.6",
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -173,7 +164,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -182,7 +172,6 @@
             "version": "7.27.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -191,7 +180,6 @@
             "version": "7.28.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -200,7 +188,6 @@
             "version": "7.27.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -209,7 +196,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/template": "^7.28.6",
                 "@babel/types": "^7.28.6"
@@ -222,7 +208,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.28.6"
             },
@@ -237,7 +222,6 @@
             "version": "7.8.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -249,7 +233,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -261,7 +244,6 @@
             "version": "7.12.13",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -273,7 +255,6 @@
             "version": "7.14.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -288,7 +269,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.28.6"
             },
@@ -303,7 +283,6 @@
             "version": "7.10.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -315,7 +294,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -327,7 +305,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.28.6"
             },
@@ -342,7 +319,6 @@
             "version": "7.10.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -354,7 +330,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -366,7 +341,6 @@
             "version": "7.10.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -378,7 +352,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -390,7 +363,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -402,7 +374,6 @@
             "version": "7.8.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -414,7 +385,6 @@
             "version": "7.14.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -429,7 +399,6 @@
             "version": "7.14.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -444,7 +413,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.28.6"
             },
@@ -459,7 +427,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/parser": "^7.28.6",
@@ -473,7 +440,6 @@
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/generator": "^7.28.6",
@@ -491,7 +457,6 @@
             "version": "4.4.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -507,14 +472,12 @@
         "node_modules/@babel/traverse/node_modules/ms": {
             "version": "2.1.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@babel/types": {
             "version": "7.28.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
                 "@babel/helper-validator-identifier": "^7.28.5"
@@ -526,8 +489,41 @@
         "node_modules/@bcoe/v8-coverage": {
             "version": "0.2.3",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
             "license": "MIT",
-            "peer": true
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@fastify/busboy": {
             "version": "3.2.0",
@@ -738,7 +734,6 @@
             "version": "8.0.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "string-width": "^5.1.2",
                 "string-width-cjs": "npm:string-width@^4.2.0",
@@ -755,7 +750,6 @@
             "version": "1.1.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
@@ -771,7 +765,6 @@
             "version": "0.1.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -780,7 +773,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -797,7 +789,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/console": "30.2.0",
                 "@jest/pattern": "30.0.1",
@@ -844,7 +835,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -853,7 +843,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/fake-timers": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -868,7 +857,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "expect": "30.2.0",
                 "jest-snapshot": "30.2.0"
@@ -881,7 +869,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0"
             },
@@ -893,7 +880,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@sinonjs/fake-timers": "^13.0.0",
@@ -910,7 +896,6 @@
             "version": "30.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -919,7 +904,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/expect": "30.2.0",
@@ -934,7 +918,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "jest-regex-util": "30.0.1"
@@ -947,7 +930,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "30.2.0",
@@ -989,7 +971,6 @@
             "version": "30.0.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -1001,7 +982,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "chalk": "^4.1.2",
@@ -1016,7 +996,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "callsites": "^3.1.0",
@@ -1030,7 +1009,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/console": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -1045,7 +1023,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/test-result": "30.2.0",
                 "graceful-fs": "^4.2.11",
@@ -1060,7 +1037,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/types": "30.2.0",
@@ -1086,7 +1062,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -1104,7 +1079,6 @@
             "version": "0.3.13",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1114,7 +1088,6 @@
             "version": "2.3.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -1124,7 +1097,6 @@
             "version": "3.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1132,14 +1104,12 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1154,6 +1124,32 @@
                 "url": "https://opencollective.com/js-sdsl"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@opentelemetry/api": {
             "version": "1.9.0",
             "license": "Apache-2.0",
@@ -1167,7 +1163,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -1176,7 +1171,6 @@
             "version": "0.2.9",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
             },
@@ -1186,6 +1180,8 @@
         },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
@@ -1193,27 +1189,28 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1225,20 +1222,20 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.47",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
@@ -1247,7 +1244,6 @@
             "version": "13.0.5",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1"
             }
@@ -1260,11 +1256,21 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+            "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.20.7",
                 "@babel/types": "^7.20.7",
@@ -1277,7 +1283,6 @@
             "version": "7.27.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
@@ -1286,7 +1291,6 @@
             "version": "7.4.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -1296,7 +1300,6 @@
             "version": "7.28.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.28.2"
             }
@@ -1354,14 +1357,12 @@
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-report": {
             "version": "3.0.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
@@ -1370,7 +1371,6 @@
             "version": "3.0.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
@@ -1455,8 +1455,7 @@
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -1467,7 +1466,6 @@
             "version": "17.0.35",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
@@ -1475,14 +1473,267 @@
         "node_modules/@types/yargs-parser": {
             "version": "21.0.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.0",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
+        },
+        "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-android-arm64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-arm64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-x64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-freebsd-x64": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^0.2.11"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
             "version": "1.11.1",
@@ -1494,8 +1745,7 @@
             "optional": true,
             "os": [
                 "win32"
-            ],
-            "peer": true
+            ]
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
@@ -1530,7 +1780,6 @@
             "version": "4.3.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "type-fest": "^0.21.3"
             },
@@ -1545,7 +1794,6 @@
             "version": "6.2.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1571,7 +1819,6 @@
             "version": "3.1.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -1580,11 +1827,23 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/argparse": {
             "version": "1.0.10",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -1618,7 +1877,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/transform": "30.2.0",
                 "@types/babel__core": "^7.20.5",
@@ -1639,7 +1897,6 @@
             "version": "7.0.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "workspaces": [
                 "test/babel-8"
             ],
@@ -1658,7 +1915,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/babel__core": "^7.20.5"
             },
@@ -1670,7 +1926,6 @@
             "version": "1.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -1696,7 +1951,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "babel-plugin-jest-hoist": "30.2.0",
                 "babel-preset-current-node-syntax": "^1.2.0"
@@ -1711,8 +1965,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -1736,7 +1989,6 @@
             "version": "2.9.14",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"
             }
@@ -1774,7 +2026,6 @@
             "version": "2.0.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -1783,7 +2034,6 @@
             "version": "3.0.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -1828,7 +2078,6 @@
             "version": "2.1.1",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
             }
@@ -1840,8 +2089,7 @@
         "node_modules/buffer-from": {
             "version": "1.1.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/bytes": {
             "version": "3.1.2",
@@ -1879,7 +2127,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1888,7 +2135,6 @@
             "version": "5.3.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -1910,14 +2156,12 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "CC-BY-4.0",
-            "peer": true
+            "license": "CC-BY-4.0"
         },
         "node_modules/chalk": {
             "version": "4.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1933,7 +2177,6 @@
             "version": "1.0.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1948,7 +2191,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1956,8 +2198,7 @@
         "node_modules/cjs-module-lexer": {
             "version": "2.2.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -2029,7 +2270,6 @@
             "version": "4.6.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
@@ -2038,8 +2278,7 @@
         "node_modules/collect-v8-coverage": {
             "version": "1.0.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -2071,8 +2310,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/content-disposition": {
             "version": "0.5.4",
@@ -2094,8 +2332,7 @@
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -2123,7 +2360,6 @@
             "version": "7.0.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2144,7 +2380,6 @@
             "version": "1.7.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "babel-plugin-macros": "^3.1.0"
             },
@@ -2158,7 +2393,6 @@
             "version": "4.3.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2190,7 +2424,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2221,8 +2454,7 @@
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
@@ -2238,14 +2470,12 @@
         "node_modules/electron-to-chromium": {
             "version": "1.5.267",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/emittery": {
             "version": "0.13.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2256,8 +2486,7 @@
         "node_modules/emoji-regex": {
             "version": "9.2.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
@@ -2278,7 +2507,6 @@
             "version": "1.3.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -2337,7 +2565,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2346,7 +2573,6 @@
             "version": "4.0.1",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -2374,7 +2600,6 @@
             "version": "5.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -2396,14 +2621,12 @@
         "node_modules/execa/node_modules/signal-exit": {
             "version": "3.0.7",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/exit-x": {
             "version": "0.2.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -2412,7 +2635,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/expect-utils": "30.2.0",
                 "@jest/get-type": "30.1.0",
@@ -2488,11 +2710,12 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
-        "node_modules/fast-xml-parser": {
-            "version": "4.5.3",
+        "node_modules/fast-xml-builder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
             "funding": [
                 {
                     "type": "github",
@@ -2502,7 +2725,29 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "strnum": "^1.1.1"
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+            "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@nodable/entities": "^2.2.0",
+                "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^1.0.1",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.4.1",
+                "xml-naming": "^0.1.0"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -2522,7 +2767,6 @@
             "version": "2.0.2",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "bser": "2.1.1"
             }
@@ -2531,7 +2775,6 @@
             "version": "7.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -2559,7 +2802,6 @@
             "version": "4.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -2571,6 +2813,7 @@
         "node_modules/firebase-admin": {
             "version": "12.7.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@fastify/busboy": "^3.0.0",
                 "@firebase/database-compat": "1.0.8",
@@ -2593,6 +2836,7 @@
         "node_modules/firebase-functions": {
             "version": "5.1.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/cors": "^2.8.5",
                 "@types/express": "4.17.3",
@@ -2632,7 +2876,6 @@
             "version": "3.3.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.6",
                 "signal-exit": "^4.0.1"
@@ -2677,8 +2920,22 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -2733,7 +2990,6 @@
             "version": "1.0.0-beta.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2772,7 +3028,6 @@
             "version": "0.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -2792,7 +3047,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -2804,7 +3058,6 @@
             "version": "10.5.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -2926,8 +3179,7 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/gtoken": {
             "version": "7.1.0",
@@ -2944,7 +3196,6 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3001,8 +3252,7 @@
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/http-errors": {
             "version": "2.0.1",
@@ -3105,7 +3355,6 @@
             "version": "2.1.0",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=10.17.0"
             }
@@ -3124,7 +3373,6 @@
             "version": "3.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pkg-dir": "^4.2.0",
                 "resolve-cwd": "^3.0.0"
@@ -3143,7 +3391,6 @@
             "version": "0.1.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -3152,7 +3399,6 @@
             "version": "1.0.6",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -3172,8 +3418,7 @@
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -3187,7 +3432,6 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3196,7 +3440,6 @@
             "version": "7.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -3211,17 +3454,28 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-unsafe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+            "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3230,7 +3484,6 @@
             "version": "6.0.3",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.23.9",
                 "@babel/parser": "^7.23.9",
@@ -3246,7 +3499,6 @@
             "version": "7.7.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -3258,7 +3510,6 @@
             "version": "3.0.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
                 "make-dir": "^4.0.0",
@@ -3272,7 +3523,6 @@
             "version": "5.0.6",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.23",
                 "debug": "^4.1.1",
@@ -3286,7 +3536,6 @@
             "version": "4.4.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -3302,14 +3551,12 @@
         "node_modules/istanbul-lib-source-maps/node_modules/ms": {
             "version": "2.1.3",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/istanbul-reports": {
             "version": "3.2.0",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
@@ -3322,7 +3569,6 @@
             "version": "3.4.3",
             "dev": true,
             "license": "BlueOak-1.0.0",
-            "peer": true,
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
             },
@@ -3363,7 +3609,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "execa": "^5.1.1",
                 "jest-util": "30.2.0",
@@ -3377,7 +3622,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/expect": "30.2.0",
@@ -3408,7 +3652,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/test-result": "30.2.0",
@@ -3440,7 +3683,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/get-type": "30.1.0",
@@ -3491,7 +3733,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/diff-sequences": "30.0.1",
                 "@jest/get-type": "30.1.0",
@@ -3506,7 +3747,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "detect-newline": "^3.1.0"
             },
@@ -3518,7 +3758,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "@jest/types": "30.2.0",
@@ -3534,7 +3773,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/fake-timers": "30.2.0",
@@ -3552,7 +3790,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -3576,7 +3813,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "pretty-format": "30.2.0"
@@ -3589,7 +3825,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
@@ -3604,7 +3839,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.2.0",
@@ -3624,7 +3858,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -3638,7 +3871,6 @@
             "version": "1.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -3655,7 +3887,6 @@
             "version": "30.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -3664,7 +3895,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
@@ -3683,7 +3913,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "jest-regex-util": "30.0.1",
                 "jest-snapshot": "30.2.0"
@@ -3696,7 +3925,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/console": "30.2.0",
                 "@jest/environment": "30.2.0",
@@ -3729,7 +3957,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.2.0",
                 "@jest/fake-timers": "30.2.0",
@@ -3762,7 +3989,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@babel/generator": "^7.27.5",
@@ -3794,7 +4020,6 @@
             "version": "7.7.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -3806,7 +4031,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/types": "30.2.0",
                 "@types/node": "*",
@@ -3823,7 +4047,6 @@
             "version": "4.0.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3835,7 +4058,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "@jest/types": "30.2.0",
@@ -3852,7 +4074,6 @@
             "version": "6.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -3864,7 +4085,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/test-result": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -3883,7 +4103,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "@ungap/structured-clone": "^1.3.0",
@@ -3899,7 +4118,6 @@
             "version": "8.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3920,14 +4138,12 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "3.14.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -3940,7 +4156,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -3958,14 +4173,12 @@
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -4099,7 +4312,6 @@
             "version": "3.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4110,14 +4322,12 @@
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -4175,7 +4385,6 @@
             "version": "5.1.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -4206,7 +4415,6 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "semver": "^7.5.3"
             },
@@ -4221,7 +4429,6 @@
             "version": "7.7.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4233,7 +4440,6 @@
             "version": "1.0.12",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "tmpl": "1.0.5"
             }
@@ -4274,8 +4480,7 @@
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -4288,7 +4493,6 @@
             "version": "4.0.8",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -4329,7 +4533,6 @@
             "version": "2.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4338,7 +4541,6 @@
             "version": "9.0.5",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -4353,7 +4555,6 @@
             "version": "7.1.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -4366,7 +4567,6 @@
             "version": "0.3.4",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "napi-postinstall": "lib/cli.js"
             },
@@ -4380,8 +4580,7 @@
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/negotiator": {
             "version": "0.6.3",
@@ -4418,14 +4617,12 @@
         "node_modules/node-int64": {
             "version": "0.4.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/node-releases": {
             "version": "2.0.27",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/nodemailer": {
             "version": "8.0.1",
@@ -4440,7 +4637,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4449,7 +4645,6 @@
             "version": "4.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "path-key": "^3.0.0"
             },
@@ -4504,7 +4699,6 @@
             "version": "5.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -4533,7 +4727,6 @@
             "version": "4.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -4545,7 +4738,6 @@
             "version": "2.3.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -4560,7 +4752,6 @@
             "version": "2.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4568,14 +4759,12 @@
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "dev": true,
-            "license": "BlueOak-1.0.0",
-            "peer": true
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -4600,16 +4789,30 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/path-expression-matcher": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+            "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4618,7 +4821,6 @@
             "version": "3.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4627,7 +4829,6 @@
             "version": "1.11.1",
             "dev": true,
             "license": "BlueOak-1.0.0",
-            "peer": true,
             "dependencies": {
                 "lru-cache": "^10.2.0",
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -4642,8 +4843,7 @@
         "node_modules/path-scurry/node_modules/lru-cache": {
             "version": "10.4.3",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/path-to-regexp": {
             "version": "0.1.12",
@@ -4652,14 +4852,12 @@
         "node_modules/picocolors": {
             "version": "1.1.1",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -4671,7 +4869,6 @@
             "version": "4.0.7",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -4680,7 +4877,6 @@
             "version": "4.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "find-up": "^4.0.0"
             },
@@ -4692,7 +4888,6 @@
             "version": "30.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -4706,7 +4901,6 @@
             "version": "5.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4726,22 +4920,23 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -4771,8 +4966,7 @@
                     "url": "https://opencollective.com/fast-check"
                 }
             ],
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.14.1",
@@ -4810,8 +5004,7 @@
         "node_modules/react-is": {
             "version": "18.3.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
@@ -4838,7 +5031,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -4850,7 +5042,6 @@
             "version": "5.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4902,7 +5093,6 @@
             "version": "6.3.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -4964,7 +5154,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -4976,7 +5165,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5049,7 +5237,6 @@
             "version": "4.1.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -5061,7 +5248,6 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5070,7 +5256,6 @@
             "version": "0.6.1",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5079,7 +5264,6 @@
             "version": "0.5.13",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -5088,14 +5272,12 @@
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
             },
@@ -5135,7 +5317,6 @@
             "version": "4.0.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "char-regex": "^1.0.2",
                 "strip-ansi": "^6.0.0"
@@ -5148,7 +5329,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5157,7 +5337,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5169,7 +5348,6 @@
             "version": "5.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "eastasianwidth": "^0.2.0",
                 "emoji-regex": "^9.2.2",
@@ -5187,7 +5365,6 @@
             "version": "4.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -5201,7 +5378,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5209,14 +5385,12 @@
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5228,7 +5402,6 @@
             "version": "7.1.2",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^6.0.1"
             },
@@ -5244,7 +5417,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5256,7 +5428,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5265,7 +5436,6 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5274,7 +5444,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5283,7 +5452,6 @@
             "version": "3.1.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -5292,7 +5460,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "1.1.2",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
                     "type": "github",
@@ -5300,7 +5470,10 @@
                 }
             ],
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
         },
         "node_modules/stubs": {
             "version": "3.0.0",
@@ -5311,7 +5484,6 @@
             "version": "7.2.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -5323,7 +5495,6 @@
             "version": "0.11.12",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@pkgr/core": "^0.2.9"
             },
@@ -5409,7 +5580,6 @@
             "version": "6.0.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
@@ -5423,7 +5593,6 @@
             "version": "1.1.12",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5433,7 +5602,6 @@
             "version": "7.2.3",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5453,7 +5621,6 @@
             "version": "3.1.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -5464,14 +5631,12 @@
         "node_modules/tmpl": {
             "version": "1.0.5",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -5503,7 +5668,6 @@
             "version": "4.0.8",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5512,7 +5676,6 @@
             "version": "0.21.3",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5559,7 +5722,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },
@@ -5606,7 +5768,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -5649,7 +5810,6 @@
             "version": "9.3.0",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",
@@ -5670,7 +5830,6 @@
             "version": "1.0.8",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "makeerror": "1.0.12"
             }
@@ -5710,7 +5869,6 @@
             "version": "2.0.2",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -5725,7 +5883,6 @@
             "version": "8.1.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^6.1.0",
                 "string-width": "^5.0.1",
@@ -5743,7 +5900,6 @@
             "version": "7.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -5760,7 +5916,6 @@
             "version": "5.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -5768,14 +5923,12 @@
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -5789,7 +5942,6 @@
             "version": "6.0.1",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -5801,7 +5953,6 @@
             "version": "6.2.3",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5818,13 +5969,28 @@
             "version": "5.0.1",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^4.0.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/y18n": {
@@ -5838,8 +6004,7 @@
         "node_modules/yallist": {
             "version": "3.1.1",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -27,5 +27,9 @@
         "firebase-functions-test": "^3.3.0",
         "typescript": "~5.4.0"
     },
+    "overrides": {
+        "protobufjs": "^7.6.3",
+        "fast-xml-parser": "^5.7.0"
+    },
     "private": true
 }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.60.0",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.6"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,64 +4836,64 @@
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-2.1.4.tgz#c45abecc7f373343132870eb23b7fe84dfc018a1"
   integrity sha512-HXciTXN/sDBYWgeAD4V4s0DN0g72x5mlxQhHxtYu3Tt8BLa6MzcJZUyDVFCdtjNs3bfENVHVzOsmooTVuNgAAw==
 
-"@vitest/expect@3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.4.tgz#8362124cd811a5ee11c5768207b9df53d34f2433"
-  integrity sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==
+"@vitest/expect@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.6.tgz#dc3a617acc1f29c132ed6be15456adb75c94a7a4"
+  integrity sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==
   dependencies:
     "@types/chai" "^5.2.2"
-    "@vitest/spy" "3.2.4"
-    "@vitest/utils" "3.2.4"
+    "@vitest/spy" "3.2.6"
+    "@vitest/utils" "3.2.6"
     chai "^5.2.0"
     tinyrainbow "^2.0.0"
 
-"@vitest/mocker@3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.4.tgz#4471c4efbd62db0d4fa203e65cc6b058a85cabd3"
-  integrity sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==
+"@vitest/mocker@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.6.tgz#fd0f2bc2a86d82b6013b3456ad662d04a3551434"
+  integrity sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==
   dependencies:
-    "@vitest/spy" "3.2.4"
+    "@vitest/spy" "3.2.6"
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@3.2.4", "@vitest/pretty-format@^3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz#3c102f79e82b204a26c7a5921bf47d534919d3b4"
-  integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
+"@vitest/pretty-format@3.2.6", "@vitest/pretty-format@^3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.6.tgz#5d1272700abe317f24b88009337b2b5cdaa68bf6"
+  integrity sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==
   dependencies:
     tinyrainbow "^2.0.0"
 
-"@vitest/runner@3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.4.tgz#5ce0274f24a971f6500f6fc166d53d8382430766"
-  integrity sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==
+"@vitest/runner@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.6.tgz#6d9fb047b1430431987782e779aa889819a2e964"
+  integrity sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==
   dependencies:
-    "@vitest/utils" "3.2.4"
+    "@vitest/utils" "3.2.6"
     pathe "^2.0.3"
     strip-literal "^3.0.0"
 
-"@vitest/snapshot@3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.4.tgz#40a8bc0346ac0aee923c0eefc2dc005d90bc987c"
-  integrity sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==
+"@vitest/snapshot@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.6.tgz#3a9cb56389289028a511e97bbfd41d914004f3f5"
+  integrity sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==
   dependencies:
-    "@vitest/pretty-format" "3.2.4"
+    "@vitest/pretty-format" "3.2.6"
     magic-string "^0.30.17"
     pathe "^2.0.3"
 
-"@vitest/spy@3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.4.tgz#cc18f26f40f3f028da6620046881f4e4518c2599"
-  integrity sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==
+"@vitest/spy@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.6.tgz#c255ab84df924b28d6fbec60a37a7f693db4ea41"
+  integrity sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==
   dependencies:
     tinyspy "^4.0.3"
 
-"@vitest/utils@3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.4.tgz#c0813bc42d99527fb8c5b138c7a88516bca46fea"
-  integrity sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==
+"@vitest/utils@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.6.tgz#6fad3368e48b7a1d058827eb9b4bbc650a3f9402"
+  integrity sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==
   dependencies:
-    "@vitest/pretty-format" "3.2.4"
+    "@vitest/pretty-format" "3.2.6"
     loupe "^3.1.4"
     tinyrainbow "^2.0.0"
 
@@ -11275,19 +11275,19 @@ vite@7.3.2, "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0", vite@^6.3.6:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^3.2.0:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.4.tgz#0637b903ad79d1539a25bc34c0ed54b5c67702ea"
-  integrity sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==
+vitest@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.6.tgz#de42ebfb58e16faba4e5a314fe35e146e03cb340"
+  integrity sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==
   dependencies:
     "@types/chai" "^5.2.2"
-    "@vitest/expect" "3.2.4"
-    "@vitest/mocker" "3.2.4"
-    "@vitest/pretty-format" "^3.2.4"
-    "@vitest/runner" "3.2.4"
-    "@vitest/snapshot" "3.2.4"
-    "@vitest/spy" "3.2.4"
-    "@vitest/utils" "3.2.4"
+    "@vitest/expect" "3.2.6"
+    "@vitest/mocker" "3.2.6"
+    "@vitest/pretty-format" "^3.2.6"
+    "@vitest/runner" "3.2.6"
+    "@vitest/snapshot" "3.2.6"
+    "@vitest/spy" "3.2.6"
+    "@vitest/utils" "3.2.6"
     chai "^5.2.0"
     debug "^4.4.1"
     expect-type "^1.2.1"


### PR DESCRIPTION
## Summary
- apply critical remediation batch on top of CI baseline unblock
- add docs/security/dependabot-triage.md
- bump app itest and regenerate yarn.lock
- add functions overrides for protobufjs and ast-xml-parser

## Validation
- corepack yarn install
- corepack yarn lint
- corepack yarn build
- corepack yarn test --watch=false --browsers=ChromeHeadless
- cd functions && npm install && npm run build && npm test


Made with [Cursor](https://cursor.com)